### PR TITLE
Let the user mute and level the dictation sounds

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,7 +109,7 @@ _Avoid_: Transcript history, cloud analytics
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation
 - Settings changes update the Appearance preview immediately, while an active Direct Dictation session keeps the choices captured at session start
-- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, and sound set
+- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, and sound volume
 - A third voice visual, Compact, shows a small five-bar voice indicator beside the leading-aligned live draft inside the shape, after the iOS Dynamic Island caption look; the shape grows with the draft
 - Compact is the only visual that shows the live draft while listening; Waveform and Edge Glow replace the draft text entirely
 - An In the Shape live-draft placement for Waveform and Edge Glow was prototyped and removed; the draft-in-shape presentation belongs to Compact alone
@@ -148,7 +148,7 @@ _Avoid_: Transcript history, cloud analytics
 - Settings section changes use a short crossfade or no transition, and Reduce Motion removes the transition
 - The Settings sidebar stays fixed while the selected section's content pane scrolls
 - Appearance controls are conditional: Waveform settings belong to Waveform, and Glow settings belong to Edge Glow; hidden values remain persisted
-- Sounds Preview plays the selected Begin and End pair; the Paste sound remains an internal insertion event
+- Sounds Preview plays the selected Begin and End pair at the chosen volume; the Paste sound remains an internal insertion event
 - Settings preserves its selected section and window frame while the app runs, and opens on Appearance after a fresh launch
 - The voice-reactive visual must make silence and a dead microphone look different
 - With Reduce Motion enabled, the HUD replaces the animated visual with a quiet level meter and skips expand/collapse animation
@@ -186,7 +186,7 @@ _Avoid_: Transcript history, cloud analytics
 - **Insights** never stores recognized text or target application identifiers
 - A completed **Direct Dictation** session with nonempty inserted text updates **Insights**
 - **Insights** shows words, sessions, speaking time, weighted words per minute, Voice Momentum, 14-day activity, streaks, and a 16-week heatmap
-- Settings lets the user choose the session sounds, the voice-reactive visual, the waveform style, and the edge glow's color palette
+- Settings lets the user choose the session sounds, mute them, adjust their volume, choose the voice-reactive visual, the waveform style, and the edge glow's color palette
 - Insertion latency must be benchmarked before choosing permanent per-application defaults
 - Mid-session insertion was prototyped (streamed finalized chunks; a ghost overlay over the focused input) and rejected: insertion stays at session end, and no live-draft direction for Waveform and Edge Glow is chosen yet
 - A marked-text input method (system-dictation-style provisional text in any field) remains a considered route, deferred: it needs a separate installable input-source bundle, System Settings enablement, and cross-process wiring
@@ -247,7 +247,7 @@ _Avoid_: Transcript history, cloud analytics
 - The custom Settings surface is a borderless AppKit window hosting SwiftUI, not a sheet attached to the status menu
 - Settings labels use the domain term Direct Dictation where scope matters and avoid Voice typing or Transcription
 - DirectDictationController creates Dictation session settings at session start and passes them to DictationHUDController
-- Direct Dictation uses the captured sound set for Begin, End, and Paste; Settings Preview reads the live AppSettings sound set only
+- Direct Dictation uses the captured sound set, enabled state, and volume for Begin, End, and Paste; Settings Preview reads the live AppSettings sound preferences
 - The session snapshot is captured after target and permission guards pass, immediately before the HUD begins listening
 - The borderless Settings header shows the close control on the leading edge (matching native macOS window controls) and centers the Talkify identity: the ghost icon and the app name
 - The sidebar retains the `SETTINGS` group label even when the header also shows Settings; it distinguishes navigation groups
@@ -261,8 +261,8 @@ _Avoid_: Transcript history, cloud analytics
 - The active-session notice text is: “Changes apply to the next Direct Dictation session.”
 - Sounds Preview disables itself while the Begin/End pair plays so repeated clicks cannot overlap playback
 - Sounds Preview waits for the selected Begin sound's actual duration before playing End
-- Changing the sound set stops an active preview before the next selection can play
-- Direct Dictation and Sounds Preview use the existing fixed playback level; Settings has no volume preference
+- Changing any sound preference stops an active preview before the next selection can play
+- Direct Dictation and Sounds Preview use the selected volume; Settings can mute all Direct Dictation sounds
 - The Appearance preview simulates a small bounded microphone-level loop and holds a quiet frame under Reduce Motion
 - The Appearance preview always uses fixed notched MacBook reference geometry; the active HUD still adapts to its display
 - The Appearance preview shows the picked **HUD size** directly, because the size applies on every display including the preview's notched reference

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -13,6 +13,8 @@ import Observation
 final class AppSettings {
   private enum Keys {
     static let soundSet = "dictationSoundSet"
+    static let soundsEnabled = "dictationSoundsEnabled"
+    static let soundVolume = "dictationSoundVolume"
     static let voiceVisual = "hudVoiceVisual"
     static let waveformStyle = "hudWaveformStyle"
     static let revealStyle = "hudRevealStyle"
@@ -33,6 +35,20 @@ final class AppSettings {
 
   var soundSet: DictationSoundSet {
     didSet { defaults.set(soundSet.rawValue, forKey: Keys.soundSet) }
+  }
+
+  var dictationSoundsEnabled: Bool {
+    didSet { defaults.set(dictationSoundsEnabled, forKey: Keys.soundsEnabled) }
+  }
+
+  private var storedDictationSoundVolume: Double
+
+  var dictationSoundVolume: Double {
+    get { storedDictationSoundVolume }
+    set {
+      storedDictationSoundVolume = DictationSoundSettings.normalizedVolume(newValue)
+      defaults.set(storedDictationSoundVolume, forKey: Keys.soundVolume)
+    }
   }
 
   var voiceVisual: HUDVoiceVisualStyle {
@@ -124,6 +140,9 @@ final class AppSettings {
   init(defaults: UserDefaults = .standard) {
     self.defaults = defaults
     soundSet = Self.stored(in: defaults, key: Keys.soundSet) ?? .synth8
+    dictationSoundsEnabled = defaults.object(forKey: Keys.soundsEnabled) as? Bool ?? true
+    let storedSoundVolume = defaults.object(forKey: Keys.soundVolume) as? Double ?? 0.5
+    storedDictationSoundVolume = DictationSoundSettings.normalizedVolume(storedSoundVolume)
     voiceVisual = Self.stored(in: defaults, key: Keys.voiceVisual) ?? .waveform
     waveformStyle = Self.stored(in: defaults, key: Keys.waveformStyle) ?? .chartLine
     revealStyle = Self.stored(in: defaults, key: Keys.revealStyle) ?? .slide
@@ -170,7 +189,7 @@ final class AppSettings {
 /// The preferences captured when Direct Dictation starts. A session keeps
 /// this value until its end and paste sounds have played.
 struct DictationSessionSettings: Equatable {
-  let soundSet: DictationSoundSet
+  let sounds: DictationSoundSettings
   let voiceVisual: HUDVoiceVisualStyle
   let waveformStyle: HUDWaveformStyle
   let revealStyle: HUDRevealStyle
@@ -181,7 +200,11 @@ struct DictationSessionSettings: Equatable {
 
   @MainActor
   init(settings: AppSettings) {
-    soundSet = settings.soundSet
+    sounds = DictationSoundSettings(
+      set: settings.soundSet,
+      isEnabled: settings.dictationSoundsEnabled,
+      volume: settings.dictationSoundVolume
+    )
     voiceVisual = settings.voiceVisual
     waveformStyle = settings.waveformStyle
     revealStyle = settings.revealStyle

--- a/Talkify/HUD/DictationHUDController.swift
+++ b/Talkify/HUD/DictationHUDController.swift
@@ -74,7 +74,7 @@ final class DictationHUDController {
     guard content.showsVoiceVisual else { return }
     if !hasPlayedBeginSound {
       hasPlayedBeginSound = true
-      sounds.playBegin(using: sessionSettings.soundSet)
+      sounds.playBegin(using: sessionSettings.sounds)
     }
     content.audioLevel = max(Double(level), content.audioLevel * 0.88)
     content.levelHistory.removeFirst()
@@ -89,7 +89,7 @@ final class DictationHUDController {
   /// Played when finalized text lands in the target, after a finished
   /// session's insertion.
   func playPasteSound() {
-    sounds.playPaste(using: sessionSettings.soundSet)
+    sounds.playPaste(using: sessionSettings.sounds)
   }
 
   func showMessage(_ text: String) {
@@ -151,7 +151,7 @@ final class DictationHUDController {
     cancelMessageDismiss()
     stopVoiceVisual()
     if case .session = mode {
-      sounds.playEnd(using: sessionSettings.soundSet)
+      sounds.playEnd(using: sessionSettings.sounds)
     }
     mode = .hidden
     content.isRevealed = false

--- a/Talkify/HUD/DictationHUDSounds.swift
+++ b/Talkify/HUD/DictationHUDSounds.swift
@@ -38,10 +38,28 @@ enum DictationSoundSet: String, CaseIterable {
   }
 }
 
+struct DictationSoundSettings: Equatable {
+  static let volumeRange = 0.0...1.0
+
+  let set: DictationSoundSet
+  let isEnabled: Bool
+  let volume: Double
+
+  init(set: DictationSoundSet, isEnabled: Bool, volume: Double) {
+    self.set = set
+    self.isEnabled = isEnabled
+    self.volume = Self.normalizedVolume(volume)
+  }
+
+  static func normalizedVolume(_ volume: Double) -> Double {
+    min(max(volume, volumeRange.lowerBound), volumeRange.upperBound)
+  }
+}
+
 /// The sounds that bracket a Direct Dictation session: begin when listening
 /// starts, end when the session closes, paste when text lands in the target.
-/// Callers supply the captured or live set. Assets reload lazily when that
-/// set changes.
+/// Callers supply captured or live sound settings. Assets reload lazily when
+/// the selected set changes.
 @MainActor
 final class DictationHUDSounds {
   private var loadedSet: DictationSoundSet?
@@ -49,16 +67,16 @@ final class DictationHUDSounds {
   private var end: NSSound?
   private var paste: NSSound?
 
-  func playBegin(using set: DictationSoundSet) {
-    play(\.begin, using: set)
+  func playBegin(using settings: DictationSoundSettings) {
+    play(\.begin, using: settings)
   }
 
-  func playEnd(using set: DictationSoundSet) {
-    play(\.end, using: set)
+  func playEnd(using settings: DictationSoundSettings) {
+    play(\.end, using: settings)
   }
 
-  func playPaste(using set: DictationSoundSet) {
-    play(\.paste, using: set)
+  func playPaste(using settings: DictationSoundSettings) {
+    play(\.paste, using: settings)
   }
 
   func beginDuration(for set: DictationSoundSet) -> TimeInterval {
@@ -79,12 +97,13 @@ final class DictationHUDSounds {
 
   private func play(
     _ sound: KeyPath<DictationHUDSounds, NSSound?>,
-    using set: DictationSoundSet
+    using settings: DictationSoundSettings
   ) {
-    loadIfNeeded(set)
+    guard settings.isEnabled else { return }
+    loadIfNeeded(settings.set)
     guard let sound = self[keyPath: sound] else { return }
     sound.stop()
-    sound.volume = 0.5
+    sound.volume = Float(settings.volume)
     sound.play()
   }
 

--- a/Talkify/Settings/Components/SettingsRow.swift
+++ b/Talkify/Settings/Components/SettingsRow.swift
@@ -46,12 +46,27 @@ struct SettingsSliderRow: View {
   let valueLabel: (Double) -> String
   var controlWidth: CGFloat = 150
 
+  /// A stepping `Slider` draws tick marks under the track. The snap happens
+  /// here instead so the slider stays continuous and the track stays clean.
+  private var steppedValue: Binding<Double> {
+    Binding(
+      get: { value },
+      set: { newValue in
+        let steps = ((newValue - range.lowerBound) / step).rounded()
+        let snapped = range.lowerBound + steps * step
+        value = min(max(snapped, range.lowerBound), range.upperBound)
+      }
+    )
+  }
+
   var body: some View {
     SettingsRow(title: title, description: description) {
       HStack(spacing: 10) {
-        Slider(value: $value, in: range, step: step)
+        Slider(value: steppedValue, in: range)
           .labelsHidden()
           .tint(SettingsTheme.accent)
+          .accessibilityLabel(title)
+          .accessibilityValue(valueLabel(value))
         Text(valueLabel(value))
           .font(.system(size: 12, weight: .medium))
           .monospacedDigit()

--- a/Talkify/Settings/Sections/SoundsSettingsView.swift
+++ b/Talkify/Settings/Sections/SoundsSettingsView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// The Sounds section: the session sound set and its begin/end preview.
+/// The Sounds section: session playback controls and the begin/end preview.
 /// Preview disables itself while playing, waits out the Begin sound's real
-/// duration, and a set change stops playback (CONTEXT.md).
+/// duration, and a preference change stops playback (CONTEXT.md).
 struct SoundsSettingsView: View {
   @Bindable var settings: AppSettings
   let sounds: DictationHUDSounds
@@ -12,6 +12,15 @@ struct SoundsSettingsView: View {
 
   var body: some View {
     SettingsCard(title: "Direct Dictation") {
+      SettingsRow(
+        title: "Play sounds",
+        description: "Play cues when dictation begins, ends, and inserts text"
+      ) {
+        Toggle("Play Direct Dictation sounds", isOn: $settings.dictationSoundsEnabled)
+          .labelsHidden()
+          .toggleStyle(.switch)
+      }
+
       SettingsPickerRow(
         title: "Sound set",
         description: "The sounds used when a session begins and ends",
@@ -19,6 +28,16 @@ struct SoundsSettingsView: View {
         optionLabel: { $0.rawValue },
         selection: $settings.soundSet
       )
+      .disabled(!settings.dictationSoundsEnabled)
+
+      SettingsSliderRow(
+        title: "Volume",
+        description: "The volume of all Direct Dictation sounds",
+        value: $settings.dictationSoundVolume,
+        range: DictationSoundSettings.volumeRange,
+        valueLabel: { "\(Int(($0 * 100).rounded()))%" }
+      )
+      .disabled(!settings.dictationSoundsEnabled)
 
       SettingsRow(
         title: "Preview",
@@ -31,11 +50,19 @@ struct SoundsSettingsView: View {
         }
         .buttonStyle(SettingsButtonStyle())
         .disabled(
-          isPreviewing || !sounds.hasPreviewSounds(for: settings.soundSet)
+          isPreviewing
+            || !settings.dictationSoundsEnabled
+            || !sounds.hasPreviewSounds(for: settings.soundSet)
         )
       }
     }
     .onChange(of: settings.soundSet) {
+      cancelPreview()
+    }
+    .onChange(of: settings.dictationSoundsEnabled) {
+      cancelPreview()
+    }
+    .onChange(of: settings.dictationSoundVolume) {
       cancelPreview()
     }
     .onDisappear {
@@ -44,15 +71,15 @@ struct SoundsSettingsView: View {
   }
 
   private func playPreview() {
-    let set = settings.soundSet
-    let delay = max(sounds.beginDuration(for: set), 0) + 0.1
+    let soundSettings = settings.sessionSettings.sounds
+    let delay = max(sounds.beginDuration(for: soundSettings.set), 0) + 0.1
     isPreviewing = true
-    sounds.playBegin(using: set)
+    sounds.playBegin(using: soundSettings)
 
     previewTask = Task { @MainActor in
       try? await Task.sleep(for: .seconds(delay))
       guard !Task.isCancelled else { return }
-      sounds.playEnd(using: set)
+      sounds.playEnd(using: soundSettings)
       isPreviewing = false
       previewTask = nil
     }

--- a/TalkifyTests/AppSettingsTests.swift
+++ b/TalkifyTests/AppSettingsTests.swift
@@ -14,6 +14,8 @@ struct AppSettingsTests {
   @Test func emptyStoreYieldsDefaults() {
     let settings = AppSettings(defaults: freshDefaults())
     #expect(settings.soundSet == .synth8)
+    #expect(settings.dictationSoundsEnabled)
+    #expect(settings.dictationSoundVolume == 0.5)
     #expect(settings.voiceVisual == .waveform)
     #expect(settings.waveformStyle == .chartLine)
     #expect(settings.revealStyle == .slide)
@@ -29,6 +31,8 @@ struct AppSettingsTests {
     let defaults = freshDefaults()
     let settings = AppSettings(defaults: defaults)
     settings.soundSet = .chime
+    settings.dictationSoundsEnabled = false
+    settings.dictationSoundVolume = 0.25
     settings.voiceVisual = .glow
     settings.waveformStyle = .dots
     settings.revealStyle = .bloom
@@ -48,6 +52,8 @@ struct AppSettingsTests {
 
     let reloaded = AppSettings(defaults: defaults)
     #expect(reloaded.soundSet == .chime)
+    #expect(!reloaded.dictationSoundsEnabled)
+    #expect(reloaded.dictationSoundVolume == 0.25)
     #expect(reloaded.voiceVisual == .glow)
     #expect(reloaded.waveformStyle == .dots)
     #expect(reloaded.revealStyle == .bloom)
@@ -58,10 +64,12 @@ struct AppSettingsTests {
     #expect(reloaded.readAloudBinding == f5Binding)
   }
 
-  @Test func storedKeysMatchTheHistoricalNames() {
+  @Test func preferencesUseStableStorageKeys() {
     let defaults = freshDefaults()
     let settings = AppSettings(defaults: defaults)
     settings.soundSet = .click
+    settings.dictationSoundsEnabled = false
+    settings.dictationSoundVolume = 0.2
     settings.voiceVisual = .glow
     settings.waveformStyle = .silver
     settings.revealStyle = .drift
@@ -69,6 +77,8 @@ struct AppSettingsTests {
     settings.readAloudVoiceID = "com.apple.voice.enhanced.en-GB.Jamie"
 
     #expect(defaults.string(forKey: "dictationSoundSet") == "Click")
+    #expect(defaults.object(forKey: "dictationSoundsEnabled") as? Bool == false)
+    #expect(defaults.double(forKey: "dictationSoundVolume") == 0.2)
     #expect(defaults.string(forKey: "hudVoiceVisual") == "Edge Glow")
     #expect(defaults.string(forKey: "hudWaveformStyle") == "Silver")
     #expect(defaults.string(forKey: "hudRevealStyle") == "Drift")
@@ -187,7 +197,7 @@ struct AppSettingsTests {
     settings.glowCenter = .siriOrb
     settings.hudScale = 0.6
 
-    #expect(snapshot.soundSet == .synth8)
+    #expect(snapshot.sounds.set == .synth8)
     #expect(snapshot.voiceVisual == .waveform)
     #expect(snapshot.waveformStyle == .chartLine)
     #expect(snapshot.revealStyle == .slide)
@@ -195,6 +205,22 @@ struct AppSettingsTests {
     #expect(snapshot.glowPalette == .spectrum)
     #expect(snapshot.glowCenter == .particles)
     #expect(snapshot.hudMetrics == .standard)
+  }
+
+  @Test func sessionSnapshotCapturesSoundPreferences() {
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.soundSet = .chime
+    settings.dictationSoundsEnabled = false
+    settings.dictationSoundVolume = 0.25
+
+    let snapshot = settings.sessionSettings
+    settings.soundSet = .click
+    settings.dictationSoundsEnabled = true
+    settings.dictationSoundVolume = 0.75
+
+    #expect(snapshot.sounds.set == .chime)
+    #expect(!snapshot.sounds.isEnabled)
+    #expect(snapshot.sounds.volume == 0.25)
   }
 
   /// The stored value is a plain number rather than a named case, so a
@@ -205,5 +231,27 @@ struct AppSettingsTests {
 
     let settings = AppSettings(defaults: defaults)
     #expect(settings.sessionSettings.hudMetrics.scale == HUDMetrics.minimumScale)
+  }
+
+  @Test func storedSoundVolumeOutsideTheRangeComesBackClamped() {
+    let defaults = freshDefaults()
+    defaults.set(1.4, forKey: "dictationSoundVolume")
+    #expect(AppSettings(defaults: defaults).dictationSoundVolume == 1)
+
+    defaults.set(-0.4, forKey: "dictationSoundVolume")
+    #expect(AppSettings(defaults: defaults).dictationSoundVolume == 0)
+  }
+
+  @Test func assignedSoundVolumeOutsideTheRangeIsClampedBeforePersistence() {
+    let defaults = freshDefaults()
+    let settings = AppSettings(defaults: defaults)
+
+    settings.dictationSoundVolume = 1.4
+    #expect(settings.dictationSoundVolume == 1)
+    #expect(defaults.double(forKey: "dictationSoundVolume") == 1)
+
+    settings.dictationSoundVolume = -0.4
+    #expect(settings.dictationSoundVolume == 0)
+    #expect(defaults.double(forKey: "dictationSoundVolume") == 0)
   }
 }


### PR DESCRIPTION
The session sounds played at a hardcoded half volume with no way to turn them off, which is the wrong default for anyone dictating next to other people.

Sounds now has a Play sounds toggle and a volume slider. DictationSoundSettings carries the set, the enabled state and the volume together, so the session snapshot captures all three at session start the way it already captured the set, and the sound player takes that one value instead of a bare set. Volume is clamped both on the way into defaults and on the way back out, since it is stored as a plain number rather than a named case, and the default stays at 0.5 so nothing changes for existing users until they touch it.

The second commit removes the dots under the sliders. A Slider given a step draws tick marks under its track, so the snap moved into a proxy binding instead: the slider runs continuous, the stored value still lands on a 5% step. Volume and HUD size both lose the dots and keep their steps.