### PR TITLE
Fix Bluetooth dictation startup

### DIFF
--- a/Talkify/Dictation/SpeechRecognitionService.swift
+++ b/Talkify/Dictation/SpeechRecognitionService.swift
@@ -243,9 +243,13 @@ actor SpeechRecognitionService {
     )
 
     do {
-      try await prepared.analyzer.start(inputSequence: stream)
-      try Task.checkCancellation()
+      // Start capturing before SpeechAnalyzer finishes attaching to the
+      // stream. Bluetooth inputs can take hundreds of milliseconds to become
+      // ready, and the stream keeps those early buffers until the analyzer
+      // starts consuming them.
       try input.start(outputFormat: prepared.audioFormat)
+      try Task.checkCancellation()
+      try await prepared.analyzer.start(inputSequence: stream)
       try Task.checkCancellation()
     } catch {
       activeSession = nil

--- a/Talkify/HUD/DictationHUDController.swift
+++ b/Talkify/HUD/DictationHUDController.swift
@@ -35,6 +35,7 @@ final class DictationHUDController {
   private var orderOutTask: Task<Void, Never>?
   private var lastLevelAt = ContinuousClock.now
   private var micWatchdogTask: Task<Void, Never>?
+  private var hasPlayedBeginSound = false
 
   init(settings: AppSettings) {
     let initialSettings = settings.sessionSettings
@@ -71,6 +72,10 @@ final class DictationHUDController {
   /// and marks the microphone alive for the dead-mic watchdog.
   func showAudioLevel(_ level: Float) {
     guard content.showsVoiceVisual else { return }
+    if !hasPlayedBeginSound {
+      hasPlayedBeginSound = true
+      sounds.playBegin(using: sessionSettings.soundSet)
+    }
     content.audioLevel = max(Double(level), content.audioLevel * 0.88)
     content.levelHistory.removeFirst()
     // Light EMA against the previous bar calms per-tick jitter without
@@ -109,13 +114,13 @@ final class DictationHUDController {
     guard let screen = selectScreen(targetDisplayID: displayID) else { return }
     sessionSettings = settings
     renderedSettings = settings
+    hasPlayedBeginSound = false
     content.languageTag = languageTag
     cancelMessageDismiss()
     mode = .session
     startVoiceVisual()
     sessionIsLatched = isLatched
     present(isLatched ? Self.latchedText : Self.listeningText, on: screen)
-    sounds.playBegin(using: settings.soundSet)
   }
 
   func showLatched() {


### PR DESCRIPTION
Fixes #26

Starts microphone capture earlier and plays the start sound after Bluetooth audio is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation startup reliability by beginning microphone capture before speech analysis.
  * Added safeguards to prevent startup actions from continuing after cancellation.
  * Ensured the listening sound plays only once per dictation session, when audio input is first detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->