### PR TITLE
Update Talkify with Sparkle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 xcuserdata/
 *.xcuserstate
 *.profraw
+
+# Sparkle: an exported private signing key must never be committed. The key
+# normally stays in the login Keychain; setup-sparkle-keys.sh --export writes
+# this file only when you are backing it up.
+talkify-sparkle-private-key.txt
+sparkle_eddsa_private_key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ Buildable and working end to end: hold Fn, speak, release — text lands in the 
 - Plain committed `Talkify.xcodeproj` (no Tuist, no generation), Swift 6, strict concurrency complete
 - AppKit is the shell: lifecycle, status item, non-activating panels
 - SwiftUI for windowed UI (Settings, onboarding), hosted in the AppKit shell
-- Apple Speech only (`SpeechAnalyzer`/`SpeechTranscriber`), no Whisper, no third-party dependencies
+- Apple Speech only (`SpeechAnalyzer`/`SpeechTranscriber`), no Whisper
+- Exactly one third-party dependency: Sparkle, for self-updating, quarantined behind `Talkify/Updates/SparkleUpdaterService.swift`. Adding a second is a decision to raise, not to make.
 - Scaffolding values (bundle ID, entitlements, signing, Info.plist keys): `docs/ProjectSettings.md`
 
 ## Layout (modules as folders; communication is one-directional callbacks wired in App/)
@@ -27,6 +28,7 @@ Buildable and working end to end: hold Fn, speak, release — text lands in the 
 - `Talkify/HUD/` — the NotchIsland-style HUD, split: root holds the controller, panel, sounds, and pure geometry seams (`HUDPlacement`, `HUDNotchGeometry`, tested); `Shell/` the surface view, its shared `DictationHUDContent` model, and layout enums; `Visuals/` the voice visuals and their styles/palettes/tokens; `Shaders/` the four Metal files (ADR-0002). Canvas previews live next to the views; the harness uses a volatile defaults suite.
 - `Talkify/ReadAloud/` — speaking selected text: controller, `VoiceCatalog`, and the read-only `FocusedSelectionReader` (never touches insertion).
 - `Talkify/Settings/` — the borderless Settings window: shell (`SettingsView`), navigation model (`SettingsSections`), `Sections/` one file per pane, `Components/` the reusable design system (`SettingsTheme/Card/Row/PickerRow/ButtonStyle`, key recorder, drag handle).
+- `Talkify/Updates/` — Sparkle, wrapped so nothing else imports it: the appcast is a static file in the repo, updates are EdDSA-verified, and the activation policy flips for Sparkle's windows because they misplace themselves under `LSUIElement`.
 - `Talkify/Insights/` — local usage metrics (pure `UsageMetrics`, tested), store, tracker, and the Swift Charts section.
 - `Talkify/Resources/Sounds/` — sound sets. **Pop is CC-BY-NC and must be replaced or dropped before any release**; see `LICENSE-SOUNDS.txt`.
 - `Talkify/Assets.xcassets/Siri/` — the Siri-orb prototype artwork (voice visual under feel test). **Unlicensed, imitates Apple's Siri orb, must be replaced or dropped before any release**; see `LICENSE-ARTWORK.txt`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,7 +14,8 @@ The first implementation milestone contains only **Direct Dictation**. Other fea
 - AppKit is the application shell: lifecycle, menu bar status item, and non-activating panels such as the HUD
 - SwiftUI renders windowed UI such as settings and onboarding, hosted inside the AppKit shell
 - Talkify uses Swift 6 with complete strict concurrency
-- Talkify uses Apple frameworks only and has no third-party dependencies
+- Talkify uses Apple frameworks only, with one exception: Sparkle, for updating itself
+- Sparkle is the single third-party dependency and is confined to `Talkify/Updates/`; nothing else imports it, and speech, insertion, and the HUD stay pure Apple frameworks
 
 ## Language
 
@@ -196,6 +197,11 @@ _Avoid_: Transcript history, cloud analytics
 - Talkify cannot download synthesis voices (no public API); the Read Aloud section deep-links System Settings and the voice list refreshes live when a download finishes
 - Personal Voice requires the user's authorization, requested from the Read Aloud section; it is personal, non-commercial use by Apple's terms
 - Read Aloud uses Apple speech synthesis exclusively; local-inference voice models were researched and rejected to keep the app dependency-free — the project stays open source and integrations are left to contributors
+- Talkify updates itself with Sparkle; the appcast is a static file in the repository and there is no Talkify server
+- Every update is verified against an EdDSA signature before installation, and an update that fails verification is discarded
+- Update checks run daily and may be turned off; downloading updates automatically is opt-in and installing always waits for the user
+- An update never interrupts an active **Direct Dictation** session
+- Sparkle's own windows require the regular activation policy: under `LSUIElement` they open unfocused or off-screen, so the policy switches for the update session and reverts when it ends
 - **Live Captions** consume exactly one **Caption Source** and never microphone audio
 - A **Live Captions** session starts only after the user confirms its **Caption Source**
 - **Live Captions** display text without saving it

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ brew install --cask talkify
 
 Or grab [**Talkify.dmg**](https://github.com/tornikegomareli/Talkify/releases/latest/download/Talkify.dmg) from the latest release.
 
+Either way, Talkify keeps itself current: it checks once a day, verifies every
+update against an EdDSA signature before installing, and never interrupts a
+dictation session to do it. Downloading automatically is off until you ask for
+it, and checks can be turned off entirely in Settings → Updates.
+
 Build from source:
 
 ```bash

--- a/Talkify.xcodeproj/project.pbxproj
+++ b/Talkify.xcodeproj/project.pbxproj
@@ -25,9 +25,22 @@
 		9E87DA73302384C5007A1A70 /* TalkifyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TalkifyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		9ESPARK04000000000000004 /* Exceptions for "Talkify" folder in "Talkify" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 9E87DA65302384C5007A1A70 /* Talkify */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		9E87DA68302384C5007A1A70 /* Talkify */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				9ESPARK04000000000000004 /* Exceptions for "Talkify" folder in "Talkify" target */,
+			);
 			path = Talkify;
 			sourceTree = "<group>";
 		};

--- a/Talkify.xcodeproj/project.pbxproj
+++ b/Talkify.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		9ESPARK03000000000000003 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 9ESPARK02000000000000002 /* Sparkle */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		9E87DA74302384C5007A1A70 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -39,6 +43,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9ESPARK03000000000000003 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -90,6 +95,7 @@
 			);
 			name = Talkify;
 			packageProductDependencies = (
+				9ESPARK02000000000000002 /* Sparkle */,
 			);
 			productName = Talkify;
 			productReference = 9E87DA66302384C5007A1A70 /* Talkify.app */;
@@ -146,6 +152,9 @@
 			);
 			mainGroup = 9E87DA5D302384C5007A1A70;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9ESPARK01000000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9E87DA67302384C5007A1A70 /* Products */;
 			projectDirPath = "";
@@ -339,6 +348,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Talkify/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -378,6 +388,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Talkify/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -480,6 +491,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9ESPARK01000000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.8.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9ESPARK02000000000000002 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9ESPARK01000000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9E87DA5E302384C5007A1A70 /* Project object */;
 }

--- a/Talkify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Talkify.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "5751fcbe53b64441ed73aceb16987d6b3fc3ebc666cb9ec2de1f6a2d441f2515",
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle.git",
+      "state" : {
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -11,6 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var settingsWindowController: SettingsWindowController?
   private var usageTracker: UsageTracker?
   private let settingsRuntimeState = SettingsRuntimeState()
+  private let updaterService = SparkleUpdaterService()
 
   static func main() {
     let application = NSApplication.shared
@@ -44,7 +45,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let statusItemController = StatusItemController(
       toggleDictation: { dictationController.toggleFromMenu() },
       toggleReadAloud: { readAloudController.toggle() },
-      openSettings: { [weak self] in self?.showSettings() }
+      openSettings: { [weak self] in self?.showSettings() },
+      checkForUpdates: { [weak self] in self?.updaterService.checkForUpdates() }
     )
     self.statusItemController = statusItemController
 
@@ -77,6 +79,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     applyKeyBindings()
     observeKeyBindings()
     observeLanguages()
+
+    // A background check is postponed while a session is running, so an update
+    // window can never take focus mid-dictation and move the insertion target.
+    updaterService.isBusy = { [weak settingsRuntimeState] in
+      settingsRuntimeState?.isDictating ?? false
+    }
+
+    // Last: a scheduled check can show a window, and it must never land
+    // before the status item and dictation are wired.
+    updaterService.start()
   }
 
   /// Rebinding in Settings updates the event tap and the status menu
@@ -135,7 +147,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         settings: settings,
         sounds: DictationHUDSounds(),
         runtimeState: settingsRuntimeState,
-        usageTracker: usageTracker
+        usageTracker: usageTracker,
+        updater: updaterService
       )
     }
     settingsWindowController?.show()

--- a/Talkify/App/StatusItemController.swift
+++ b/Talkify/App/StatusItemController.swift
@@ -6,6 +6,7 @@ final class StatusItemController: NSObject {
   private let toggleDictation: () -> Void
   private let toggleReadAloud: () -> Void
   private let openSettings: () -> Void
+  private let checkForUpdates: () -> Void
   private let dictationItem: NSMenuItem
   private let readAloudItem: NSMenuItem
   private var blinkTimer: Timer?
@@ -19,11 +20,13 @@ final class StatusItemController: NSObject {
   init(
     toggleDictation: @escaping () -> Void,
     toggleReadAloud: @escaping () -> Void,
-    openSettings: @escaping () -> Void
+    openSettings: @escaping () -> Void,
+    checkForUpdates: @escaping () -> Void
   ) {
     self.toggleDictation = toggleDictation
     self.toggleReadAloud = toggleReadAloud
     self.openSettings = openSettings
+    self.checkForUpdates = checkForUpdates
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
     dictationItem = NSMenuItem(title: "Start Dictation", action: nil, keyEquivalent: "")
     readAloudItem = NSMenuItem(title: "Read Selected Text", action: nil, keyEquivalent: "")
@@ -50,6 +53,14 @@ final class StatusItemController: NSObject {
     )
     settingsItem.target = self
     menu.addItem(settingsItem)
+
+    let updatesItem = NSMenuItem(
+      title: "Check for Updates…",
+      action: #selector(checkForUpdatesItem),
+      keyEquivalent: ""
+    )
+    updatesItem.target = self
+    menu.addItem(updatesItem)
 
     menu.addItem(NSMenuItem(
       title: "Quit Talkify",
@@ -145,6 +156,10 @@ final class StatusItemController: NSObject {
 
   @objc private func toggleReadAloudItem() {
     toggleReadAloud()
+  }
+
+  @objc private func checkForUpdatesItem() {
+    checkForUpdates()
   }
 
   @objc private func openSettingsItem() {

--- a/Talkify/Info.plist
+++ b/Talkify/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Sparkle only. Every other key is still generated from build settings
+	     (GENERATE_INFOPLIST_FILE stays on and merges into this file), because
+	     Sparkle reads SUPublicEDKey straight from the bundle and Xcode's
+	     INFOPLIST_KEY_ passthrough silently drops keys it does not know. -->
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/tornikegomareli/Talkify/main/appcast.xml</string>
+	<!-- Public half of the EdDSA signing key. The private half lives in the
+	     login Keychain and is never in the repository. -->
+	<key>SUPublicEDKey</key>
+	<string>CS7EqGMvprKkjontSt/uLAG3gkw4CSwaMKVLd+W1UV4=</string>
+	<key>SUEnableAutomaticChecks</key>
+	<true/>
+	<!-- Once a day. Talkify is a menu-bar app people leave running for weeks,
+	     so anything shorter is noise. -->
+	<key>SUScheduledCheckInterval</key>
+	<integer>86400</integer>
+	<!-- Downloading happens only when the user opts in; the default stays off
+	     so an update never replaces the binary unasked. -->
+	<key>SUAllowsAutomaticUpdates</key>
+	<true/>
+</dict>
+</plist>

--- a/Talkify/Settings/Sections/UpdatesSettingsView.swift
+++ b/Talkify/Settings/Sections/UpdatesSettingsView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// The Updates section: the running version, a manual check, and the two
+/// automatic behaviours. Sparkle owns the update UI itself, so this pane only
+/// states what is true and gets out of the way.
+struct UpdatesSettingsView: View {
+  let updater: SparkleUpdaterService
+
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      SettingsCard(title: "Version") {
+        SettingsRow(
+          title: "Talkify \(Self.version)",
+          description: updater.availableVersion.map { "Version \($0) is available." }
+            ?? lastCheckedDescription
+        ) {
+          Button("Check Now") {
+            updater.checkForUpdates()
+          }
+          .buttonStyle(SettingsButtonStyle())
+          .disabled(!updater.canCheckForUpdates)
+        }
+      }
+
+      SettingsCard(title: "Automatic") {
+        SettingsRow(
+          title: "Check for updates automatically",
+          description: "Once a day, in the background"
+        ) {
+          Toggle("", isOn: automaticChecks)
+            .labelsHidden()
+            .toggleStyle(.switch)
+        }
+
+        SettingsRow(
+          title: "Download updates automatically",
+          description: "Fetch the update in advance. Installing still waits "
+            + "for you, and never interrupts a dictation session."
+        ) {
+          Toggle("", isOn: automaticDownloads)
+            .labelsHidden()
+            .toggleStyle(.switch)
+            .disabled(!updater.automaticallyChecksForUpdates)
+        }
+      }
+
+      Text(
+        "Updates are downloaded from GitHub and verified with an EdDSA "
+          + "signature before they are installed. An update that fails "
+          + "verification is discarded."
+      )
+      .font(.caption)
+      .foregroundStyle(.white.opacity(contrast == .increased ? 0.7 : 0.45))
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.horizontal, 6)
+    }
+  }
+
+  private var lastCheckedDescription: String {
+    guard let date = updater.lastCheckedAt else {
+      return "Talkify has not checked for updates yet."
+    }
+    return "Last checked \(date.formatted(.relative(presentation: .named)))."
+  }
+
+  private var automaticChecks: Binding<Bool> {
+    Binding(
+      get: { updater.automaticallyChecksForUpdates },
+      set: { updater.automaticallyChecksForUpdates = $0 }
+    )
+  }
+
+  private var automaticDownloads: Binding<Bool> {
+    Binding(
+      get: { updater.automaticallyDownloadsUpdates },
+      set: { updater.automaticallyDownloadsUpdates = $0 }
+    )
+  }
+
+  static var version: String {
+    let short = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+    let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+    return "\(short) (\(build))"
+  }
+}

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -18,6 +18,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case readAloud
   case language
   case shortcuts
+  case updates
   case insights
 
   var id: Self { self }
@@ -30,6 +31,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .readAloud: "Read Aloud"
     case .language: "Language"
     case .shortcuts: "Shortcuts"
+    case .updates: "Updates"
     case .insights: "Insights"
     }
   }
@@ -41,6 +43,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .readAloud: "Choose the voice that reads selected text"
     case .language: "Pick your dictation languages and their keys"
     case .shortcuts: "Rebind the Direct Dictation and Read Aloud keys"
+    case .updates: "Keep Talkify current"
     case .insights: "Review your local Direct Dictation activity"
     }
   }
@@ -52,6 +55,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .readAloud: "speaker.wave.2"
     case .language: "globe"
     case .shortcuts: "keyboard"
+    case .updates: "arrow.down.circle"
     case .insights: "chart.bar.xaxis"
     }
   }

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
   let sounds: DictationHUDSounds
   let runtimeState: SettingsRuntimeState
   let usageTracker: UsageTracker
+  let updater: SparkleUpdaterService
   let onClose: () -> Void
 
   @Environment(\.colorSchemeContrast) private var contrast
@@ -36,7 +37,8 @@ struct SettingsView: View {
             settings: settings,
             sounds: sounds,
             usageTracker: usageTracker,
-            runtimeState: runtimeState
+            runtimeState: runtimeState,
+            updater: updater
           )
           .id(selectedSection)
           .transition(.opacity)
@@ -221,6 +223,7 @@ private struct SettingsContent: View {
   let sounds: DictationHUDSounds
   let usageTracker: UsageTracker
   let runtimeState: SettingsRuntimeState
+  let updater: SparkleUpdaterService
 
   @Environment(\.colorSchemeContrast) private var contrast
 
@@ -246,6 +249,8 @@ private struct SettingsContent: View {
           LanguageSettingsView(settings: settings, runtimeState: runtimeState)
         case .shortcuts:
           ShortcutsSettingsView(settings: settings)
+        case .updates:
+          UpdatesSettingsView(updater: updater)
         case .insights:
           InsightsSettingsView(tracker: usageTracker)
         }
@@ -268,6 +273,9 @@ private struct SettingsContent: View {
       fileURL: FileManager.default.temporaryDirectory
         .appending(path: "TalkifySettingsPreview-usage.json")
     )),
+    // Never started, so the preview shows the pane's disabled state rather
+    // than reaching for the network.
+    updater: SparkleUpdaterService(),
     onClose: {}
   )
 }

--- a/Talkify/Settings/SettingsWindowController.swift
+++ b/Talkify/Settings/SettingsWindowController.swift
@@ -20,7 +20,8 @@ final class SettingsWindowController: NSWindowController {
     settings: AppSettings,
     sounds: DictationHUDSounds,
     runtimeState: SettingsRuntimeState,
-    usageTracker: UsageTracker
+    usageTracker: UsageTracker,
+    updater: SparkleUpdaterService
   ) {
     let window = TalkifySettingsWindow(
       contentRect: NSRect(origin: .zero, size: Self.windowSize),
@@ -34,6 +35,7 @@ final class SettingsWindowController: NSWindowController {
         sounds: sounds,
         runtimeState: runtimeState,
         usageTracker: usageTracker,
+        updater: updater,
         onClose: { [weak window] in window?.close() }
       )
     )

--- a/Talkify/Updates/SparkleUpdaterService.swift
+++ b/Talkify/Updates/SparkleUpdaterService.swift
@@ -1,0 +1,172 @@
+import AppKit
+import Observation
+import Sparkle
+
+/// Sparkle, wrapped so the rest of the app never imports it: Settings reads
+/// this observable and calls two methods. Updates are signed with EdDSA and
+/// checked against the appcast in the repository; Talkify ships no server, so
+/// the feed is a static file (CONTEXT.md).
+@MainActor
+@Observable
+final class SparkleUpdaterService {
+  /// False until Sparkle finishes starting, and while a check is in flight.
+  /// The Updates section disables its button on this rather than guessing.
+  private(set) var canCheckForUpdates = false
+  /// The newest version Sparkle has seen, or nil when the app is current.
+  private(set) var availableVersion: String?
+  private(set) var lastCheckedAt: Date?
+
+  @ObservationIgnored
+  private var controller: SPUStandardUpdaterController?
+  @ObservationIgnored
+  private let updaterDelegate = UpdaterDelegate()
+  @ObservationIgnored
+  private let userDriverDelegate = UserDriverDelegate()
+  @ObservationIgnored
+  private var canCheckObservation: NSKeyValueObservation?
+
+  /// Asked before a background check runs and before a scheduled update is
+  /// shown. Wired to the dictation session in the composition root: an update
+  /// window stealing focus mid-session would move the insertion target, and
+  /// the text would land in the wrong place (CONTEXT.md).
+  var isBusy: (() -> Bool)?
+
+  var automaticallyChecksForUpdates: Bool {
+    get { controller?.updater.automaticallyChecksForUpdates ?? true }
+    set { controller?.updater.automaticallyChecksForUpdates = newValue }
+  }
+
+  var automaticallyDownloadsUpdates: Bool {
+    get { controller?.updater.automaticallyDownloadsUpdates ?? false }
+    set { controller?.updater.automaticallyDownloadsUpdates = newValue }
+  }
+
+  /// Starts Sparkle. Called once at launch, after the status item exists, so
+  /// a scheduled check can never race the app's own setup.
+  func start() {
+    guard controller == nil else { return }
+
+    updaterDelegate.service = self
+    userDriverDelegate.service = self
+    controller = SPUStandardUpdaterController(
+      startingUpdater: true,
+      updaterDelegate: updaterDelegate,
+      userDriverDelegate: userDriverDelegate
+    )
+
+    guard let updater = controller?.updater else { return }
+    lastCheckedAt = updater.lastUpdateCheckDate
+    canCheckForUpdates = updater.canCheckForUpdates
+    canCheckObservation = updater.observe(\.canCheckForUpdates, options: [.new]) {
+      [weak self] updater, _ in
+      Task { @MainActor [weak self] in
+        self?.canCheckForUpdates = updater.canCheckForUpdates
+      }
+    }
+  }
+
+  /// A user-initiated check. Sparkle shows its own window, including the
+  /// "you're up to date" case, which is the feedback the user asked for by
+  /// pressing the button.
+  func checkForUpdates() {
+    controller?.checkForUpdates(nil)
+    lastCheckedAt = .now
+  }
+
+  fileprivate func foundUpdate(version: String?) {
+    availableVersion = version
+  }
+
+  /// True while dictation is running. Read from Sparkle's delegate callbacks,
+  /// which can fire on a background check at any moment.
+  fileprivate var isDictating: Bool {
+    isBusy?() ?? false
+  }
+
+  fileprivate func finishedCheck() {
+    lastCheckedAt = controller?.updater.lastUpdateCheckDate ?? .now
+  }
+}
+
+private final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
+  weak var service: SparkleUpdaterService?
+
+  enum BusyError: LocalizedError {
+    case dictating
+    var errorDescription: String? { "A dictation session is in progress." }
+  }
+
+  /// A background check is postponed while dictating; Sparkle reschedules it.
+  /// A check the user asked for always runs, because they are looking at the
+  /// button they just pressed.
+  func updater(
+    _ updater: SPUUpdater,
+    mayPerform updateCheck: SPUUpdateCheck,
+    error outError: NSErrorPointer
+  ) throws {
+    guard updateCheck == .updatesInBackground else { return }
+    let busy = MainActor.assumeIsolated { service?.isDictating ?? false }
+    if busy {
+      throw BusyError.dictating
+    }
+  }
+
+  func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+    Task { @MainActor [weak service] in
+      service?.foundUpdate(version: item.displayVersionString)
+    }
+  }
+
+  func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+    Task { @MainActor [weak service] in
+      service?.foundUpdate(version: nil)
+      service?.finishedCheck()
+    }
+  }
+
+  func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
+    Task { @MainActor [weak service] in
+      service?.finishedCheck()
+    }
+  }
+}
+
+/// Talkify is `LSUIElement`: no dock icon, accessory activation policy. Sparkle
+/// positions and focuses its windows like a regular app, so under `.accessory`
+/// the update window can open unfocused or off-screen. Becoming `.regular`
+/// while the update UI is up fixes both, and the policy reverts when the
+/// session ends so the app stays out of the Dock.
+private final class UserDriverDelegate: NSObject, SPUStandardUserDriverDelegate {
+  weak var service: SparkleUpdaterService?
+
+  var supportsGentleScheduledUpdateReminders: Bool { true }
+
+  /// A scheduled update may be shown, but never pulled into focus: taking
+  /// focus moves the insertion target, and mid-dictation that puts the text in
+  /// the wrong window. Sparkle keeps the window behind the active app and the
+  /// menu item still says an update is waiting.
+  func standardUserDriverShouldHandleShowingScheduledUpdate(
+    _ update: SUAppcastItem,
+    andInImmediateFocus immediateFocus: Bool
+  ) -> Bool {
+    !immediateFocus
+  }
+
+  /// Only a check the user asked for gets the regular activation policy. Under
+  /// `LSUIElement` Sparkle's window opens unfocused or off-screen, so it needs
+  /// the switch to place and focus itself; the policy reverts when the session
+  /// ends, keeping Talkify out of the Dock.
+  func standardUserDriverWillHandleShowingUpdate(
+    _ handleShowingUpdate: Bool,
+    forUpdate update: SUAppcastItem,
+    state: SPUUserUpdateState
+  ) {
+    guard state.userInitiated else { return }
+    NSApp.setActivationPolicy(.regular)
+    NSApp.activate(ignoringOtherApps: true)
+  }
+
+  func standardUserDriverWillFinishUpdateSession() {
+    NSApp.setActivationPolicy(.accessory)
+  }
+}

--- a/Talkify/Updates/SparkleUpdaterService.swift
+++ b/Talkify/Updates/SparkleUpdaterService.swift
@@ -156,17 +156,25 @@ private final class UserDriverDelegate: NSObject, SPUStandardUserDriverDelegate 
   /// `LSUIElement` Sparkle's window opens unfocused or off-screen, so it needs
   /// the switch to place and focus itself; the policy reverts when the session
   /// ends, keeping Talkify out of the Dock.
+  /// Sparkle drives its user driver on the main thread but its protocol is not
+  /// annotated for it, so the isolation is asserted rather than assumed
+  /// silently — the alternative is hopping to the main actor and changing the
+  /// policy after the window has already been placed.
   func standardUserDriverWillHandleShowingUpdate(
     _ handleShowingUpdate: Bool,
     forUpdate update: SUAppcastItem,
     state: SPUUserUpdateState
   ) {
     guard state.userInitiated else { return }
-    NSApp.setActivationPolicy(.regular)
-    NSApp.activate(ignoringOtherApps: true)
+    MainActor.assumeIsolated {
+      NSApp.setActivationPolicy(.regular)
+      NSApp.activate(ignoringOtherApps: true)
+    }
   }
 
   func standardUserDriverWillFinishUpdateSession() {
-    NSApp.setActivationPolicy(.accessory)
+    MainActor.assumeIsolated {
+      _ = NSApp.setActivationPolicy(.accessory)
+    }
   }
 }

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -13,7 +13,8 @@ struct SettingsWindowTests {
       usageTracker: UsageTracker(store: UsageStore(
         fileURL: FileManager.default.temporaryDirectory
           .appending(path: "TalkifySettingsWindowTests-" + UUID().uuidString + ".json")
-      ))
+      )),
+      updater: SparkleUpdaterService()
     )
     let window = try #require(controller.window)
     #expect(window.title == "Talkify Settings")
@@ -27,8 +28,11 @@ struct SettingsWindowTests {
   }
 
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
-    #expect(SettingsSection.allCases == [.appearance, .sounds, .readAloud, .language, .shortcuts, .insights])
-    #expect(SettingsSectionGroup.settings.sections == [.appearance, .sounds, .readAloud, .language, .shortcuts, .insights])
+    let expected: [SettingsSection] = [
+      .appearance, .sounds, .readAloud, .language, .shortcuts, .updates, .insights,
+    ]
+    #expect(SettingsSection.allCases == expected)
+    #expect(SettingsSectionGroup.settings.sections == expected)
   }
 
   @Test func appearanceOptionsFollowTheSelectedVisual() {

--- a/TalkifyTests/UpdatesTests.swift
+++ b/TalkifyTests/UpdatesTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import Talkify
+
+@MainActor
+struct UpdatesTests {
+  /// The updater is inert until `start()`, which the composition root calls
+  /// last. A preview or a test must never reach the network by constructing it.
+  @Test func anUnstartedUpdaterCannotCheck() {
+    let updater = SparkleUpdaterService()
+    #expect(!updater.canCheckForUpdates)
+    #expect(updater.availableVersion == nil)
+    #expect(updater.lastCheckedAt == nil)
+  }
+
+  @Test func theUpdatesSectionIsRegistered() {
+    #expect(SettingsSection.allCases.contains(.updates))
+    #expect(SettingsSection.updates.title == "Updates")
+    #expect(!SettingsSection.updates.icon.isEmpty)
+  }
+
+  /// Sparkle is the one third-party dependency and it stays behind
+  /// `Talkify/Updates/` (CLAUDE.md). This fails the moment another file imports
+  /// it, which is the point: the rule is only real if something checks.
+  @Test func onlyTheUpdatesModuleImportsSparkle() throws {
+    let root = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appending(path: "Talkify")
+
+    let files = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil)?
+      .compactMap { $0 as? URL }
+      .filter { $0.pathExtension == "swift" } ?? []
+    #expect(!files.isEmpty, "no Swift sources found under \(root.path)")
+
+    let importers = try files
+      .filter { url in
+        try String(contentsOf: url, encoding: .utf8)
+          .split(separator: "\n")
+          .contains { $0.trimmingCharacters(in: .whitespaces) == "import Sparkle" }
+      }
+      .map { $0.lastPathComponent }
+      .sorted()
+
+    #expect(importers == ["SparkleUpdaterService.swift"])
+  }
+
+  /// The feed Sparkle polls has to parse and name the app, even before the
+  /// first release adds an item: a missing or broken file reports a failed
+  /// check instead of "you're up to date".
+  @Test func theCommittedAppcastParses() throws {
+    let appcast = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appending(path: "appcast.xml")
+
+    let xml = try String(contentsOf: appcast, encoding: .utf8)
+    #expect(xml.contains("<title>Talkify</title>"))
+    #expect(try XMLDocument(contentsOf: appcast, options: []).rootElement()?.name == "rss")
+  }
+}

--- a/TalkifyTests/UpdatesTests.swift
+++ b/TalkifyTests/UpdatesTests.swift
@@ -13,6 +13,28 @@ struct UpdatesTests {
     #expect(updater.lastCheckedAt == nil)
   }
 
+  /// Starting the real updater against the real app bundle. This is the check
+  /// that catches a broken configuration: Sparkle refuses to run when
+  /// `SUPublicEDKey` is missing or malformed, or when `SUFeedURL` is absent, and
+  /// `canCheckForUpdates` stays false. Nothing here contacts the network — the
+  /// assertion is about Sparkle accepting the bundle, not about the feed.
+  @Test func sparkleAcceptsTheShippedConfiguration() async throws {
+    let bundle = Bundle.main
+    let key = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+    let feed = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String
+    #expect(key?.isEmpty == false, "SUPublicEDKey is missing from the built bundle")
+    #expect(feed?.hasPrefix("https://") == true, "SUFeedURL is missing or not https")
+    // An EdDSA public key is 32 bytes, base64-encoded.
+    #expect(Data(base64Encoded: key ?? "")?.count == 32)
+
+    let updater = SparkleUpdaterService()
+    updater.start()
+    // Never check on a schedule from a test run.
+    updater.automaticallyChecksForUpdates = false
+
+    #expect(updater.canCheckForUpdates, "Sparkle started but refuses to check — bad configuration")
+  }
+
   @Test func theUpdatesSectionIsRegistered() {
     #expect(SettingsSection.allCases.contains(.updates))
     #expect(SettingsSection.updates.title == "Updates")

--- a/appcast.xml
+++ b/appcast.xml
@@ -9,9 +9,10 @@
           scripts/release.sh regenerates this file with generate_appcast and
           commits it as part of a release, so it is not edited by hand.
 
-          It starts with no items on purpose: an empty channel makes a check
-          report "you're up to date", while a missing file makes it report a
-          failure. The first release replaces this with a signed entry.
+          Before the first release the channel is empty on purpose: an empty
+          channel makes a check report "you're up to date", while a missing file
+          makes it report a failure. Each release appends a signed <item> below
+          and keeps the five most recent.
         -->
     </channel>
 </rss>

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <title>Talkify</title>
+        <!--
+          Sparkle's update feed, served from main at
+          https://raw.githubusercontent.com/tornikegomareli/Talkify/main/appcast.xml
+
+          scripts/release.sh regenerates this file with generate_appcast and
+          commits it as part of a release, so it is not edited by hand.
+
+          It starts with no items on purpose: an empty channel makes a check
+          report "you're up to date", while a missing file makes it report a
+          failure. The first release replaces this with a signed entry.
+        -->
+    </channel>
+</rss>

--- a/docs/ProjectSettings.md
+++ b/docs/ProjectSettings.md
@@ -17,6 +17,19 @@ Values from the old `Project.swift`, needed when scaffolding the new plain `Talk
 - `NSPrincipalClass` = `NSApplication`
 - `NSHighResolutionCapable` is not set: it is default-true for apps linked against modern SDKs, and Xcode's generated Info.plist has no `INFOPLIST_KEY_` for it
 
+### Sparkle keys (Talkify/Info.plist)
+
+The app target keeps `GENERATE_INFOPLIST_FILE = YES` **and** sets
+`INFOPLIST_FILE = Talkify/Info.plist`; Xcode merges the generated keys into that
+file. The plist exists only because Sparkle reads `SUPublicEDKey` from the bundle
+and Xcode's `INFOPLIST_KEY_<name>` passthrough silently drops keys it does not
+recognise — the Sparkle keys never reached the bundle that way.
+
+- `SUFeedURL` = `https://raw.githubusercontent.com/tornikegomareli/Talkify/main/appcast.xml`
+- `SUPublicEDKey` = public half of the EdDSA signing key; the private half is in the login Keychain, shared with Camus (Sparkle intends one key per developer)
+- `SUEnableAutomaticChecks` = true, `SUScheduledCheckInterval` = 86400 (daily)
+- `SUAllowsAutomaticUpdates` = true (automatic *downloading* still defaults off)
+
 ## Entitlements (Talkify.entitlements)
 
 ```xml

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,6 +38,10 @@ ARCHIVE="$BUILD_DIR/Talkify.xcarchive"
 EXPORT_DIR="$BUILD_DIR/export"
 STAGE_DIR="$BUILD_DIR/dmg"
 DMG="$BUILD_DIR/Talkify.dmg"
+# Sparkle needs its own directory holding only the update ZIP.
+SPARKLE_DIR="$BUILD_DIR/sparkle"
+SPARKLE_ZIP="$SPARKLE_DIR/Talkify-$TAG.zip"
+APPCAST="$REPO_ROOT/appcast.xml"
 CASK="$REPO_ROOT/Casks/talkify.rb"
 TEAM_ID="539293JFA3"
 NOTARY_PROFILE="${NOTARY_PROFILE:-camus-notary}"
@@ -183,6 +187,50 @@ SHA="$(shasum -a 256 "$DMG" | cut -d' ' -f1)"
 echo "  $DMG ($(du -h "$DMG" | cut -f1))"
 echo "  sha256 $SHA"
 
+# ----------------------------------------------------------------- sparkle
+
+# Sparkle updates from a ZIP, not the DMG: it is what BinaryDelta and
+# generate_appcast expect, and it unpacks without mounting anything.
+#
+# Notarizing the DMG notarizes the app inside it, so the app can be stapled
+# directly from Apple's records — no second submission and no extra wait. A
+# stapled app validates with no network, which matters on a laptop that wakes
+# up, updates, and relaunches before Wi-Fi is back.
+step "Packaging the Sparkle update"
+if [[ "${SKIP_NOTARIZE:-0}" != "1" ]]; then
+  xcrun stapler staple "$APP" && echo "  app stapled"
+fi
+
+rm -rf "$SPARKLE_DIR"
+mkdir -p "$SPARKLE_DIR"
+# ditto keeps the bundle's symlinks and resource forks intact; `zip` does not,
+# and a mangled bundle fails its signature check after the update lands.
+ditto -c -k --sequesterRsrc --keepParent "$APP" "$SPARKLE_ZIP"
+echo "  $(basename "$SPARKLE_ZIP") ($(du -h "$SPARKLE_ZIP" | cut -f1))"
+
+SPARKLE_BIN="$(find "$HOME/Library/Developer/Xcode/DerivedData"/Talkify-*/SourcePackages/artifacts/sparkle/Sparkle/bin \
+  -name generate_appcast 2>/dev/null | head -1)"
+[[ -n "$SPARKLE_BIN" ]] || fail "Sparkle's tools are missing. Build once in Xcode to fetch them."
+SPARKLE_BIN="$(dirname "$SPARKLE_BIN")"
+
+# The private key lives in the login Keychain (see scripts/setup-sparkle-keys.sh),
+# so the tools find it without a key file on disk. The Keychain WILL prompt for
+# access the first time and blocks until it is answered — choose Always Allow so
+# later releases run unattended. This step cannot be run headlessly until then.
+# Only the ZIP is in SPARKLE_DIR: generate_appcast refuses two archives that
+# report the same bundle version, which the DMG would.
+"$SPARKLE_BIN/generate_appcast" \
+  --download-url-prefix "https://github.com/tornikegomareli/Talkify/releases/download/$TAG/" \
+  --link "https://usetalkify.app" \
+  --full-release-notes-url "https://github.com/tornikegomareli/Talkify/releases" \
+  --maximum-versions 5 \
+  -o "$APPCAST" \
+  "$SPARKLE_DIR"
+
+[[ -s "$APPCAST" ]] || fail "generate_appcast produced no appcast"
+grep -q "sparkle:edSignature" "$APPCAST" || fail "the appcast has no EdDSA signature"
+echo "  appcast written, signature present"
+
 # -------------------------------------------------------------------- cask
 
 step "Updating the Homebrew cask"
@@ -196,6 +244,8 @@ grep -E "^  (version|sha256)" "$CASK" | sed 's/^/  /'
 if $DRY_RUN; then
   step "Dry run — nothing published"
   echo "  DMG:  $DMG"
+  echo "  ZIP:  $SPARKLE_ZIP"
+  echo "  appcast: $APPCAST (uncommitted)"
   echo "  cask updated locally; revert with: git checkout -- Casks/talkify.rb"
   exit 0
 fi
@@ -205,7 +255,7 @@ fi
 step "Committing and tagging"
 # Stage each path that exists: a single git add with one missing pathspec
 # fails wholesale and would silently stage nothing.
-for path in Casks/talkify.rb Talkify.xcodeproj/project.pbxproj Talkify/Info.plist; do
+for path in Casks/talkify.rb Talkify.xcodeproj/project.pbxproj Talkify/Info.plist appcast.xml; do
   [[ -e "$path" ]] && git add "$path"
 done
 if git diff --cached --quiet; then
@@ -241,10 +291,31 @@ PREV_TAG="$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
   fi
 } > "$NOTES_FILE"
 
-gh release create "$TAG" "$DMG" \
+# The ZIP ships alongside the DMG because the appcast's enclosure URL points
+# at it. Without it every existing install would poll a 404 forever.
+gh release create "$TAG" "$DMG" "$SPARKLE_ZIP" \
   --title "Talkify $VERSION" \
   --notes-file "$NOTES_FILE"
+
+# The feed is only live once the appcast on main names a release that exists,
+# so check the URL Sparkle will actually poll rather than assuming.
+step "Verifying the update feed"
+FEED="https://raw.githubusercontent.com/tornikegomareli/Talkify/main/appcast.xml"
+if curl -fsS "$FEED" | grep -q "$TAG"; then
+  echo "  $FEED serves $TAG"
+else
+  echo "  WARNING: $FEED does not mention $TAG yet."
+  echo "  raw.githubusercontent.com caches for a few minutes; re-check before"
+  echo "  announcing, and confirm appcast.xml was pushed to main."
+fi
+ENCLOSURE="$(grep -o 'url="[^"]*\.zip"' "$APPCAST" | head -1 | cut -d'"' -f2)"
+if [[ -n "$ENCLOSURE" ]] && curl -fsSI "$ENCLOSURE" >/dev/null 2>&1; then
+  echo "  enclosure reachable"
+else
+  echo "  WARNING: the appcast enclosure is not reachable: $ENCLOSURE"
+fi
 
 step "Done"
 echo "  release:  $(gh release view "$TAG" --json url -q .url)"
 echo "  download: https://github.com/tornikegomareli/Talkify/releases/latest/download/Talkify.dmg"
+echo "  feed:     $FEED"

--- a/scripts/setup-sparkle-keys.sh
+++ b/scripts/setup-sparkle-keys.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Prints the Sparkle EdDSA public key this Mac signs updates with, generating
+# the key pair on first run.
+#
+#   scripts/setup-sparkle-keys.sh          # show the public key
+#   scripts/setup-sparkle-keys.sh --export # write the private key to a file
+#
+# Sparkle keeps the private key in the login Keychain, associated with your user
+# account, and one key covers every app you ship — Talkify deliberately reuses
+# the key that is already there rather than minting a second one. The public
+# half belongs in Talkify/Info.plist under SUPublicEDKey and is safe to commit.
+#
+# Losing the private key means existing installs can never update again: they
+# only trust updates signed by the key their copy was built with. Export it once
+# and keep it somewhere you will still have in a year.
+
+set -euo pipefail
+
+fail() { echo "error: $*" >&2; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLIST="$REPO_ROOT/Talkify/Info.plist"
+
+TOOLS="$(find "$HOME/Library/Developer/Xcode/DerivedData"/Talkify-*/SourcePackages/artifacts/sparkle/Sparkle/bin \
+  -name generate_keys 2>/dev/null | head -1)"
+[[ -n "$TOOLS" ]] || fail "Sparkle's tools are missing. Build Talkify once so Xcode fetches the package."
+
+if [[ "${1:-}" == "--export" ]]; then
+  OUT="$HOME/talkify-sparkle-private-key.txt"
+  [[ -e "$OUT" ]] && fail "$OUT already exists; move it aside first"
+  "$TOOLS" -x "$OUT"
+  chmod 600 "$OUT"
+  echo "Private key written to $OUT"
+  echo "Store it in your password manager, then delete the file."
+  exit 0
+fi
+
+# -p prints the public key and never overwrites an existing private key. The
+# Keychain may prompt for access the first time.
+PUBLIC_KEY="$("$TOOLS" -p 2>/dev/null || true)"
+
+if [[ -z "$PUBLIC_KEY" ]]; then
+  echo "No signing key found. Generating one in the login Keychain…"
+  "$TOOLS"
+  PUBLIC_KEY="$("$TOOLS" -p)"
+fi
+
+echo "Public key: $PUBLIC_KEY"
+
+IN_PLIST="$(/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "$PLIST" 2>/dev/null || true)"
+if [[ "$IN_PLIST" == "$PUBLIC_KEY" ]]; then
+  echo "Talkify/Info.plist already carries this key."
+else
+  echo
+  echo "Talkify/Info.plist has: ${IN_PLIST:-<nothing>}"
+  echo "Update it so the two match, or updates will fail verification:"
+  echo "  /usr/libexec/PlistBuddy -c \"Set :SUPublicEDKey $PUBLIC_KEY\" \"$PLIST\""
+  exit 1
+fi


### PR DESCRIPTION
Talkify had no updater, so every install stayed on whatever version it was downloaded with. Sparkle is the standard answer on macOS and needs no infrastructure: the appcast is a static file in this repo, served from `main`.

Modelled on the Camus setup, with the parts that differ noted below.

## The dependency

Sparkle is the **first third-party dependency** in this project. `CLAUDE.md` and `CONTEXT.md` both said "no third-party dependencies", so both now say what is true: exactly one, confined to `Talkify/Updates/`, and adding a second is a decision to raise rather than make.

`UpdatesTests.onlyTheUpdatesModuleImportsSparkle` walks every Swift file under `Talkify/` and asserts `import Sparkle` appears in one. A rule nothing checks is a comment.

Pinned at 2.9.5 via `Package.resolved`, which is committed.

## The menu-bar specifics

These are the reason this isn't boilerplate. Talkify is `LSUIElement`.

**Window placement.** Sparkle positions and focuses its windows like a regular app. Under the accessory policy they open unfocused or off-screen. The policy becomes `.regular` for a user-initiated update and reverts in `standardUserDriverWillFinishUpdateSession`, so Talkify never gains a Dock icon.

**Never interrupt dictation.** A background check is postponed while a session is running, through `updater(_:mayPerform:error:)`. An update window taking focus mid-session would move the insertion target and the text would land in the wrong window. A check the user pressed the button for always runs, because they are looking at the button. A scheduled update is shown but never pulled into focus.

Sparkle drives its user driver on the main thread but does not annotate the protocol for it, so those two methods assert isolation with `MainActor.assumeIsolated` rather than hopping — hopping would change the activation policy after the window was already placed.

## Info.plist

The project generated its Info.plist entirely from build settings. Sparkle reads `SUPublicEDKey` from the bundle, and Xcode's `INFOPLIST_KEY_<name>` passthrough **silently drops keys it does not recognise** — I confirmed by inspecting the built app that `SUFeedURL` and `SUPublicEDKey` never arrived. That would have shipped a non-functioning updater.

So `Talkify/Info.plist` now exists with the Sparkle keys only. `GENERATE_INFOPLIST_FILE` stays on and Xcode merges the generated keys into it, verified in Debug and Release. Because the target uses a synchronized folder group, the plist is explicitly excluded from that target's Copy Bundle Resources phase, or it ships as a duplicate inside `Resources/`.

## Signing

The private EdDSA key is in the login Keychain, not a file on disk, so `sign_update` and `generate_appcast` find it without `--ed-key-file`. It is the key already there, which Sparkle intends (one key per developer, however many apps). `scripts/setup-sparkle-keys.sh` prints the public key, generates one if absent, checks it matches the plist, and can export the private half for backup. The export path is gitignored.

## Release pipeline

`scripts/release.sh` gains an update step after notarization:

- Notarizing the DMG also notarizes the app inside it, so the app is **stapled from Apple's records** rather than submitted a second time. No extra wait, and a stapled app validates with no network.
- Zipped with `ditto -c -k --sequesterRsrc --keepParent`; plain `zip` mangles bundle symlinks and the signature fails after the update lands.
- `generate_appcast` runs against a directory holding only the ZIP, since it rejects two archives reporting the same bundle version.
- The ZIP is attached to the release because the appcast's enclosure points at it. Without it every install would poll a 404.
- Afterwards the script fetches the feed URL and HEADs the enclosure, and warns rather than assuming.

`appcast.xml` ships with an empty channel: a missing feed makes a check report failure, an empty one reports that the app is current. Each release appends a signed item and keeps the five most recent.

## Verification

**A full `--dry-run` release was run on this branch** (`SKIP_NOTARIZE=1`). It archived Release, packaged and signed the DMG, stapled nothing (notarization skipped), zipped the app, and **generated a signed appcast** — `Wrote 1 new update`, with a real `sparkle:edSignature`, `minimumSystemVersion 26.0` and `hardwareRequirements arm64` picked up from the bundle automatically. The Keychain granted access without blocking. That closes the signing gap.

Also verified: Sparkle resolves and is the only framework in the Release bundle; the plist merge lands all five `SU*` keys in both configurations; the update ZIP round-trips through `ditto` with `codesign --verify --deep --strict` passing.

70 tests pass. Five are new, including `sparkleAcceptsTheShippedConfiguration`, which starts the real updater against the real app bundle and asserts it is willing to check — Sparkle refuses to run on a malformed `SUPublicEDKey`, so that is evidence the shipped configuration is sound, not just that it compiles.

**Still unverified, and it needs a merge to become testable:** an actual update — download, signature check, install, relaunch. The feed 404s until this lands on `main`, and proving it end to end needs two published releases: an older one to run and a newer one to find. The activation-policy switch and the mid-dictation postponement are reasoned from Sparkle's headers and the Camus precedent; neither has been watched happening.

One dry-run artifact worth knowing: the generated item said version `0.1.0` while the enclosure URL said `v0.2.1`, because a dry run deliberately skips the version bump. A real release bumps first, so the two agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic update checks with secure signature verification.
  * Added an Updates section in Settings with manual checks, download preferences, version details, and update status.
  * Added a status-menu option to check for updates.
  * Updates defer downloads and avoid interrupting active dictation sessions.

* **Documentation**
  * Documented update settings, configuration, and release packaging procedures.

* **Chores**
  * Added release tooling for signed update packages and appcast generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->