### PR TITLE
Add typing insertion method for apps that refuse pasted text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ xcuserdata/
 # this file only when you are backing it up.
 talkify-sparkle-private-key.txt
 sparkle_eddsa_private_key
+build/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,6 +176,9 @@ _Avoid_: Transcript history, cloud analytics
 - Once speech has arrived, the session stays open until the user ends or cancels it
 - **Direct Dictation** ends by inserting text into the previously focused control
 - **Direct Dictation** inserts through clipboard paste after Accessibility validates the original target
+- The insertion method is a Settings choice: clipboard paste by default, or simulated typing for apps that refuse pasted text
+- Simulated typing delivers the transcript as chunked Unicode keyboard events and never touches the clipboard
+- A typing pass that cannot be posted leaves the finalized text on the clipboard, like every failed insertion
 - If an app exposes no focused element, Talkify captures and later validates the frontmost application instead
 - Talkify sends the paste event globally only after the captured focus boundary passes validation
 - Clipboard paste restores the previous clipboard after a short delay only if the pasteboard change count still matches Talkify's write

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,8 +177,9 @@ _Avoid_: Transcript history, cloud analytics
 - **Direct Dictation** ends by inserting text into the previously focused control
 - **Direct Dictation** inserts through clipboard paste after Accessibility validates the original target
 - The insertion method is a Settings choice: clipboard paste by default, or simulated typing for apps that refuse pasted text
-- Simulated typing delivers the transcript as chunked Unicode keyboard events and never touches the clipboard
-- A typing pass that cannot be posted leaves the finalized text on the clipboard, like every failed insertion
+- Simulated typing delivers the transcript as chunked Unicode keyboard events; a successful pass never touches the clipboard
+- Simulated typing sends line breaks as Return key events rather than embedding them in the Unicode stream
+- A typing pass stops at the first failed focus validation or unpostable chunk and copies the undelivered remainder to the clipboard, like every failed insertion
 - If an app exposes no focused element, Talkify captures and later validates the frontmost application instead
 - Talkify sends the paste event globally only after the captured focus boundary passes validation
 - Clipboard paste restores the previous clipboard after a short delay only if the pasteboard change count still matches Talkify's write

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -25,6 +25,7 @@ final class AppSettings {
     static let readAloudVoice = "readAloudVoice"
     static let dictationTriggerBinding = "dictationTriggerBinding"
     static let readAloudBinding = "readAloudBinding"
+    static let insertionMethod = "dictationInsertionMethod"
     static let recognitionLocale = "recognitionLocale"
     static let secondaryRecognitionLocale = "recognitionLocaleSecondary"
     static let secondaryTriggerBinding = "dictationTriggerBindingSecondary"
@@ -96,6 +97,12 @@ final class AppSettings {
     didSet { Self.store(readAloudBinding, in: defaults, key: Keys.readAloudBinding) }
   }
 
+  /// How finalized dictation text reaches the focused app. Paste is the
+  /// historical default; typing exists for apps that refuse pasted text.
+  var insertionMethod: TextInsertionService.InsertionMethod {
+    didSet { defaults.set(insertionMethod.rawValue, forKey: Keys.insertionMethod) }
+  }
+
   /// The dictation language, as a locale identifier; empty means follow the
   /// Mac's own language, which is what every session did before the Language
   /// section existed.
@@ -160,6 +167,7 @@ final class AppSettings {
     readAloudBinding = Self.storedBinding(
       in: defaults, key: Keys.readAloudBinding
     ) ?? .optionEscape
+    insertionMethod = Self.stored(in: defaults, key: Keys.insertionMethod) ?? .paste
     recognitionLocaleIdentifier = defaults.string(forKey: Keys.recognitionLocale) ?? ""
     secondaryRecognitionLocaleIdentifier =
       defaults.string(forKey: Keys.secondaryRecognitionLocale) ?? ""

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -434,7 +434,11 @@ final class DirectDictationController {
       do {
         let text = try await speechService.finish()
         hudController.hide()
-        await textInsertionService.insert(text, into: focusedTarget)
+        await textInsertionService.insert(
+          text,
+          into: focusedTarget,
+          method: settings.insertionMethod
+        )
         hudController.playPasteSound()
         send(.sessionEnded)
         let wordCount = UsageMetrics.wordCount(in: text)

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -3,6 +3,14 @@ import ApplicationServices
 
 @MainActor
 final class TextInsertionService {
+  /// How finalized text reaches the target app. Paste is the default;
+  /// typing exists for editors that refuse synthetic ⌘V — terminals,
+  /// virtual machines, apps with custom paste handling.
+  enum InsertionMethod: String, CaseIterable, Hashable {
+    case paste
+    case typing
+  }
+
   struct Target {
     fileprivate let element: AXUIElement?
     fileprivate let processIdentifier: pid_t
@@ -30,6 +38,7 @@ final class TextInsertionService {
     let isProcessRunning: @MainActor (pid_t) -> Bool
     let isTargetFocused: @MainActor (Target) -> Bool
     let postPasteShortcut: @MainActor () -> Bool
+    let postTypingText: @MainActor (String) -> Bool
     let waitForPasteRead: @MainActor () async -> Void
 
     static var live: Self {
@@ -47,6 +56,7 @@ final class TextInsertionService {
         },
         isTargetFocused: TextInsertionService.isStillFocused,
         postPasteShortcut: TextInsertionService.postPasteShortcut,
+        postTypingText: TextInsertionService.postTypingText,
         waitForPasteRead: {
           try? await Task.sleep(for: .milliseconds(500))
         }
@@ -84,7 +94,7 @@ final class TextInsertionService {
     )
   }
 
-  func insert(_ text: String, into target: Target?) async {
+  func insert(_ text: String, into target: Target?, method: InsertionMethod = .paste) async {
     guard !text.isEmpty else { return }
     guard let target else {
       copyToClipboard(text)
@@ -100,7 +110,23 @@ final class TextInsertionService {
       copyToClipboard(text)
       return
     }
-    await pasteAndRestoreClipboard(text, into: target)
+    switch method {
+    case .paste:
+      await pasteAndRestoreClipboard(text, into: target)
+    case .typing:
+      typeText(text, into: target)
+    }
+  }
+
+  /// Typing skips the clipboard entirely: the events land wherever the
+  /// keyboard would, which is the whole point for apps that refuse pasted
+  /// text. A target that slipped away mid-session still gets nothing typed.
+  private func typeText(_ text: String, into target: Target) {
+    guard dependencies.isTargetFocused(target),
+       dependencies.postTypingText(text) else {
+      copyToClipboard(text)
+      return
+    }
   }
 
   private static func focusedElement() -> AXUIElement? {
@@ -263,6 +289,50 @@ final class TextInsertionService {
 
     keyDown.flags = .maskCommand
     keyUp.flags = .maskCommand
+    keyDown.post(tap: .cghidEventTap)
+    keyUp.post(tap: .cghidEventTap)
+    return true
+  }
+
+  /// Delivers text as Unicode keyboard events. The HID event carries a
+  /// string rather than real keycodes, so it types into any editor that
+  /// accepts a keyboard — including ones that reject synthetic ⌘V.
+  private static func postTypingText(_ text: String) -> Bool {
+    guard let source = CGEventSource(stateID: .combinedSessionState) else {
+      return false
+    }
+
+    // Apps read only a few tens of characters per event before truncating,
+    // so the transcript goes out in chunks split on grapheme boundaries.
+    var start = text.startIndex
+    while start < text.endIndex {
+      let end = text.index(start, offsetBy: 20, limitedBy: text.endIndex) ?? text.endIndex
+      guard postTypingChunk(String(text[start..<end]), source: source) else {
+        return false
+      }
+      start = end
+    }
+    return true
+  }
+
+  private static func postTypingChunk(_ chunk: String, source: CGEventSource) -> Bool {
+    let characters = Array(chunk.utf16)
+    guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+       let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
+      return false
+    }
+
+    characters.withUnsafeBufferPointer { buffer in
+      keyDown.keyboardSetUnicodeString(
+        stringLength: characters.count,
+        unicodeString: buffer.baseAddress
+      )
+      keyUp.keyboardSetUnicodeString(
+        stringLength: characters.count,
+        unicodeString: buffer.baseAddress
+      )
+    }
+
     keyDown.post(tap: .cghidEventTap)
     keyUp.post(tap: .cghidEventTap)
     return true

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -38,7 +38,7 @@ final class TextInsertionService {
     let isProcessRunning: @MainActor (pid_t) -> Bool
     let isTargetFocused: @MainActor (Target) -> Bool
     let postPasteShortcut: @MainActor () -> Bool
-    let postTypingText: @MainActor (String) -> Bool
+    let postTypingChunk: @MainActor (String) -> Bool
     let waitForPasteRead: @MainActor () async -> Void
 
     static var live: Self {
@@ -56,7 +56,7 @@ final class TextInsertionService {
         },
         isTargetFocused: TextInsertionService.isStillFocused,
         postPasteShortcut: TextInsertionService.postPasteShortcut,
-        postTypingText: TextInsertionService.postTypingText,
+        postTypingChunk: TextInsertionService.postTypingChunk,
         waitForPasteRead: {
           try? await Task.sleep(for: .milliseconds(500))
         }
@@ -120,12 +120,26 @@ final class TextInsertionService {
 
   /// Typing skips the clipboard entirely: the events land wherever the
   /// keyboard would, which is the whole point for apps that refuse pasted
-  /// text. A target that slipped away mid-session still gets nothing typed.
+  /// text. The focus boundary is revalidated before every chunk, so a
+  /// target that slips away mid-transcript stops the pass; whatever was
+  /// not yet delivered lands on the clipboard like every failed insertion.
   private func typeText(_ text: String, into target: Target) {
-    guard dependencies.isTargetFocused(target),
-       dependencies.postTypingText(text) else {
-      copyToClipboard(text)
-      return
+    var start = text.startIndex
+    while start < text.endIndex {
+      guard dependencies.isTargetFocused(target) else {
+        copyToClipboard(String(text[start..<text.endIndex]))
+        return
+      }
+
+      // Apps read only a few tens of characters per event before
+      // truncating, so the transcript goes out in chunks split on
+      // grapheme boundaries.
+      let end = text.index(start, offsetBy: 20, limitedBy: text.endIndex) ?? text.endIndex
+      guard dependencies.postTypingChunk(String(text[start..<end])) else {
+        copyToClipboard(String(text[start..<text.endIndex]))
+        return
+      }
+      start = end
     }
   }
 
@@ -294,29 +308,38 @@ final class TextInsertionService {
     return true
   }
 
-  /// Delivers text as Unicode keyboard events. The HID event carries a
-  /// string rather than real keycodes, so it types into any editor that
-  /// accepts a keyboard — including ones that reject synthetic ⌘V.
-  private static func postTypingText(_ text: String) -> Bool {
+  /// Posts one typing chunk as Unicode keyboard events. The HID event
+  /// carries a string rather than real keycodes, so it types into any
+  /// editor that accepts a keyboard — including ones that reject ⌘V.
+  /// Line breaks go out as explicit Return presses: editors that ignore
+  /// newlines embedded in a Unicode string still honor a Return key.
+  private static func postTypingChunk(_ chunk: String) -> Bool {
     guard let source = CGEventSource(stateID: .combinedSessionState) else {
       return false
     }
 
-    // Apps read only a few tens of characters per event before truncating,
-    // so the transcript goes out in chunks split on grapheme boundaries.
-    var start = text.startIndex
-    while start < text.endIndex {
-      let end = text.index(start, offsetBy: 20, limitedBy: text.endIndex) ?? text.endIndex
-      guard postTypingChunk(String(text[start..<end]), source: source) else {
+    var line = ""
+    for character in chunk {
+      if character == "\n" {
+        guard postUnicodeString(line, source: source),
+           postReturnKey(source: source) else {
+          return false
+        }
+        line = ""
+      } else {
+        line.append(character)
+      }
+    }
+    if !line.isEmpty {
+      guard postUnicodeString(line, source: source) else {
         return false
       }
-      start = end
     }
     return true
   }
 
-  private static func postTypingChunk(_ chunk: String, source: CGEventSource) -> Bool {
-    let characters = Array(chunk.utf16)
+  private static func postUnicodeString(_ string: String, source: CGEventSource) -> Bool {
+    let characters = Array(string.utf16)
     guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false) else {
       return false
@@ -331,6 +354,17 @@ final class TextInsertionService {
         stringLength: characters.count,
         unicodeString: buffer.baseAddress
       )
+    }
+
+    keyDown.post(tap: .cghidEventTap)
+    keyUp.post(tap: .cghidEventTap)
+    return true
+  }
+
+  private static func postReturnKey(source: CGEventSource) -> Bool {
+    guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: true),
+       let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 36, keyDown: false) else {
+      return false
     }
 
     keyDown.post(tap: .cghidEventTap)

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -318,24 +318,48 @@ final class TextInsertionService {
       return false
     }
 
-    var line = ""
-    for character in chunk {
-      if character == "\n" {
-        guard postUnicodeString(line, source: source),
-           postReturnKey(source: source) else {
+    let lines = typingLines(in: chunk)
+    for (index, line) in lines.enumerated() {
+      // Empty segments still carry the break that follows them, so
+      // leading and consecutive newlines send a Return each without
+      // ever posting an empty Unicode event.
+      if !line.isEmpty {
+        guard postUnicodeString(line, source: source) else {
           return false
         }
+      }
+      if index < lines.count - 1 {
+        guard postReturnKey(source: source) else {
+          return false
+        }
+      }
+    }
+    return true
+  }
+
+  /// Splits a chunk on every Unicode line break, collapsing CRLF into a
+  /// single break. Empty segments are preserved so the caller can turn
+  /// each break into a Return without emitting empty text events.
+  static func typingLines(in chunk: String) -> [String] {
+    var lines: [String] = []
+    var line = ""
+    var index = chunk.startIndex
+    while index < chunk.endIndex {
+      let character = chunk[index]
+      if character.isNewline {
+        let nextIndex = chunk.index(after: index)
+        if character == "\r", nextIndex < chunk.endIndex, chunk[nextIndex] == "\n" {
+          index = nextIndex
+        }
+        lines.append(line)
         line = ""
       } else {
         line.append(character)
       }
+      index = chunk.index(after: index)
     }
-    if !line.isEmpty {
-      guard postUnicodeString(line, source: source) else {
-        return false
-      }
-    }
-    return true
+    lines.append(line)
+    return lines
   }
 
   private static func postUnicodeString(_ string: String, source: CGEventSource) -> Bool {

--- a/Talkify/Settings/Sections/InsertionSettingsView.swift
+++ b/Talkify/Settings/Sections/InsertionSettingsView.swift
@@ -33,8 +33,9 @@ struct InsertionSettingsView: View {
           "Paste works in most apps. Switch to Typing when an app ignores "
             + "dictated text or pastes it somewhere unexpected — terminals, "
             + "virtual machines, and some editors refuse pasted events but "
-            + "accept typed ones. Typing never touches the clipboard, and "
-            + "line breaks arrive as Return presses."
+            + "accept typed ones. Typing keeps your clipboard untouched, and "
+            + "line breaks arrive as Return presses; a text that cannot be "
+            + "typed lands on the clipboard instead."
         )
           .font(.caption)
           .foregroundStyle(.white.opacity(contrast == .increased ? 0.7 : 0.45))

--- a/Talkify/Settings/Sections/InsertionSettingsView.swift
+++ b/Talkify/Settings/Sections/InsertionSettingsView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// The Insertion section: how finalized dictation text is delivered to the
+/// focused app. Paste is the default; Typing posts Unicode keyboard events
+/// for editors that refuse synthetic ⌘V (CONTEXT.md).
+struct InsertionSettingsView: View {
+  @Bindable var settings: AppSettings
+
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      SettingsCard(title: "Method") {
+        SettingsPickerRow(
+          title: "Insert text by",
+          description: "Paste keeps your clipboard intact and restores it after use",
+          options: TextInsertionService.InsertionMethod.allCases,
+          optionLabel: { method in
+            switch method {
+            case .paste: "Paste"
+            case .typing: "Typing"
+            }
+          },
+          selection: $settings.insertionMethod,
+          controlWidth: 240
+        )
+      }
+
+      // Informational only: the choice is app-agnostic, so this stays a
+      // footnote telling users when the non-default method earns its keep.
+      VStack(alignment: .leading, spacing: 2) {
+        Text(
+          "Paste works in most apps. Switch to Typing when an app ignores "
+            + "dictated text or pastes it somewhere unexpected — terminals, "
+            + "virtual machines, and some editors refuse pasted events but "
+            + "accept typed ones. Typing never touches the clipboard, and "
+            + "line breaks arrive as Return presses."
+        )
+          .font(.caption)
+          .foregroundStyle(.white.opacity(contrast == .increased ? 0.7 : 0.45))
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(.horizontal, 6)
+    }
+  }
+}

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -18,6 +18,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case readAloud
   case language
   case shortcuts
+  case insertion
   case updates
   case insights
 
@@ -30,8 +31,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .sounds: "Sounds"
     case .readAloud: "Read Aloud"
     case .language: "Language"
-    case .shortcuts: "Shortcuts"
-    case .updates: "Updates"
+      case .shortcuts: "Shortcuts"
+      case .insertion: "Insertion"
+      case .updates: "Updates"
     case .insights: "Insights"
     }
   }
@@ -42,8 +44,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .sounds: "Choose and preview Direct Dictation sounds"
     case .readAloud: "Choose the voice that reads selected text"
     case .language: "Pick your dictation languages and their keys"
-    case .shortcuts: "Rebind the Direct Dictation and Read Aloud keys"
-    case .updates: "Keep Talkify current"
+      case .shortcuts: "Rebind the Direct Dictation and Read Aloud keys"
+      case .insertion: "Choose how dictated text reaches the focused app"
+      case .updates: "Keep Talkify current"
     case .insights: "Review your local Direct Dictation activity"
     }
   }
@@ -54,8 +57,9 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .sounds: "waveform"
     case .readAloud: "speaker.wave.2"
     case .language: "globe"
-    case .shortcuts: "keyboard"
-    case .updates: "arrow.down.circle"
+      case .shortcuts: "keyboard"
+      case .insertion: "text.insert"
+      case .updates: "arrow.down.circle"
     case .insights: "chart.bar.xaxis"
     }
   }

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -249,6 +249,8 @@ private struct SettingsContent: View {
           LanguageSettingsView(settings: settings, runtimeState: runtimeState)
         case .shortcuts:
           ShortcutsSettingsView(settings: settings)
+        case .insertion:
+          InsertionSettingsView(settings: settings)
         case .updates:
           UpdatesSettingsView(updater: updater)
         case .insights:

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -29,7 +29,7 @@ struct SettingsWindowTests {
 
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
     let expected: [SettingsSection] = [
-      .appearance, .sounds, .readAloud, .language, .shortcuts, .updates, .insights,
+      .appearance, .sounds, .readAloud, .language, .shortcuts, .insertion, .updates, .insights,
     ]
     #expect(SettingsSection.allCases == expected)
     #expect(SettingsSectionGroup.settings.sections == expected)

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -18,7 +18,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
       }
@@ -41,7 +41,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {
         pasteboard.clearContents()
         pasteboard.setString("new clipboard", forType: .string)
@@ -65,7 +65,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { false },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {
         waitedForPasteRead = true
       }
@@ -89,7 +89,7 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {}
     ))
     await service.insert("dictated text", into: makeTarget())
@@ -115,7 +115,7 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {}
     ))
     await service.insert("dictated text", into: makeTarget())
@@ -139,7 +139,7 @@ struct TextInsertionServiceTests {
       },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {}
     ))
 
@@ -166,7 +166,7 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      postTypingText: { text in
+      postTypingChunk: { text in
         typedText = text
         return true
       },
@@ -190,7 +190,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
-      postTypingText: { _ in false },
+      postTypingChunk: { _ in false },
       waitForPasteRead: {}
     ))
     await service.insert("dictated text", into: makeTarget(), method: .typing)
@@ -208,7 +208,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in false },
       postPasteShortcut: { true },
-      postTypingText: { _ in
+      postTypingChunk: { _ in
         postedTyping = true
         return true
       },
@@ -218,6 +218,40 @@ struct TextInsertionServiceTests {
 
     #expect(!postedTyping)
     #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  @Test func focusLostMidStreamStopsTypingAndCopiesRemainder() async {
+    let pasteboard = makePasteboard()
+    var focusCheckCount = 0
+    var typedChunks: [String] = []
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in
+        focusCheckCount += 1
+        // insert() validates the focus boundary once before dispatching,
+        // then typeText revalidates before every chunk.
+        return focusCheckCount < 4
+      },
+      postPasteShortcut: { true },
+      postTypingChunk: { chunk in
+        typedChunks.append(chunk)
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+    await service.insert(
+      String(repeating: "a", count: 45),
+      into: makeTarget(),
+      method: .typing
+    )
+
+    // Two 20-character chunks typed, then the focus check failed before
+    // the third: the undelivered remainder lands on the clipboard.
+    #expect(typedChunks == [String(repeating: "a", count: 20), String(repeating: "a", count: 20)])
+    #expect(pasteboard.string(forType: .string) == String(repeating: "a", count: 5))
   }
 
   private func makePasteboard() -> NSPasteboard {

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -18,6 +18,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
+      postTypingText: { _ in false },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
       }
@@ -40,6 +41,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
+      postTypingText: { _ in false },
       waitForPasteRead: {
         pasteboard.clearContents()
         pasteboard.setString("new clipboard", forType: .string)
@@ -63,6 +65,7 @@ struct TextInsertionServiceTests {
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
       postPasteShortcut: { false },
+      postTypingText: { _ in false },
       waitForPasteRead: {
         waitedForPasteRead = true
       }
@@ -86,6 +89,7 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
+      postTypingText: { _ in false },
       waitForPasteRead: {}
     ))
     await service.insert("dictated text", into: makeTarget())
@@ -111,6 +115,7 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
+      postTypingText: { _ in false },
       waitForPasteRead: {}
     ))
     await service.insert("dictated text", into: makeTarget())
@@ -134,6 +139,7 @@ struct TextInsertionServiceTests {
       },
       isTargetFocused: { _ in true },
       postPasteShortcut: { true },
+      postTypingText: { _ in false },
       waitForPasteRead: {}
     ))
 
@@ -141,6 +147,77 @@ struct TextInsertionServiceTests {
     #expect(target != nil)
     await service.insert("dictated text", into: target)
     #expect(checkedProcessIdentifier == application.processIdentifier)
+  }
+
+  @Test func typingMethodTypesWithoutTouchingClipboard() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var typedText: String?
+    var postedPaste = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      postTypingText: { text in
+        typedText = text
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+    await service.insert("dictated text", into: makeTarget(), method: .typing)
+
+    #expect(typedText == "dictated text")
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  @Test func failedTypingLeavesTranscriptOnClipboard() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      postTypingText: { _ in false },
+      waitForPasteRead: {}
+    ))
+    await service.insert("dictated text", into: makeTarget(), method: .typing)
+
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  @Test func changedTargetReceivesNoTypingEvent() async {
+    let pasteboard = makePasteboard()
+    var postedTyping = false
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in false },
+      postPasteShortcut: { true },
+      postTypingText: { _ in
+        postedTyping = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+    await service.insert("dictated text", into: makeTarget(), method: .typing)
+
+    #expect(!postedTyping)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
   }
 
   private func makePasteboard() -> NSPasteboard {

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -254,6 +254,17 @@ struct TextInsertionServiceTests {
     #expect(pasteboard.string(forType: .string) == String(repeating: "a", count: 5))
   }
 
+  @Test func typingLinesSplitOnEveryBreakAndCollapseCRLF() {
+    #expect(TextInsertionService.typingLines(in: "plain") == ["plain"])
+    #expect(TextInsertionService.typingLines(in: "a\nb") == ["a", "b"])
+    #expect(TextInsertionService.typingLines(in: "a\n\nb") == ["a", "", "b"])
+    #expect(TextInsertionService.typingLines(in: "\nlead") == ["", "lead"])
+    #expect(TextInsertionService.typingLines(in: "trail\n") == ["trail", ""])
+    #expect(TextInsertionService.typingLines(in: "a\r\nb") == ["a", "b"])
+    #expect(TextInsertionService.typingLines(in: "a\rb") == ["a", "b"])
+    #expect(TextInsertionService.typingLines(in: "\r\n\r\n") == ["", "", ""])
+  }
+
   private func makePasteboard() -> NSPasteboard {
     NSPasteboard(
       name: NSPasteboard.Name("TextInsertionServiceTests-\(UUID().uuidString)")


### PR DESCRIPTION
## Problem

Direct Dictation delivers the transcript through clipboard paste (synthetic ⌘V) only. Some editors reject synthetic paste events or read the pasteboard in ways that swallow the text — terminals, virtual machines, and apps with custom paste handling. There, a finished session ends with the transcript sitting on the clipboard and nothing inserted.

## Change

- New `TextInsertionService.InsertionMethod` (`.paste` stays the default, `.typing` the alternative), picked in a new **Settings → Insertion** section and persisted through `AppSettings`.
- Typing delivers the transcript as Unicode keyboard events (`CGEventKeyboardSetUnicodeString`), chunked at 20 characters on grapheme boundaries — apps read only a few tens of characters per event before truncating.
- Typing never touches the clipboard and keeps the same target validation as paste (process alive, focus boundary unchanged); a pass that cannot be posted leaves the text on the clipboard like every failed insertion.
- `CONTEXT.md` gains the matching invariants; the Settings section guard test learns the new section.

## Testing

- Three new `TextInsertionServiceTests` cases: typing posts without touching the clipboard or firing the paste path; a failed typing pass falls back to the clipboard; a changed target receives no typing events.
- Full suite green via `xcodebuild test`.

Behavior note: with Typing selected, line breaks arrive as Return presses — called out in the section's footnote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a setting to choose between pasting dictated text and simulated typing.
  * Simulated typing supports applications that reject pasted text and preserves Unicode text, including line breaks.
  * Typing validates focus during insertion and automatically copies undelivered text to the clipboard if insertion cannot finish.
  * The selected insertion method is saved and restored between sessions.

* **Chores**
  * Build output directories are now excluded from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->