### PR TITLE
Dictate in two languages, one key each

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,10 @@ _Avoid_: Voice typing, transcription mode
 The configured keyboard input that controls **Direct Dictation** through press, release, and tap gestures.
 _Avoid_: Hotkey, shortcut
 
+**Dictation Language**:
+The locale a **Direct Dictation** session transcribes, chosen by the user and bound to a **Dictation Trigger**.
+_Avoid_: Locale setting, speech language
+
 **Live Captions**:
 Ephemeral text produced from a selected application's live audio and displayed while that audio continues.
 _Avoid_: Subtitles, meeting transcription
@@ -144,7 +148,11 @@ _Avoid_: Transcript history, cloud analytics
 - With Reduce Motion enabled, the HUD replaces the animated visual with a quiet level meter and skips expand/collapse animation
 - Version 1 inserts raw finalized text without filler-word or AI cleanup
 - Text cleanup is a later feature and must not affect the first implementation
-- Version 1 uses one user-selected recognition language and does not auto-detect languages
+- A **Dictation Language** is bound to a **Dictation Trigger**; a second language means a second trigger key, never automatic detection
+- Talkify never detects the spoken language: Apple Speech transcribes one language per session, and a wrong guess returns confident nonsense instead of an error
+- Every bound **Dictation Language** stays prewarmed and reserved, so either trigger answers as fast as the other
+- A session runs in the language of the key that started it, and the other trigger is inert until that session ends
+- The HUD shows a language tag only while a second **Dictation Language** is configured
 - Speech models use Apple's `lingering` retention policy
 - Talkify prepares the selected speech model shortly after launch
 - Talkify does not bundle or train speech models

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -56,6 +56,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       statusItemController?.setRecording(isRecording, accent: accent)
       settingsRuntimeState?.isDictating = isRecording
     }
+    dictationController.onLanguageDownloadChange = {
+      [weak settingsRuntimeState] identifier, fraction in
+      settingsRuntimeState?.setDownload(identifier: identifier, fraction: fraction)
+    }
     readAloudController.onSpeakingStateChange = {
       [weak statusItemController] isSpeaking in
       statusItemController?.setSpeaking(isSpeaking)
@@ -72,6 +76,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     applyKeyBindings()
     observeKeyBindings()
+    observeLanguages()
   }
 
   /// Rebinding in Settings updates the event tap and the status menu
@@ -81,12 +86,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     guard let settings else { return }
     withObservationTracking {
       _ = settings.dictationTriggerBinding
+      _ = settings.secondaryTriggerBinding
       _ = settings.readAloudBinding
       _ = settings.isRecordingKeybind
+      // The second trigger is only installed once a second language exists,
+      // so the pick that enables it belongs in this loop too.
+      _ = settings.secondaryRecognitionLocaleIdentifier
     } onChange: { [weak self] in
       Task { @MainActor [weak self] in
         self?.applyKeyBindings()
         self?.observeKeyBindings()
+      }
+    }
+  }
+
+  /// Changing a language in Settings re-resolves and re-warms both, so the
+  /// next keypress meets a prepared analyzer rather than a cold one.
+  private func observeLanguages() {
+    guard let settings else { return }
+    withObservationTracking {
+      _ = settings.recognitionLocaleIdentifier
+      _ = settings.secondaryRecognitionLocaleIdentifier
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        self?.dictationController?.applyLanguages()
+        self?.observeLanguages()
       }
     }
   }

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -76,7 +76,15 @@ final class AppSettings {
   /// Mac's own language, which is what every session did before the Language
   /// section existed.
   var recognitionLocaleIdentifier: String {
-    didSet { defaults.set(recognitionLocaleIdentifier, forKey: Keys.recognitionLocale) }
+    didSet {
+      defaults.set(recognitionLocaleIdentifier, forKey: Keys.recognitionLocale)
+      // Choosing the second language as the first leaves one language behind
+      // two keys, so the second turns off rather than becoming a duplicate.
+      if !recognitionLocaleIdentifier.isEmpty,
+       recognitionLocaleIdentifier == secondaryRecognitionLocaleIdentifier {
+        secondaryRecognitionLocaleIdentifier = ""
+      }
+    }
   }
 
   /// The second language, with its own trigger key. Empty means off, which

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -22,6 +22,9 @@ final class AppSettings {
     static let readAloudVoice = "readAloudVoice"
     static let dictationTriggerBinding = "dictationTriggerBinding"
     static let readAloudBinding = "readAloudBinding"
+    static let recognitionLocale = "recognitionLocale"
+    static let secondaryRecognitionLocale = "recognitionLocaleSecondary"
+    static let secondaryTriggerBinding = "dictationTriggerBindingSecondary"
   }
 
   @ObservationIgnored
@@ -69,6 +72,34 @@ final class AppSettings {
     didSet { Self.store(readAloudBinding, in: defaults, key: Keys.readAloudBinding) }
   }
 
+  /// The dictation language, as a locale identifier; empty means follow the
+  /// Mac's own language, which is what every session did before the Language
+  /// section existed.
+  var recognitionLocaleIdentifier: String {
+    didSet { defaults.set(recognitionLocaleIdentifier, forKey: Keys.recognitionLocale) }
+  }
+
+  /// The second language, with its own trigger key. Empty means off, which
+  /// is the default: one key, one language, exactly as before.
+  var secondaryRecognitionLocaleIdentifier: String {
+    didSet {
+      defaults.set(
+        secondaryRecognitionLocaleIdentifier,
+        forKey: Keys.secondaryRecognitionLocale
+      )
+    }
+  }
+
+  var secondaryTriggerBinding: KeyBinding {
+    didSet { Self.store(secondaryTriggerBinding, in: defaults, key: Keys.secondaryTriggerBinding) }
+  }
+
+  /// True once a second language is chosen. The second trigger is ignored
+  /// while this is false, so an unused binding cannot start a session.
+  var isSecondLanguageEnabled: Bool {
+    !secondaryRecognitionLocaleIdentifier.isEmpty
+  }
+
   /// Transient, never persisted: true while a Shortcuts key recorder is
   /// armed, so global trigger handling pauses and the rebind keystroke
   /// cannot start a session.
@@ -90,6 +121,12 @@ final class AppSettings {
     readAloudBinding = Self.storedBinding(
       in: defaults, key: Keys.readAloudBinding
     ) ?? .optionEscape
+    recognitionLocaleIdentifier = defaults.string(forKey: Keys.recognitionLocale) ?? ""
+    secondaryRecognitionLocaleIdentifier =
+      defaults.string(forKey: Keys.secondaryRecognitionLocale) ?? ""
+    secondaryTriggerBinding = Self.storedBinding(
+      in: defaults, key: Keys.secondaryTriggerBinding
+    ) ?? .rightOptionTrigger
   }
 
   private static func stored<Value: RawRepresentable<String>>(

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -14,6 +14,9 @@ final class DirectDictationController {
   /// active — speaking through the speaker path mid-dictation would feed
   /// the recognizer its own audio.
   var onReadAloudTriggered: (() -> Void)?
+  /// A language model downloading, as a locale identifier and progress (0…1),
+  /// or nil progress once it finishes. Settings shows it on the language row.
+  var onLanguageDownloadChange: ((String, Double?) -> Void)?
 
   private static let noSpeechTimeout = Duration.seconds(15)
 
@@ -32,6 +35,13 @@ final class DirectDictationController {
   private var isPrepared = false
   private var preparationFailureMessage: String?
   private var currentSessionSettings: DictationSessionSettings?
+  /// The languages behind the two trigger keys, resolved to locales Apple
+  /// Speech supports. `secondary` is nil unless a second language is chosen.
+  private var primaryLocale: Locale?
+  private var secondaryLocale: Locale?
+  /// Which slot's key began the session in flight, so the session runs in
+  /// the language of the key that started it even if Settings change.
+  private var activeSlot: GlobalKeyEventMonitor.TriggerSlot = .primary
 
   init(
     settings: AppSettings,
@@ -50,7 +60,38 @@ final class DirectDictationController {
 
   func start() {
     applyKeyBindings()
+    observeModelDownloads()
     requestPermissionsAndPrepare()
+  }
+
+  /// Routes model downloads to both places they matter: the Language section,
+  /// and the HUD when a session is already waiting on that very language.
+  private func observeModelDownloads() {
+    let handler: @Sendable (SpeechRecognitionService.ModelDownload) -> Void = { [weak self] download in
+      Task { @MainActor in
+        self?.receive(download)
+      }
+    }
+
+    Task { [speechService] in
+      await speechService.setDownloadHandler(handler)
+    }
+  }
+
+  private func receive(_ download: SpeechRecognitionService.ModelDownload) {
+    onLanguageDownloadChange?(download.locale.identifier, download.fraction)
+
+    // Only speak up in the HUD for the language this session is waiting on.
+    guard machine.isSessionActive, locale(for: activeSlot) == download.locale else { return }
+
+    guard let fraction = download.fraction else {
+      hudController.showModelDownload(nil)
+      return
+    }
+    let name = SpeechLanguageCatalog.shortName(for: download.locale)
+    hudController.showModelDownload(
+      "Downloading \(name)… \(Int(fraction * 100))%"
+    )
   }
 
   /// Pushes the recorded Settings bindings into the event tap; called at
@@ -58,9 +99,70 @@ final class DirectDictationController {
   func applyKeyBindings() {
     keyEventMonitor?.setBindings(
       trigger: settings.dictationTriggerBinding,
+      secondaryTrigger: settings.isSecondLanguageEnabled
+        ? settings.secondaryTriggerBinding
+        : nil,
       readAloud: settings.readAloudBinding
     )
     keyEventMonitor?.setEventHandlingSuspended(settings.isRecordingKeybind)
+  }
+
+  /// Re-resolves both languages and warms them. Called whenever the Language
+  /// section changes a pick, so the key you press next is already prepared
+  /// rather than building its analyzer on the keypress.
+  func applyLanguages() {
+    Task { [weak self] in
+      guard let self else { return }
+      do {
+        try await prepareLanguages()
+        isPrepared = true
+        preparationFailureMessage = nil
+      } catch {
+        isPrepared = false
+        preparationFailed(message: error.localizedDescription)
+      }
+    }
+  }
+
+  /// Resolves both picks, drops anything no longer bound to a key, then warms
+  /// the primary language. The second warms behind it and never throws: a
+  /// model that still needs downloading must not delay the primary key.
+  private func prepareLanguages() async throws {
+    let primary = try await speechService.resolveLocale(
+      identifier: settings.recognitionLocaleIdentifier
+    )
+    primaryLocale = primary
+
+    var secondary: Locale?
+    if settings.isSecondLanguageEnabled {
+      secondary = try? await speechService.resolveLocale(
+        identifier: settings.secondaryRecognitionLocaleIdentifier
+      )
+    }
+    // A second language equal to the first is not a second language.
+    secondaryLocale = secondary == primary ? nil : secondary
+
+    let bound = [primary, secondaryLocale].compactMap(\.self)
+    await speechService.retainOnly(locales: bound)
+    try await speechService.prewarm(locale: primary)
+
+    if let secondaryLocale {
+      try? await speechService.prewarm(locale: secondaryLocale)
+    }
+  }
+
+  private func locale(for slot: GlobalKeyEventMonitor.TriggerSlot) -> Locale? {
+    switch slot {
+    case .primary: primaryLocale
+    case .secondary: secondaryLocale ?? primaryLocale
+    }
+  }
+
+  /// The HUD's language tag, shown only once a second language exists: with
+  /// one language there is nothing to disambiguate.
+  private var activeLanguageTag: String? {
+    guard secondaryLocale != nil, let locale = locale(for: activeSlot) else { return nil }
+    return SpeechLanguageCatalog.tag(for: locale)
   }
 
   func stop() {
@@ -76,6 +178,10 @@ final class DirectDictationController {
   }
 
   func toggleFromMenu() {
+    // The menu item has no language of its own, so it dictates in the first.
+    if !machine.isSessionActive {
+      activeSlot = .primary
+    }
     send(.menuToggled(now: .now))
   }
 
@@ -104,7 +210,7 @@ final class DirectDictationController {
       }
 
       do {
-        _ = try await speechService.prewarmPreferredLocale()
+        try await prepareLanguages()
       } catch {
         guard !Task.isCancelled else { return }
         preparationFailed(message: error.localizedDescription)
@@ -128,9 +234,18 @@ final class DirectDictationController {
 
   private func handle(_ event: GlobalKeyEventMonitor.Event) {
     switch event {
-    case .triggerPressed:
+    case let .triggerPressed(slot):
+      // While a session runs, only the key that started it controls it. The
+      // other language's key is inert until this session ends, so a latched
+      // German session cannot be stopped by the English key.
+      if machine.isSessionActive {
+        guard slot == activeSlot else { return }
+      } else {
+        activeSlot = slot
+      }
       send(.triggerPressed(now: .now))
-    case .triggerReleased:
+    case let .triggerReleased(slot):
+      guard slot == activeSlot else { return }
       send(.triggerReleased(now: .now))
     case .cancelPressed:
       send(.escapePressed)
@@ -177,7 +292,8 @@ final class DirectDictationController {
       hudController.showListening(
         on: focusedTarget?.displayID,
         isLatched: latched,
-        settings: session
+        settings: session,
+        languageTag: activeLanguageTag
       )
     case .showLatched:
       hudController.showLatched()
@@ -231,10 +347,16 @@ final class DirectDictationController {
   }
 
   private func beginRecognition() {
+    guard let locale = locale(for: activeSlot) else {
+      fail(message: "Preparing speech…", wasCancelled: false)
+      return
+    }
+
     sessionStartTask = Task { [weak self] in
       guard let self else { return }
       do {
         try await speechService.start(
+          locale: locale,
           updateHandler: { [weak self] update in
             Task { @MainActor [weak self] in
               self?.receive(update)

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -133,9 +133,12 @@ final class DirectDictationController {
     )
     primaryLocale = primary
 
+    // Resolved strictly: a stored pick this Mac cannot transcribe drops the
+    // second language instead of quietly becoming the system default, which
+    // would dictate in a language the user never chose.
     var secondary: Locale?
     if settings.isSecondLanguageEnabled {
-      secondary = try? await speechService.resolveLocale(
+      secondary = await speechService.supportedLocale(
         identifier: settings.secondaryRecognitionLocaleIdentifier
       )
     }

--- a/Talkify/Dictation/SpeechLanguage.swift
+++ b/Talkify/Dictation/SpeechLanguage.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Speech
+
+/// One language Apple Speech can transcribe, as the Language section lists it.
+/// `isInstalled` matters to the user: an uninstalled language downloads its
+/// model on first use, so the picker says so before they pick it.
+struct SpeechLanguage: Identifiable, Equatable, Sendable {
+  let locale: Locale
+  let name: String
+  let isInstalled: Bool
+
+  var id: String { locale.identifier }
+
+  var tag: String { SpeechLanguageCatalog.tag(for: locale) }
+}
+
+/// Reads the language list from Apple Speech. Every entry comes from
+/// `SpeechTranscriber.supportedLocales`, so the list is whatever this Mac's
+/// macOS actually supports rather than a hardcoded table that can drift.
+enum SpeechLanguageCatalog {
+  /// Two-letter tag for the HUD ("EN", "DE"), so a session shows which
+  /// language is listening. Recognition fails confidently in the wrong
+  /// language, which makes this worth the space.
+  static func tag(for locale: Locale) -> String {
+    (locale.language.languageCode?.identifier ?? locale.identifier)
+      .prefix(2)
+      .uppercased()
+  }
+
+  /// The language's own name without its region ("German"), for prose where
+  /// the region adds nothing: a HUD line has no room for "German (Germany)".
+  static func shortName(for locale: Locale) -> String {
+    guard let code = locale.language.languageCode?.identifier,
+       let name = Locale.current.localizedString(forLanguageCode: code) else {
+      return tag(for: locale)
+    }
+    return name.localizedCapitalized
+  }
+
+  static func available() async -> [SpeechLanguage] {
+    let installed = Set(await SpeechTranscriber.installedLocales.map(\.identifier))
+    let display = Locale.current
+
+    return await SpeechTranscriber.supportedLocales
+      .map { locale in
+        SpeechLanguage(
+          locale: locale,
+          name: name(for: locale, in: display),
+          isInstalled: installed.contains(locale.identifier)
+        )
+      }
+      .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+  }
+
+  /// "German (Germany)" rather than "de_DE": the region matters, because
+  /// Apple ships several variants of most of these languages.
+  private static func name(for locale: Locale, in display: Locale) -> String {
+    guard let code = locale.language.languageCode?.identifier,
+       let language = display.localizedString(forLanguageCode: code) else {
+      return locale.identifier
+    }
+
+    guard let region = locale.region?.identifier,
+       let regionName = display.localizedString(forRegionCode: region) else {
+      return language.localizedCapitalized
+    }
+
+    return "\(language.localizedCapitalized) (\(regionName))"
+  }
+}

--- a/Talkify/Dictation/SpeechRecognitionService.swift
+++ b/Talkify/Dictation/SpeechRecognitionService.swift
@@ -58,6 +58,20 @@ actor SpeechRecognitionService {
     }
   }
 
+  /// A language model download in flight. `fraction` is 0…1 while it runs and
+  /// nil once it finishes or fails, which is how the UI knows to stop showing
+  /// it. Reported for the language being prepared, whichever key it belongs to.
+  struct ModelDownload: Sendable {
+    let locale: Locale
+    let fraction: Double?
+  }
+
+  /// Foundation's `Progress` is documented as safe to read from any thread,
+  /// but it is not `Sendable`; the box carries it into the reporting task.
+  private struct ProgressBox: @unchecked Sendable {
+    let progress: Progress
+  }
+
   private struct PreparedSession: @unchecked Sendable {
     let locale: Locale
     let transcriber: SpeechTranscriber
@@ -72,17 +86,84 @@ actor SpeechRecognitionService {
     let resultTask: Task<String, any Error>
   }
 
-  private var preparedSession: PreparedSession?
+  /// One warm session per language, keyed by locale: a second language is
+  /// only worth having if it answers as fast as the first, and that means
+  /// keeping its analyzer prepared rather than building it on the keypress.
+  private var preparedSessions: [Locale: PreparedSession] = [:]
   private var activeSession: ActiveSession?
-  private var reservedLocale: Locale?
+  /// Locales reserved with AssetInventory, oldest first. The system caps how
+  /// many an app may hold (`maximumReservedLocales`), so the oldest is
+  /// released when a new one would exceed it.
+  private var reservedLocales: [Locale] = []
+  /// Builds in flight, one per locale. Preparing a language suspends while
+  /// its model downloads, and an actor is reentrant at a suspension point:
+  /// without this, pressing the key mid-download starts a second install
+  /// request for the same language. Both callers await the same build.
+  private var buildTasks: [Locale: Task<PreparedSession, any Error>] = [:]
+  private var downloadHandler: (@Sendable (ModelDownload) -> Void)?
 
-  func prewarmPreferredLocale() async throws -> Locale {
-    let locale = try await preferredLocale()
-    try await prewarm(locale: locale)
-    return locale
+  /// Reports language model downloads, so a wait that can take minutes is
+  /// visible instead of looking like a stall.
+  func setDownloadHandler(_ handler: @escaping @Sendable (ModelDownload) -> Void) {
+    downloadHandler = handler
+  }
+
+  /// Resolves a stored language identifier to a locale Apple Speech
+  /// actually supports, falling back to the system language and then to
+  /// English, the way a missing preference always behaved.
+  func resolveLocale(identifier: String?) async throws -> Locale {
+    if let identifier, !identifier.isEmpty,
+     let supported = await SpeechTranscriber.supportedLocale(
+       equivalentTo: Locale(identifier: identifier)
+     ) {
+      return supported
+    }
+    return try await defaultLocale()
+  }
+
+  func prewarm(locale: Locale) async throws {
+    try await ensureWarm(locale: locale)
+  }
+
+  /// Leaves a warm session for this locale in `preparedSessions`, building
+  /// one only if no build is already under way. Exactly one path owns the
+  /// cache, so two awaiters of the same build can never end up with the same
+  /// analyzer, one using it while the other caches it as idle.
+  private func ensureWarm(locale: Locale) async throws {
+    if preparedSessions[locale] != nil { return }
+
+    if let existing = buildTasks[locale] {
+      _ = try await existing.value
+      return
+    }
+
+    let task = Task { try await makePreparedSession(locale: locale) }
+    buildTasks[locale] = task
+
+    do {
+      preparedSessions[locale] = try await task.value
+      buildTasks[locale] = nil
+    } catch {
+      buildTasks[locale] = nil
+      throw error
+    }
+  }
+
+  /// Drops warm sessions and releases reservations for languages no longer
+  /// bound to a key, so changing a language in Settings does not leak a
+  /// reservation slot or keep a stale analyzer alive.
+  func retainOnly(locales: [Locale]) async {
+    let keep = Set(locales)
+    for locale in Set(preparedSessions.keys).union(buildTasks.keys) where !keep.contains(locale) {
+      discard(locale: locale)
+    }
+    for locale in reservedLocales where !keep.contains(locale) {
+      await release(locale: locale)
+    }
   }
 
   func start(
+    locale: Locale,
     updateHandler: @escaping @Sendable (Update) -> Void,
     failureHandler: @escaping @Sendable (String) -> Void,
     levelHandler: (@Sendable (Float) -> Void)? = nil
@@ -91,7 +172,7 @@ actor SpeechRecognitionService {
       throw RecognitionError.sessionAlreadyActive
     }
 
-    let prepared = try await takePreparedSession()
+    let prepared = try await takePreparedSession(locale: locale)
     try Task.checkCancellation()
     let (stream, continuation) = AsyncStream.makeStream(
       of: AnalyzerInput.self,
@@ -173,27 +254,26 @@ actor SpeechRecognitionService {
 
   func shutDown() async {
     await cancel()
-    preparedSession = nil
+    for task in buildTasks.values { task.cancel() }
+    buildTasks.removeAll()
+    preparedSessions.removeAll()
 
-    if let reservedLocale {
-      await AssetInventory.release(reservedLocale: reservedLocale)
-      self.reservedLocale = nil
+    for locale in reservedLocales {
+      await AssetInventory.release(reservedLocale: locale)
     }
+    reservedLocales.removeAll()
   }
 
-  private func takePreparedSession() async throws -> PreparedSession {
-    if let preparedSession {
-      self.preparedSession = nil
-      return preparedSession
+  /// Hands the session its analyzer. Cold or mid-download, it waits for the
+  /// build already in flight rather than starting a rival one.
+  private func takePreparedSession(locale: Locale) async throws -> PreparedSession {
+    try await ensureWarm(locale: locale)
+
+    guard let prepared = preparedSessions[locale] else {
+      throw RecognitionError.unavailable
     }
-
-    let locale = try await preferredLocale()
-    return try await makePreparedSession(locale: locale)
-  }
-
-  private func prewarm(locale: Locale) async throws {
-    guard preparedSession == nil else { return }
-    preparedSession = try await makePreparedSession(locale: locale)
+    preparedSessions[locale] = nil
+    return prepared
   }
 
   private func makePreparedSession(locale requestedLocale: Locale) async throws -> PreparedSession {
@@ -217,9 +297,16 @@ actor SpeechRecognitionService {
       attributeOptions: []
     )
 
+    // Only a missing model produces a request, so this is the one branch that
+    // can take real time. Everything else here is fast.
     if let installationRequest = try await AssetInventory.assetInstallationRequest(
       supporting: [transcriber]
     ) {
+      let reporter = reportProgress(of: installationRequest.progress, for: locale)
+      defer {
+        reporter.cancel()
+        downloadHandler?(ModelDownload(locale: locale, fraction: nil))
+      }
       try await installationRequest.downloadAndInstall()
     }
 
@@ -245,14 +332,26 @@ actor SpeechRecognitionService {
     )
   }
 
-  private func preferredLocale() async throws -> Locale {
-    if let storedIdentifier = UserDefaults.standard.string(forKey: "recognitionLocale"),
-     let storedLocale = await SpeechTranscriber.supportedLocale(
-       equivalentTo: Locale(identifier: storedIdentifier)
-     ) {
-      return storedLocale
-    }
+  /// Polls the install request's progress rather than observing it: the value
+  /// only feeds a label and a HUD line, so a few reads a second is plenty and
+  /// it keeps KVO out of an actor.
+  private func reportProgress(of progress: Progress, for locale: Locale) -> Task<Void, Never> {
+    let box = ProgressBox(progress: progress)
+    let handler = downloadHandler
+    handler?(ModelDownload(locale: locale, fraction: 0))
 
+    return Task { [box, handler] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .milliseconds(250))
+        guard !Task.isCancelled else { return }
+        handler?(ModelDownload(locale: locale, fraction: box.progress.fractionCompleted))
+      }
+    }
+  }
+
+  /// The language to use when the user has never chosen one: the Mac's own,
+  /// then English, then whatever Apple Speech supports at all.
+  private func defaultLocale() async throws -> Locale {
     if let currentLocale = await SpeechTranscriber.supportedLocale(equivalentTo: .current) {
       return currentLocale
     }
@@ -269,15 +368,34 @@ actor SpeechRecognitionService {
     return firstLocale
   }
 
+  /// Reserves a locale, keeping every language bound to a key reserved at
+  /// once. Only when the system cap would be exceeded is the oldest released,
+  /// which also drops its warm session so the two never disagree.
   private func reserve(locale: Locale) async throws {
-    if reservedLocale == locale { return }
+    if reservedLocales.contains(locale) { return }
 
-    if let reservedLocale {
-      await AssetInventory.release(reservedLocale: reservedLocale)
+    let cap = max(1, AssetInventory.maximumReservedLocales)
+    while reservedLocales.count >= cap, let oldest = reservedLocales.first {
+      await release(locale: oldest)
     }
 
-    try await AssetInventory.reserve(locale: locale)
-    reservedLocale = locale
+    _ = try await AssetInventory.reserve(locale: locale)
+    reservedLocales.append(locale)
+  }
+
+  private func release(locale: Locale) async {
+    await AssetInventory.release(reservedLocale: locale)
+    reservedLocales.removeAll { $0 == locale }
+    discard(locale: locale)
+  }
+
+  /// Forgets a language: drops its warm session and stops any build still
+  /// running for it, so deselecting a language mid-download does not leave
+  /// work in flight that would cache a session nothing can reach.
+  private func discard(locale: Locale) {
+    preparedSessions[locale] = nil
+    buildTasks[locale]?.cancel()
+    buildTasks[locale] = nil
   }
 
   private func prewarmAfterSession(locale: Locale) {

--- a/Talkify/Dictation/SpeechRecognitionService.swift
+++ b/Talkify/Dictation/SpeechRecognitionService.swift
@@ -41,6 +41,9 @@ actor SpeechRecognitionService {
     case missingAudioFormat
     case sessionAlreadyActive
     case noActiveSession
+    /// Every language slot the system allows is already held by a language a
+    /// key points at. The cap is device-dependent and can be 1.
+    case tooManyLanguages(cap: Int)
 
     var errorDescription: String? {
       switch self {
@@ -54,6 +57,10 @@ actor SpeechRecognitionService {
         "A dictation session is already active."
       case .noActiveSession:
         "No dictation session is active."
+      case let .tooManyLanguages(cap):
+        cap == 1
+          ? "This Mac can keep only one dictation language ready at a time."
+          : "This Mac can keep only \(cap) dictation languages ready at a time."
       }
     }
   }
@@ -101,6 +108,10 @@ actor SpeechRecognitionService {
   /// request for the same language. Both callers await the same build.
   private var buildTasks: [Locale: Task<PreparedSession, any Error>] = [:]
   private var downloadHandler: (@Sendable (ModelDownload) -> Void)?
+  /// Locales a trigger key currently points at, set by `retainOnly`. These are
+  /// protected from eviction: the whole point of keeping them reserved is that
+  /// their key answers instantly.
+  private var boundLocales: Set<Locale> = []
 
   /// Reports language model downloads, so a wait that can take minutes is
   /// visible instead of looking like a stall.
@@ -112,13 +123,21 @@ actor SpeechRecognitionService {
   /// actually supports, falling back to the system language and then to
   /// English, the way a missing preference always behaved.
   func resolveLocale(identifier: String?) async throws -> Locale {
-    if let identifier, !identifier.isEmpty,
-     let supported = await SpeechTranscriber.supportedLocale(
-       equivalentTo: Locale(identifier: identifier)
-     ) {
+    if let identifier, let supported = await supportedLocale(identifier: identifier) {
       return supported
     }
     return try await defaultLocale()
+  }
+
+  /// Strict resolution: nil when the identifier names nothing Apple Speech
+  /// supports. The second language must use this rather than falling back to
+  /// the system default — a key silently dictating in a language the user never
+  /// picked produces fluent nonsense instead of an error (CONTEXT.md).
+  func supportedLocale(identifier: String) async -> Locale? {
+    guard !identifier.isEmpty else { return nil }
+    return await SpeechTranscriber.supportedLocale(
+      equivalentTo: Locale(identifier: identifier)
+    )
   }
 
   func prewarm(locale: Locale) async throws {
@@ -132,20 +151,37 @@ actor SpeechRecognitionService {
   private func ensureWarm(locale: Locale) async throws {
     if preparedSessions[locale] != nil { return }
 
+    let task: Task<PreparedSession, any Error>
     if let existing = buildTasks[locale] {
-      _ = try await existing.value
-      return
+      task = existing
+    } else {
+      task = Task { try await makePreparedSession(locale: locale) }
+      buildTasks[locale] = task
     }
 
-    let task = Task { try await makePreparedSession(locale: locale) }
-    buildTasks[locale] = task
-
     do {
-      preparedSessions[locale] = try await task.value
-      buildTasks[locale] = nil
+      let prepared = try await task.value
+      // Every awaiter caches, not only whoever created the task. Continuations
+      // resume in an unspecified order, so if only the creator wrote here a
+      // waiter that resumed first would find an empty cache and report Apple
+      // Speech as unavailable for what was really a race with a prewarm.
+      if preparedSessions[locale] == nil {
+        preparedSessions[locale] = prepared
+      }
+      clearBuildTask(task, for: locale)
     } catch {
-      buildTasks[locale] = nil
+      clearBuildTask(task, for: locale)
       throw error
+    }
+  }
+
+  /// Clears the build slot only when it still holds this task. A discard can
+  /// cancel one build while a later call installs another under the same
+  /// locale; clearing blindly would drop the newer task's entry and let a third
+  /// build start, which is exactly the duplicate install this map prevents.
+  private func clearBuildTask(_ task: Task<PreparedSession, any Error>, for locale: Locale) {
+    if buildTasks[locale] == task {
+      buildTasks[locale] = nil
     }
   }
 
@@ -154,6 +190,7 @@ actor SpeechRecognitionService {
   /// reservation slot or keep a stale analyzer alive.
   func retainOnly(locales: [Locale]) async {
     let keep = Set(locales)
+    boundLocales = keep
     for locale in Set(preparedSessions.keys).union(buildTasks.keys) where !keep.contains(locale) {
       discard(locale: locale)
     }
@@ -374,9 +411,21 @@ actor SpeechRecognitionService {
   private func reserve(locale: Locale) async throws {
     if reservedLocales.contains(locale) { return }
 
+    // The cap is device-dependent and can be as low as 1. Only locales that no
+    // key points at any more may be evicted: releasing a bound one would drop
+    // the language the user is about to press, cancel a download in flight, and
+    // fail its awaiter with a cancellation.
     let cap = max(1, AssetInventory.maximumReservedLocales)
-    while reservedLocales.count >= cap, let oldest = reservedLocales.first {
+    var evictable = reservedLocales.filter { !boundLocales.contains($0) }
+    while reservedLocales.count >= cap, let oldest = evictable.first {
+      evictable.removeFirst()
       await release(locale: oldest)
+    }
+
+    guard reservedLocales.count < cap else {
+      // Every slot is held by another bound language. Say so plainly rather
+      // than evicting one and leaving two keys fighting over one slot.
+      throw RecognitionError.tooManyLanguages(cap: cap)
     }
 
     _ = try await AssetInventory.reserve(locale: locale)

--- a/Talkify/HUD/DictationHUDController.swift
+++ b/Talkify/HUD/DictationHUDController.swift
@@ -13,6 +13,7 @@ final class DictationHUDController {
   /// WWDC23 "Animate with springs": don't wait for settling.
   private static let dismissDuration = Duration.milliseconds(350)
   private static let latchedText = "Listening (latched)"
+  private static let listeningText = "Listening…"
 
   private enum Mode {
     case hidden
@@ -28,6 +29,8 @@ final class DictationHUDController {
   private let content = DictationHUDContent()
   private let sounds: DictationHUDSounds
   private var mode = Mode.hidden
+  /// Remembered so a download line can restore the right session text.
+  private var sessionIsLatched = false
   private var messageDismissTask: Task<Void, Never>?
   private var orderOutTask: Task<Void, Never>?
   private var lastLevelAt = ContinuousClock.now
@@ -100,21 +103,32 @@ final class DictationHUDController {
   func showListening(
     on displayID: CGDirectDisplayID?,
     isLatched: Bool,
-    settings: DictationSessionSettings
+    settings: DictationSessionSettings,
+    languageTag: String? = nil
   ) {
     guard let screen = selectScreen(targetDisplayID: displayID) else { return }
     sessionSettings = settings
     renderedSettings = settings
+    content.languageTag = languageTag
     cancelMessageDismiss()
     mode = .session
     startVoiceVisual()
-    present(isLatched ? Self.latchedText : "Listening…", on: screen)
+    sessionIsLatched = isLatched
+    present(isLatched ? Self.latchedText : Self.listeningText, on: screen)
     sounds.playBegin(using: settings.soundSet)
   }
 
   func showLatched() {
     guard case .session = mode else { return }
     content.text = Self.latchedText
+  }
+
+  /// A session waiting on its language model. The band says what it is waiting
+  /// for instead of sitting on "Listening…" while nothing arrives; passing nil
+  /// restores whatever the session was saying before.
+  func showModelDownload(_ text: String?) {
+    guard case .session = mode else { return }
+    content.text = text ?? (sessionIsLatched ? Self.latchedText : Self.listeningText)
   }
 
   func showLiveText(_ text: String) {

--- a/Talkify/HUD/Shell/DictationHUDContent.swift
+++ b/Talkify/HUD/Shell/DictationHUDContent.swift
@@ -19,6 +19,10 @@ final class DictationHUDContent {
   /// False once levels stop arriving while listening: a dead microphone
   /// must look different from silence (CONTEXT.md).
   var isAudioAlive = true
+  /// The session's language as a short tag ("DE"), or nil when only one
+  /// language is set up. Recognition in the wrong language returns confident
+  /// nonsense rather than an error, so a two-key setup says which is live.
+  var languageTag: String?
   /// Bumped once per session start; one-shot effects (the ripple) trigger
   /// on the change rather than on the listening state, so they never
   /// re-fire mid-session.

--- a/Talkify/HUD/Shell/DictationHUDShellView.swift
+++ b/Talkify/HUD/Shell/DictationHUDShellView.swift
@@ -187,9 +187,28 @@ struct DictationHUDShellView: View {
     }
     .font(.system(size: 15, weight: .medium))
     .foregroundStyle(.white)
-    .padding(.horizontal, 24)
+    // The tag sits in the inset rather than in the flow, and the inset grows
+    // on both sides, so centered drafts stay centered and nothing overlaps.
+    .padding(.horizontal, content.languageTag == nil ? 24 : 46)
     .padding(.vertical, 9)
     .frame(minHeight: HUDNotchGeometry.textBandHeight)
+    .overlay(alignment: .topLeading) { languageTag }
+  }
+
+  @ViewBuilder
+  private var languageTag: some View {
+    if let tag = content.languageTag {
+      Text(tag)
+        .font(.system(size: 9, weight: .semibold, design: .rounded))
+        .tracking(0.5)
+        .foregroundStyle(.white.opacity(0.72))
+        .padding(.horizontal, 4)
+        .padding(.vertical, 1.5)
+        .background(Capsule(style: .continuous).fill(.white.opacity(0.13)))
+        .padding(.leading, 12)
+        .padding(.top, 11)
+        .allowsHitTesting(false)
+    }
   }
 
   /// The Compact draft: the same long-draft semantics, leading-aligned so

--- a/Talkify/HUD/Shell/DictationHUDShellView.swift
+++ b/Talkify/HUD/Shell/DictationHUDShellView.swift
@@ -93,6 +93,11 @@ struct DictationHUDShellView: View {
         textBand
       }
     }
+    // The tag hangs off the shell, not the text band: Waveform and Edge Glow
+    // hide the band for the whole listening phase, which is exactly when the
+    // live language needs naming. Padded below the housing so it clears the
+    // camera, and an overlay so it never changes the fixed window's size.
+    .overlay(alignment: .topLeading) { languageTag }
     .frame(width: size.width)
     .frame(minHeight: size.height, alignment: .top)
     .animation(
@@ -192,7 +197,6 @@ struct DictationHUDShellView: View {
     .padding(.horizontal, content.languageTag == nil ? 24 : 46)
     .padding(.vertical, 9)
     .frame(minHeight: HUDNotchGeometry.textBandHeight)
-    .overlay(alignment: .topLeading) { languageTag }
   }
 
   @ViewBuilder
@@ -206,7 +210,8 @@ struct DictationHUDShellView: View {
         .padding(.vertical, 1.5)
         .background(Capsule(style: .continuous).fill(.white.opacity(0.13)))
         .padding(.leading, 12)
-        .padding(.top, 11)
+        // Clears the housing, so the tag never sits beside the camera.
+        .padding(.top, HUDNotchGeometry.closedSize(for: screen).height + 5)
         .allowsHitTesting(false)
     }
   }

--- a/Talkify/Input/GlobalKeyEventMonitor.swift
+++ b/Talkify/Input/GlobalKeyEventMonitor.swift
@@ -160,7 +160,7 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
 
       stateLock.withLock {
         guard let (slot, binding) = modifierTrigger(forKeyCode: keyCode) else { return }
-        let isDown = event.flags.contains(binding.modifierKeyMask)
+        let isDown = Self.isModifierKeyDown(binding, flags: event.flags)
 
         if isDown {
           // Another language's key is already held; ignore this one rather
@@ -262,6 +262,24 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
       return (.secondary, secondary)
     }
     return nil
+  }
+
+  /// Whether the bound modifier key itself is down.
+  ///
+  /// The shared flag cannot answer this for a side-specific key: with left ⌥
+  /// held, releasing right ⌥ leaves `.maskAlternate` set. The per-key device
+  /// bits can, so they decide whenever this keyboard reports them. If the
+  /// shared flag says down while both device bits are clear, nothing is
+  /// reporting them and the shared flag is all there is.
+  static func isModifierKeyDown(_ binding: KeyBinding, flags: CGEventFlags) -> Bool {
+    let sharedDown = flags.contains(binding.modifierKeyMask)
+    guard let masks = KeyBinding.deviceMasks(forKeyCode: binding.keyCode) else {
+      return sharedDown
+    }
+    if sharedDown, flags.rawValue & masks.pair == 0 {
+      return true
+    }
+    return flags.rawValue & masks.own != 0
   }
 
   /// Exact-modifier match: ⌥⎋ means Option and only Option; a bare key

--- a/Talkify/Input/GlobalKeyEventMonitor.swift
+++ b/Talkify/Input/GlobalKeyEventMonitor.swift
@@ -2,9 +2,16 @@ import ApplicationServices
 import Foundation
 
 final class GlobalKeyEventMonitor: @unchecked Sendable {
+  /// Which dictation trigger fired. Each slot carries its own language, so
+  /// the controller needs to know which key started the session.
+  enum TriggerSlot: Sendable {
+    case primary
+    case secondary
+  }
+
   enum Event: Sendable {
-    case triggerPressed
-    case triggerReleased
+    case triggerPressed(TriggerSlot)
+    case triggerReleased(TriggerSlot)
     case cancelPressed
     /// Option+Escape — the Read Aloud toggle, matching the shortcut
     /// macOS Spoken Content uses for "speak selection".
@@ -16,7 +23,10 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
 
   private var eventTap: CFMachPort?
   private var runLoopSource: CFRunLoopSource?
-  private var triggerKeyIsDown = false
+  /// Which slot's key is currently held, nil when none. One at a time: the
+  /// other language's key is inert until this one is released, so a session
+  /// can never be half German and half English.
+  private var heldSlot: TriggerSlot?
   private var captureEscape = false
   /// True while a Settings key recorder is armed: every event passes
   /// through untouched so the rebind keystroke cannot start a session.
@@ -24,6 +34,8 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
   // Bindings, mutable from the main actor via setBindings; read on the
   // tap thread under the lock. Defaults match AppSettings' defaults.
   private var triggerBinding = KeyBinding.fnTrigger
+  /// The second language's trigger; nil when no second language is chosen.
+  private var secondaryTriggerBinding: KeyBinding?
   private var readAloudBinding = KeyBinding.optionEscape
 
   init(handler: @escaping @Sendable (Event) -> Void) {
@@ -89,7 +101,7 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
     runLoopSource = nil
 
     stateLock.withLock {
-      triggerKeyIsDown = false
+      heldSlot = nil
       captureEscape = false
     }
   }
@@ -102,11 +114,19 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
 
   /// Applies the recorded Settings bindings. Safe while the tap runs; a
   /// key held through a rebind simply never delivers its release.
-  func setBindings(trigger: KeyBinding, readAloud: KeyBinding) {
+  /// `secondaryTrigger` is nil when no second language is chosen.
+  func setBindings(
+    trigger: KeyBinding,
+    secondaryTrigger: KeyBinding?,
+    readAloud: KeyBinding
+  ) {
     stateLock.withLock {
       triggerBinding = trigger
+      // A second trigger identical to the first would make the slot
+      // ambiguous, so the primary always wins and the second is dropped.
+      secondaryTriggerBinding = secondaryTrigger == trigger ? nil : secondaryTrigger
       readAloudBinding = readAloud
-      triggerKeyIsDown = false
+      heldSlot = nil
     }
   }
 
@@ -114,7 +134,7 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
   func setEventHandlingSuspended(_ isSuspended: Bool) {
     stateLock.withLock {
       suspended = isSuspended
-      triggerKeyIsDown = false
+      heldSlot = nil
     }
   }
 
@@ -139,12 +159,20 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
       var output: Event?
 
       stateLock.withLock {
-        guard triggerBinding.isModifierKey,
-           keyCode == triggerBinding.keyCode else { return }
-        let isDown = event.flags.contains(triggerBinding.modifierKeyMask)
-        guard isDown != triggerKeyIsDown else { return }
-        triggerKeyIsDown = isDown
-        output = isDown ? .triggerPressed : .triggerReleased
+        guard let (slot, binding) = modifierTrigger(forKeyCode: keyCode) else { return }
+        let isDown = event.flags.contains(binding.modifierKeyMask)
+
+        if isDown {
+          // Another language's key is already held; ignore this one rather
+          // than starting a second session on top of the first.
+          guard heldSlot == nil else { return }
+          heldSlot = slot
+          output = .triggerPressed(slot)
+        } else {
+          guard heldSlot == slot else { return }
+          heldSlot = nil
+          output = .triggerReleased(slot)
+        }
       }
 
       if let output {
@@ -156,21 +184,21 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
 
     if type == .keyDown {
       let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-      let (trigger, readAloud, shouldCapture) = stateLock.withLock {
-        (triggerBinding, readAloudBinding, captureEscape)
+      let (readAloud, shouldCapture, plainTrigger) = stateLock.withLock {
+        (readAloudBinding, captureEscape, plainKeyTrigger(forKeyCode: keyCode))
       }
 
       // A non-modifier trigger key: press starts the hold gesture.
       // Autorepeat is the key being held, not pressed again.
-      if !trigger.isModifierKey, keyCode == trigger.keyCode {
+      if let (slot, _) = plainTrigger {
         guard event.getIntegerValueField(.keyboardEventAutorepeat) == 0 else {
           return nil
         }
         var output: Event?
         stateLock.withLock {
-          guard !triggerKeyIsDown else { return }
-          triggerKeyIsDown = true
-          output = .triggerPressed
+          guard heldSlot == nil else { return }
+          heldSlot = slot
+          output = .triggerPressed(slot)
         }
         if let output { handler(output) }
         return nil
@@ -197,11 +225,10 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
       let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
       var output: Event?
       stateLock.withLock {
-        guard !triggerBinding.isModifierKey,
-           keyCode == triggerBinding.keyCode,
-           triggerKeyIsDown else { return }
-        triggerKeyIsDown = false
-        output = .triggerReleased
+        guard let (slot, _) = plainKeyTrigger(forKeyCode: keyCode),
+           heldSlot == slot else { return }
+        heldSlot = nil
+        output = .triggerReleased(slot)
       }
       if let output {
         handler(output)
@@ -211,6 +238,30 @@ final class GlobalKeyEventMonitor: @unchecked Sendable {
     }
 
     return Unmanaged.passUnretained(event)
+  }
+
+  /// Resolves a keycode to a trigger slot. Both helpers must be called with
+  /// `stateLock` held; the primary is checked first so it wins any overlap.
+  private func modifierTrigger(forKeyCode keyCode: Int64) -> (TriggerSlot, KeyBinding)? {
+    if triggerBinding.isModifierKey, keyCode == triggerBinding.keyCode {
+      return (.primary, triggerBinding)
+    }
+    if let secondary = secondaryTriggerBinding,
+     secondary.isModifierKey, keyCode == secondary.keyCode {
+      return (.secondary, secondary)
+    }
+    return nil
+  }
+
+  private func plainKeyTrigger(forKeyCode keyCode: Int64) -> (TriggerSlot, KeyBinding)? {
+    if !triggerBinding.isModifierKey, keyCode == triggerBinding.keyCode {
+      return (.primary, triggerBinding)
+    }
+    if let secondary = secondaryTriggerBinding,
+     !secondary.isModifierKey, keyCode == secondary.keyCode {
+      return (.secondary, secondary)
+    }
+    return nil
   }
 
   /// Exact-modifier match: ⌥⎋ means Option and only Option; a bare key

--- a/Talkify/Input/KeyBindings.swift
+++ b/Talkify/Input/KeyBindings.swift
@@ -54,6 +54,32 @@ struct KeyBinding: Equatable, Codable {
     isModifierKey: false, label: "⌥ ⎋", keyEquivalent: "\u{1B}"
   )
 
+  /// Which physical key a side-specific modifier binding watches, and the pair
+  /// it belongs to.
+  ///
+  /// `CGEventFlags` collapses left and right into one bit: releasing right ⌥
+  /// while left ⌥ is held leaves `.maskAlternate` set, so a trigger bound to
+  /// right ⌥ would never see its release and the session would stay open. The
+  /// low 16 bits carry per-key state (`NX_DEVICE*KEYMASK` in IOKit's
+  /// `IOLLEvent.h`), which does distinguish them.
+  ///
+  /// `pair` exists to tell "both keys are up" apart from "this keyboard does
+  /// not report device bits at all", so the monitor can fall back safely.
+  static func deviceMasks(forKeyCode keyCode: Int64) -> (own: UInt64, pair: UInt64)? {
+    switch keyCode {
+    case 55: (own: 0x0000_0008, pair: 0x0000_0018)  // left ⌘
+    case 54: (own: 0x0000_0010, pair: 0x0000_0018)  // right ⌘
+    case 58: (own: 0x0000_0020, pair: 0x0000_0060)  // left ⌥
+    case 61: (own: 0x0000_0040, pair: 0x0000_0060)  // right ⌥
+    case 59: (own: 0x0000_0001, pair: 0x0000_2001)  // left ⌃
+    case 62: (own: 0x0000_2000, pair: 0x0000_2001)  // right ⌃
+    case 56: (own: 0x0000_0002, pair: 0x0000_0006)  // left ⇧
+    case 60: (own: 0x0000_0004, pair: 0x0000_0006)  // right ⇧
+    // fn has no left/right twin, so its shared flag is already unambiguous.
+    default: nil
+    }
+  }
+
   static func modifierMask(forKeyCode keyCode: Int64) -> CGEventFlags {
     switch keyCode {
     case 63: .maskSecondaryFn

--- a/Talkify/Input/KeyBindings.swift
+++ b/Talkify/Input/KeyBindings.swift
@@ -41,6 +41,14 @@ struct KeyBinding: Equatable, Codable {
     label: "fn", keyEquivalent: ""
   )
 
+  /// Default second-language trigger: right ⌥ held, mirroring the fn hold
+  /// on the other side of the keyboard. Only ever installed once a second
+  /// language is chosen, so it costs nothing until then.
+  static let rightOptionTrigger = KeyBinding(
+    keyCode: 61, modifierFlags: 0, isModifierKey: true,
+    label: "right ⌥", keyEquivalent: ""
+  )
+
   static let optionEscape = KeyBinding(
     keyCode: 53, modifierFlags: CGEventFlags.maskAlternate.rawValue,
     isModifierKey: false, label: "⌥ ⎋", keyEquivalent: "\u{1B}"

--- a/Talkify/Settings/Sections/LanguageSettingsView.swift
+++ b/Talkify/Settings/Sections/LanguageSettingsView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+/// The Language section: the dictation language, an optional second language,
+/// and the key that dictates in it. Two keys rather than automatic detection —
+/// Apple Speech transcribes one language per session, and a wrong guess
+/// produces confident nonsense rather than an error (CONTEXT.md).
+struct LanguageSettingsView: View {
+  @Bindable var settings: AppSettings
+  let runtimeState: SettingsRuntimeState
+
+  @Environment(\.colorSchemeContrast) private var contrast
+  @State private var languages: [SpeechLanguage] = []
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      SettingsCard(title: "Languages") {
+        SettingsPickerRow(
+          title: "Dictation language",
+          description: "The language the trigger key transcribes",
+          options: [""] + languages.map(\.id),
+          optionLabel: label(for:),
+          selection: $settings.recognitionLocaleIdentifier,
+          controlWidth: 260
+        )
+
+        SettingsPickerRow(
+          title: "Second language",
+          description: settings.isSecondLanguageEnabled
+            ? "Its own key, so you never switch a setting to switch language"
+            : "Off. Choose one to dictate in two languages",
+          options: [""] + languages.map(\.id),
+          optionLabel: secondaryLabel(for:),
+          selection: $settings.secondaryRecognitionLocaleIdentifier,
+          controlWidth: 260
+        )
+
+        if settings.isSecondLanguageEnabled {
+          SettingsRow(
+            title: "Second language key",
+            description: "Hold it to dictate in \(secondaryName)"
+          ) {
+            KeyRecorderView(
+              keyBinding: $settings.secondaryTriggerBinding,
+              capturesSingleKey: true,
+              onRecordingChanged: { settings.isRecordingKeybind = $0 }
+            )
+          }
+        }
+
+        // A model download can take minutes. Naming the language and its
+        // progress is what separates "working" from "stuck".
+        ForEach(downloads, id: \.name) { download in
+          SettingsRow(
+            title: "Downloading \(download.name)",
+            description: "The model is downloading now. You can keep using "
+              + "your other language while it finishes."
+          ) {
+            HStack(spacing: 8) {
+              ProgressView(value: download.fraction)
+                .progressViewStyle(.linear)
+                .frame(width: 120)
+              Text("\(Int(download.fraction * 100))%")
+                .font(.system(size: 12, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.white.opacity(0.6))
+            }
+          }
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(
+          "Both languages stay loaded, so either key answers as fast as the "
+            + "other. A language that is not installed yet downloads its model "
+            + "the first time you use it, which takes a moment; after that it "
+            + "runs on device like the rest."
+        )
+        .font(.caption)
+        .foregroundStyle(.white.opacity(contrast == .increased ? 0.7 : 0.45))
+        .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(.horizontal, 6)
+    }
+    .task {
+      languages = await SpeechLanguageCatalog.available()
+    }
+  }
+
+  /// Downloads in flight, named for the reader. Sorted by name so the rows
+  /// do not reorder while progress changes.
+  private var downloads: [(name: String, fraction: Double)] {
+    runtimeState.languageDownloads
+      .map { identifier, fraction in
+        let name = languages.first { $0.id == identifier }?.name ?? identifier
+        return (name: name, fraction: fraction)
+      }
+      .sorted { $0.name < $1.name }
+  }
+
+  private func label(for identifier: String) -> String {
+    guard !identifier.isEmpty else { return "Automatic (\(automaticName))" }
+    guard let language = languages.first(where: { $0.id == identifier }) else {
+      return identifier
+    }
+    return language.isInstalled
+      ? language.name
+      : "\(language.name) — downloads on first use"
+  }
+
+  private func secondaryLabel(for identifier: String) -> String {
+    identifier.isEmpty ? "Off" : label(for: identifier)
+  }
+
+  /// What "Automatic" resolves to, named rather than left abstract: the Mac's
+  /// own language when Apple Speech supports it.
+  private var automaticName: String {
+    let current = Locale.current.language.languageCode?.identifier
+    let match = languages.first {
+      $0.locale.language.languageCode?.identifier == current
+    }
+    return match?.name ?? "English"
+  }
+
+  private var secondaryName: String {
+    languages
+      .first { $0.id == settings.secondaryRecognitionLocaleIdentifier }?
+      .name ?? "the second language"
+  }
+}

--- a/Talkify/Settings/Sections/LanguageSettingsView.swift
+++ b/Talkify/Settings/Sections/LanguageSettingsView.swift
@@ -28,7 +28,7 @@ struct LanguageSettingsView: View {
           description: settings.isSecondLanguageEnabled
             ? "Its own key, so you never switch a setting to switch language"
             : "Off. Choose one to dictate in two languages",
-          options: [""] + languages.map(\.id),
+          options: [""] + secondaryOptions,
           optionLabel: secondaryLabel(for:),
           selection: $settings.secondaryRecognitionLocaleIdentifier,
           controlWidth: 260
@@ -84,6 +84,15 @@ struct LanguageSettingsView: View {
     .task {
       languages = await SpeechLanguageCatalog.available()
     }
+  }
+
+  /// The first language is not offered as the second: picking it would show the
+  /// key row for a language that is already covered, and the key would do
+  /// nothing new.
+  private var secondaryOptions: [String] {
+    languages
+      .map(\.id)
+      .filter { $0 != settings.recognitionLocaleIdentifier }
   }
 
   /// Downloads in flight, named for the reader. Sorted by name so the rows

--- a/Talkify/Settings/SettingsRuntimeState.swift
+++ b/Talkify/Settings/SettingsRuntimeState.swift
@@ -8,7 +8,20 @@ import Observation
 final class SettingsRuntimeState {
   var isDictating: Bool
 
+  /// Language models currently downloading, as locale identifier to progress
+  /// (0…1). A language picked before its model exists downloads in the
+  /// background, and the Language section says so rather than looking idle.
+  var languageDownloads: [String: Double] = [:]
+
   init(isDictating: Bool = false) {
     self.isDictating = isDictating
+  }
+
+  func setDownload(identifier: String, fraction: Double?) {
+    if let fraction {
+      languageDownloads[identifier] = fraction
+    } else {
+      languageDownloads[identifier] = nil
+    }
   }
 }

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -16,6 +16,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case appearance
   case sounds
   case readAloud
+  case language
   case shortcuts
   case insights
 
@@ -27,6 +28,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .appearance: "Appearance"
     case .sounds: "Sounds"
     case .readAloud: "Read Aloud"
+    case .language: "Language"
     case .shortcuts: "Shortcuts"
     case .insights: "Insights"
     }
@@ -37,6 +39,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .appearance: "Customize the Direct Dictation HUD"
     case .sounds: "Choose and preview Direct Dictation sounds"
     case .readAloud: "Choose the voice that reads selected text"
+    case .language: "Pick your dictation languages and their keys"
     case .shortcuts: "Rebind the Direct Dictation and Read Aloud keys"
     case .insights: "Review your local Direct Dictation activity"
     }
@@ -47,6 +50,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .appearance: "sparkles"
     case .sounds: "waveform"
     case .readAloud: "speaker.wave.2"
+    case .language: "globe"
     case .shortcuts: "keyboard"
     case .insights: "chart.bar.xaxis"
     }

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -35,7 +35,8 @@ struct SettingsView: View {
             section: selectedSection,
             settings: settings,
             sounds: sounds,
-            usageTracker: usageTracker
+            usageTracker: usageTracker,
+            runtimeState: runtimeState
           )
           .id(selectedSection)
           .transition(.opacity)
@@ -219,6 +220,7 @@ private struct SettingsContent: View {
   @Bindable var settings: AppSettings
   let sounds: DictationHUDSounds
   let usageTracker: UsageTracker
+  let runtimeState: SettingsRuntimeState
 
   @Environment(\.colorSchemeContrast) private var contrast
 
@@ -240,6 +242,8 @@ private struct SettingsContent: View {
           SoundsSettingsView(settings: settings, sounds: sounds)
         case .readAloud:
           ReadAloudSettingsView(settings: settings)
+        case .language:
+          LanguageSettingsView(settings: settings, runtimeState: runtimeState)
         case .shortcuts:
           ShortcutsSettingsView(settings: settings)
         case .insights:

--- a/TalkifyTests/AppSettingsTests.swift
+++ b/TalkifyTests/AppSettingsTests.swift
@@ -128,9 +128,30 @@ struct AppSettingsTests {
     #expect(state.languageDownloads.isEmpty)
   }
 
+  /// The name is localized for whoever is reading it, so the expectation comes
+  /// from the same source rather than hardcoding English. What the test pins is
+  /// the behaviour: the region is dropped, and both German regions read alike.
   @Test func languagesAreNamedWithoutTheirRegionForProse() {
-    #expect(SpeechLanguageCatalog.shortName(for: Locale(identifier: "de_DE")) == "German")
-    #expect(SpeechLanguageCatalog.shortName(for: Locale(identifier: "de_CH")) == "German")
+    let expected = Locale.current.localizedString(forLanguageCode: "de")?.localizedCapitalized
+    let germany = SpeechLanguageCatalog.shortName(for: Locale(identifier: "de_DE"))
+    let switzerland = SpeechLanguageCatalog.shortName(for: Locale(identifier: "de_CH"))
+
+    #expect(germany == switzerland)
+    #expect(!germany.contains("_"))
+    if let expected {
+      #expect(germany == expected)
+    }
+  }
+
+  @Test func pickingTheSecondLanguageAsTheFirstTurnsTheSecondOff() {
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.recognitionLocaleIdentifier = "en_US"
+    settings.secondaryRecognitionLocaleIdentifier = "de_DE"
+    #expect(settings.isSecondLanguageEnabled)
+
+    settings.recognitionLocaleIdentifier = "de_DE"
+    #expect(!settings.isSecondLanguageEnabled)
+    #expect(settings.secondaryRecognitionLocaleIdentifier == "")
   }
 
   @Test func languageTagsAreTwoLetterUppercase() {

--- a/TalkifyTests/AppSettingsTests.swift
+++ b/TalkifyTests/AppSettingsTests.swift
@@ -82,6 +82,63 @@ struct AppSettingsTests {
     #expect(defaults.data(forKey: "readAloudBinding") != nil)
   }
 
+  @Test func languagesDefaultToOneFollowingTheMac() {
+    let settings = AppSettings(defaults: freshDefaults())
+    #expect(settings.recognitionLocaleIdentifier == "")
+    #expect(settings.secondaryRecognitionLocaleIdentifier == "")
+    #expect(!settings.isSecondLanguageEnabled)
+    #expect(settings.secondaryTriggerBinding == .rightOptionTrigger)
+  }
+
+  @Test func secondLanguageTurnsOnWithItsPickAndOffAgain() {
+    let defaults = freshDefaults()
+    let settings = AppSettings(defaults: defaults)
+
+    settings.recognitionLocaleIdentifier = "en_US"
+    settings.secondaryRecognitionLocaleIdentifier = "de_DE"
+    #expect(settings.isSecondLanguageEnabled)
+    #expect(defaults.string(forKey: "recognitionLocale") == "en_US")
+    #expect(defaults.string(forKey: "recognitionLocaleSecondary") == "de_DE")
+
+    settings.secondaryRecognitionLocaleIdentifier = ""
+    #expect(!settings.isSecondLanguageEnabled)
+  }
+
+  @Test func languagePicksSurviveARelaunch() {
+    let defaults = freshDefaults()
+    let first = AppSettings(defaults: defaults)
+    first.recognitionLocaleIdentifier = "fr_FR"
+    first.secondaryRecognitionLocaleIdentifier = "it_IT"
+    first.secondaryTriggerBinding = .fnTrigger
+
+    let second = AppSettings(defaults: defaults)
+    #expect(second.recognitionLocaleIdentifier == "fr_FR")
+    #expect(second.secondaryRecognitionLocaleIdentifier == "it_IT")
+    #expect(second.secondaryTriggerBinding == .fnTrigger)
+  }
+
+  @Test func downloadsAppearWhileRunningAndClearWhenDone() {
+    let state = SettingsRuntimeState()
+    #expect(state.languageDownloads.isEmpty)
+
+    state.setDownload(identifier: "de_DE", fraction: 0.4)
+    #expect(state.languageDownloads["de_DE"] == 0.4)
+
+    state.setDownload(identifier: "de_DE", fraction: nil)
+    #expect(state.languageDownloads.isEmpty)
+  }
+
+  @Test func languagesAreNamedWithoutTheirRegionForProse() {
+    #expect(SpeechLanguageCatalog.shortName(for: Locale(identifier: "de_DE")) == "German")
+    #expect(SpeechLanguageCatalog.shortName(for: Locale(identifier: "de_CH")) == "German")
+  }
+
+  @Test func languageTagsAreTwoLetterUppercase() {
+    #expect(SpeechLanguageCatalog.tag(for: Locale(identifier: "de_DE")) == "DE")
+    #expect(SpeechLanguageCatalog.tag(for: Locale(identifier: "en_US")) == "EN")
+    #expect(SpeechLanguageCatalog.tag(for: Locale(identifier: "yue_CN")) == "YU")
+  }
+
   @Test func unknownStoredValueFallsBackToDefault() {
     let defaults = freshDefaults()
     defaults.set("Kazoo", forKey: "dictationSoundSet")

--- a/TalkifyTests/ModifierTriggerTests.swift
+++ b/TalkifyTests/ModifierTriggerTests.swift
@@ -1,0 +1,76 @@
+import ApplicationServices
+import Testing
+@testable import Talkify
+
+/// Down/up detection for a modifier-key trigger.
+///
+/// `CGEventFlags` collapses left and right into one bit, so with left ⌥ held,
+/// releasing right ⌥ still reports `.maskAlternate`. A trigger bound to right ⌥
+/// would never see its release and the session would stay open. The per-key
+/// device bits are what make the two distinguishable.
+struct ModifierTriggerTests {
+  private let rightOption = KeyBinding.rightOptionTrigger
+  private let leftOption = KeyBinding(
+    keyCode: 58, modifierFlags: 0, isModifierKey: true,
+    label: "⌥", keyEquivalent: ""
+  )
+
+  /// From IOKit's IOLLEvent.h: left ⌥ is 0x20, right ⌥ is 0x40.
+  private func flags(shared: Bool, device: UInt64) -> CGEventFlags {
+    CGEventFlags(rawValue: (shared ? CGEventFlags.maskAlternate.rawValue : 0) | device)
+  }
+
+  @Test func rightOptionIsDownOnlyWhenItsOwnBitIsSet() {
+    #expect(GlobalKeyEventMonitor.isModifierKeyDown(
+      rightOption, flags: flags(shared: true, device: 0x40)
+    ))
+    #expect(!GlobalKeyEventMonitor.isModifierKeyDown(
+      rightOption, flags: flags(shared: false, device: 0)
+    ))
+  }
+
+  /// The regression: left ⌥ held, right ⌥ released. The shared flag is still
+  /// set, and reading it alone would keep the session open forever.
+  @Test func releasingRightOptionWhileLeftIsHeldReadsAsUp() {
+    let bothDown = flags(shared: true, device: 0x20 | 0x40)
+    #expect(GlobalKeyEventMonitor.isModifierKeyDown(rightOption, flags: bothDown))
+
+    let onlyLeftDown = flags(shared: true, device: 0x20)
+    #expect(!GlobalKeyEventMonitor.isModifierKeyDown(rightOption, flags: onlyLeftDown))
+    #expect(GlobalKeyEventMonitor.isModifierKeyDown(leftOption, flags: onlyLeftDown))
+  }
+
+  /// A keyboard that reports no device bits at all still has to work: the
+  /// shared flag is then the only signal there is.
+  @Test func fallsBackToTheSharedFlagWithoutDeviceBits() {
+    #expect(GlobalKeyEventMonitor.isModifierKeyDown(
+      rightOption, flags: flags(shared: true, device: 0)
+    ))
+    #expect(!GlobalKeyEventMonitor.isModifierKeyDown(
+      leftOption, flags: flags(shared: false, device: 0)
+    ))
+  }
+
+  /// fn has no twin, so it keeps using its own flag and no device bits.
+  @Test func fnUsesItsSharedFlag() {
+    let fn = KeyBinding.fnTrigger
+    #expect(KeyBinding.deviceMasks(forKeyCode: fn.keyCode) == nil)
+    #expect(GlobalKeyEventMonitor.isModifierKeyDown(
+      fn, flags: CGEventFlags.maskSecondaryFn
+    ))
+    #expect(!GlobalKeyEventMonitor.isModifierKeyDown(fn, flags: []))
+  }
+
+  /// Every side-specific modifier is covered, not only Option, since any of
+  /// them can be recorded as a trigger.
+  @Test func everySidedModifierHasDistinctBits() {
+    let pairs = [(55, 54), (58, 61), (59, 62), (56, 60)]
+    for (left, right) in pairs {
+      let l = try! #require(KeyBinding.deviceMasks(forKeyCode: Int64(left)))
+      let r = try! #require(KeyBinding.deviceMasks(forKeyCode: Int64(right)))
+      #expect(l.own != r.own, "keycodes \(left)/\(right) share a device bit")
+      #expect(l.pair == r.pair, "keycodes \(left)/\(right) disagree on their pair")
+      #expect(l.pair == l.own | r.own)
+    }
+  }
+}

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -27,8 +27,8 @@ struct SettingsWindowTests {
   }
 
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
-    #expect(SettingsSection.allCases == [.appearance, .sounds, .readAloud, .shortcuts, .insights])
-    #expect(SettingsSectionGroup.settings.sections == [.appearance, .sounds, .readAloud, .shortcuts, .insights])
+    #expect(SettingsSection.allCases == [.appearance, .sounds, .readAloud, .language, .shortcuts, .insights])
+    #expect(SettingsSectionGroup.settings.sections == [.appearance, .sounds, .readAloud, .language, .shortcuts, .insights])
   }
 
   @Test func appearanceOptionsFollowTheSelectedVisual() {


### PR DESCRIPTION
Adds a second dictation language with its own trigger key, plus the two fixes that came out of building it.

## Why keys, not detection

Apple Speech transcribes one language per session and ships no language identification. `SpeechDetector` is voice-activity detection, and a transcriber's `selectedLocales` is get-only and always reports the single locale it was built with. The only detector on the system is `NLLanguageRecognizer`, which reads **text** — so detection would mean transcribing first and guessing from the output. In the wrong language that output is confident nonsense, not an error. It also needs a sentence to be reliable (`"okay"` alone resolves to English), and most dictations are short.

A key per language is instant, deterministic, and never guesses.

## What it does

Settings gains a **Language** section: the dictation language, an optional second one, and the key for it (right ⌥ by default, rebindable). The second language is off by default, so an existing single-language setup behaves exactly as before.

Both languages stay prewarmed, keyed by locale. A second language is only worth having if it answers as fast as the first, and that means keeping its analyzer prepared rather than building it on the keypress.

## Two fixes that fell out

**Reservations no longer thrash.** `reserve()` released the previous locale before taking a new one, holding one of the five slots `maximumReservedLocales` actually allows. It now keeps every bound language reserved and evicts only at the real cap.

**A keypress during a model download no longer starts a second download.** Preparing a language suspends inside `downloadAndInstall()`, and an actor is reentrant at a suspension point, so a press entered `makePreparedSession` and requested the same asset again. This is the shape of [yap#32](https://github.com/finnvoor/yap/issues/32). Builds are now shared per locale, with a single path owning the cache so two waiters cannot receive the same analyzer.

## Rules

- A session runs in the language of the key that started it; the other key is inert until it ends, so a latched German session cannot be stopped by the English key.
- A second trigger identical to the first is dropped rather than made ambiguous.
- The menu item dictates in the first language.

## Visibility

A model download can take minutes, so it is shown in both places it matters: a progress row in the Language section, and the HUD band naming the language and percentage instead of sitting on "Listening…". The HUD also carries a two-letter tag (`DE`) while a second language is configured, because recognition in the wrong language fails silently.

The tag sits in the text band's inset and the inset grows on both sides, so centred drafts stay centred and the fixed-size window never resizes.

## Notes

`DictationSessionMachine` is untouched — slot filtering lives in the controller, so the tested reducer keeps its coverage. `CONTEXT.md` gains **Dictation Language** as a term plus five rules, replacing the old "one user-selected recognition language" line.

## Testing

71 tests pass, including six new ones covering the language preferences, their persistence, the download state, and the naming helpers. Not yet verified by hand: an actual non-English model download, which needs a real fetch to confirm the percentage tracks honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring primary and optional secondary dictation languages.
  * Added a secondary trigger key for switching between configured languages.
  * Added language settings with availability, installation status, and download progress.
  * Dictation sessions now use the language associated with the initiating trigger.
  * Added language indicators to the dictation HUD when multiple languages are configured.
  * Added download progress messaging while language models are prepared.

* **Bug Fixes**
  * Prevented conflicting or simultaneous language triggers from starting ambiguous sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->