### PR TITLE
Fixed a freeze that could occur at the end of dictation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -178,7 +178,10 @@ _Avoid_: Transcript history, cloud analytics
 - **Direct Dictation** inserts through clipboard paste after Accessibility validates the original target
 - If an app exposes no focused element, Talkify captures and later validates the frontmost application instead
 - Talkify sends the paste event globally only after the captured focus boundary passes validation
-- Clipboard paste restores the previous clipboard after a short delay only if the pasteboard change count still matches Talkify's write
+- Clipboard insertion obtains a complete snapshot within one 600-millisecond acquisition deadline, with one reread permitted if the pasteboard changes during capture
+- If a clipboard read is already active, remains blocked at the deadline, or changes during both permitted reads, Talkify leaves the clipboard and target untouched and reports that insertion failed
+- If a completed clipboard snapshot fails or omits an advertised representation, Talkify places finalized text on the clipboard for manual paste
+- After a successful paste, Talkify restores the accepted snapshot after a short delay only if the pasteboard change count still matches Talkify's write
 - If the original text target disappears, Talkify places finalized text on the clipboard without showing a message
 - Early versions persist no audio, recognized text, captions, or transcript history
 - Talkify persists application settings and aggregate **Direct Dictation** usage; macOS manages permission state

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -428,20 +428,29 @@ final class DirectDictationController {
     pendingLiveText = nil
   }
 
+  /// Finishes recognition and routes the insertion outcome to its terminal UI.
+  ///
+  /// - Parameter speakingDuration: The completed session's measured speech time.
   private func finishRecognition(speakingDuration: TimeInterval) {
     Task { [weak self] in
       guard let self else { return }
       do {
         let text = try await speechService.finish()
         hudController.hide()
-        await textInsertionService.insert(text, into: focusedTarget)
-        hudController.playPasteSound()
-        send(.sessionEnded)
-        let wordCount = UsageMetrics.wordCount(in: text)
-        await usageTracker.recordSession(
-          wordCount: wordCount,
-          speakingDuration: speakingDuration
-        )
+        let outcome = await textInsertionService.insert(text, into: focusedTarget)
+        switch outcome {
+        case .inserted, .copiedToClipboard:
+          hudController.playPasteSound()
+          send(.sessionEnded)
+          let wordCount = UsageMetrics.wordCount(in: text)
+          await usageTracker.recordSession(
+            wordCount: wordCount,
+            speakingDuration: speakingDuration
+          )
+        case .unavailable:
+          send(.sessionEnded)
+          hudController.showMessage("Couldn't insert text")
+        }
       } catch {
         fail(message: error.localizedDescription, wasCancelled: false)
       }

--- a/Talkify/Dictation/TextInsertionService+Clipboard.swift
+++ b/Talkify/Dictation/TextInsertionService+Clipboard.swift
@@ -1,0 +1,254 @@
+import AppKit
+import os
+
+/// Provides safe pasteboard access through its lease, budget, snapshots, staging, and restore.
+extension TextInsertionService {
+  /// The result of acquiring one stable, complete pre-insertion snapshot.
+  enum SnapshotAcquisitionResult: Sendable {
+    /// A complete snapshot whose count stayed stable during its read.
+    case accepted(items: [ClipboardItemSnapshot], changeCount: Int)
+    /// The actual read completed but could not capture every advertised value.
+    case failed
+    /// Both the initial read and the single permitted reread changed mid-read.
+    case unstable
+    /// The total acquisition deadline elapsed before a stable read completed.
+    case timedOut
+    /// Another acquisition still owns the service-wide read lease.
+    case busy
+  }
+
+  /// A Sendable value copy of one pasteboard item's ordered type payloads.
+  struct ClipboardItemSnapshot: Sendable {
+    /// One pasteboard type and its byte-for-byte payload.
+    struct Entry: Sendable {
+      /// The pasteboard representation type advertised by the source item.
+      let type: NSPasteboard.PasteboardType
+      /// The complete payload returned for the advertised representation.
+      let data: Data
+    }
+
+    /// Every advertised representation in the source item's original order.
+    let entries: [Entry]
+  }
+
+  /// Copies every advertised pasteboard representation into Sendable values.
+  ///
+  /// Capture is all-or-nothing because restoring an item without one of its
+  /// advertised representations would silently corrupt the clipboard.
+  /// Callers must run this off the main actor on the serial reader queue while
+  /// the read lease excludes same-instance writes: resolving promised values is
+  /// the operation that can block indefinitely inside an unresponsive owner.
+  ///
+  /// - Parameter pasteboard: The pasteboard whose current items are copied.
+  /// - Returns: Ordered item snapshots, including `[]` for a confirmed empty
+  ///   pasteboard, or `nil` when AppKit cannot return every advertised value.
+  static nonisolated func snapshot(
+    of pasteboard: NSPasteboard
+  ) -> [ClipboardItemSnapshot]? {
+    guard let sourceItems = pasteboard.pasteboardItems else { return nil }
+
+    var snapshots: [ClipboardItemSnapshot] = []
+    snapshots.reserveCapacity(sourceItems.count)
+    for sourceItem in sourceItems {
+      var entries: [ClipboardItemSnapshot.Entry] = []
+      entries.reserveCapacity(sourceItem.types.count)
+      for type in sourceItem.types {
+        guard let data = sourceItem.data(forType: type) else {
+          // An incomplete restore would silently discard an advertised
+          // representation, so abandon the whole snapshot instead.
+          return nil
+        }
+        entries.append(ClipboardItemSnapshot.Entry(type: type, data: data))
+      }
+      snapshots.append(ClipboardItemSnapshot(entries: entries))
+    }
+    return snapshots
+  }
+
+  /// Acquires one stable snapshot under the service-wide read lease.
+  ///
+  /// The lease is claimed before queueing, so a busy acquisition returns
+  /// without allocating a continuation or timer. A timeout resumes the caller
+  /// but leaves the lease claimed until the actual AppKit read returns.
+  ///
+  /// - Returns: The accepted snapshot and count, or the exact reason that a
+  ///   safe snapshot was unavailable.
+  func snapshotClipboardItems() async -> SnapshotAcquisitionResult {
+    let didClaimLease = clipboardReadLease.withLock { isClaimed in
+      guard !isClaimed else { return false }
+      isClaimed = true
+      return true
+    }
+    guard didClaimLease else { return .busy }
+
+    let readClipboardItems = dependencies.readClipboardItems
+    let timeout = dependencies.snapshotTimeout
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    let completionLock = OSAllocatedUnfairLock(initialState: false)
+    let readLease = clipboardReadLease
+    let pasteboard = dependencies.pasteboard
+    nonisolated(unsafe) let backgroundPasteboard = pasteboard
+
+    return await withCheckedContinuation { continuation in
+      let complete: @Sendable (SnapshotAcquisitionResult) -> Void = { result in
+        // The reader and deadline can finish together; only the winner owns
+        // the continuation, while the reader always owns lease release.
+        let shouldResume = completionLock.withLock { didComplete in
+          guard !didComplete else { return false }
+          didComplete = true
+          return true
+        }
+        if shouldResume {
+          continuation.resume(returning: result)
+        }
+      }
+
+      let timeoutTask = Self.makeSnapshotTimeoutTask(after: timeout) {
+        complete(.timedOut)
+      }
+      let executeRead: @Sendable () -> Void = {
+        let result = Self.readStableSnapshot(
+          of: backgroundPasteboard,
+          using: readClipboardItems,
+          before: deadline
+        )
+        readLease.withLock { $0 = false }
+        timeoutTask.cancel()
+        complete(result)
+      }
+      clipboardReaderQueue.async(execute: executeRead)
+    }
+  }
+
+  /// Reads at most twice and accepts only a complete, count-stable snapshot.
+  ///
+  /// This method runs on the serial reader queue while the read lease excludes
+  /// every same-instance pasteboard write until the actual read returns.
+  ///
+  /// - Parameters:
+  ///   - pasteboard: The pasteboard whose change count bounds each read.
+  ///   - readClipboardItems: The all-or-nothing snapshot operation.
+  ///   - deadline: The total deadline shared by both permitted reads.
+  /// - Returns: A stable snapshot, a completed failure, an unstable result, or
+  ///   a timeout when the second read cannot start or finish within the budget.
+  private nonisolated static func readStableSnapshot(
+    of pasteboard: NSPasteboard,
+    using readClipboardItems: @Sendable () -> [ClipboardItemSnapshot]?,
+    before deadline: ContinuousClock.Instant
+  ) -> SnapshotAcquisitionResult {
+    let startCount = pasteboard.changeCount
+    let firstSnapshot = readClipboardItems()
+    let firstEndCount = pasteboard.changeCount
+    guard ContinuousClock.now < deadline else { return .timedOut }
+
+    if firstEndCount == startCount {
+      guard let firstSnapshot else { return .failed }
+      return .accepted(items: firstSnapshot, changeCount: firstEndCount)
+    }
+
+    guard ContinuousClock.now < deadline else { return .timedOut }
+    let secondStartCount = pasteboard.changeCount
+    let secondSnapshot = readClipboardItems()
+    let secondEndCount = pasteboard.changeCount
+    guard ContinuousClock.now < deadline else { return .timedOut }
+    guard secondEndCount == secondStartCount else { return .unstable }
+    guard let secondSnapshot else { return .failed }
+    return .accepted(items: secondSnapshot, changeCount: secondEndCount)
+  }
+
+  /// Starts the independent acquisition deadline without detaching execution.
+  ///
+  /// Cancelling the returned task stops the timer without invoking its handler.
+  /// Caller cancellation does not shorten the clipboard acquisition budget.
+  ///
+  /// - Parameters:
+  ///   - timeout: The total duration allowed for snapshot acquisition.
+  ///   - onTimeout: The single-resume contender invoked when the budget elapses.
+  /// - Returns: A task the actual reader must cancel when it completes.
+  private nonisolated static func makeSnapshotTimeoutTask(
+    after timeout: Duration,
+    onTimeout: @escaping @Sendable () -> Void
+  ) -> Task<Void, Never> {
+    Task {
+      do {
+        try await Task.sleep(for: timeout)
+      } catch {
+        return
+      }
+      guard !Task.isCancelled else { return }
+      onTimeout()
+    }
+  }
+
+  /// Stages finalized text only while the accepted snapshot remains current.
+  ///
+  /// - Parameters:
+  ///   - text: The finalized text to stage for paste.
+  ///   - acceptedChangeCount: The stable count captured with the snapshot.
+  /// - Returns: Talkify's staged change count, or `nil` when staging is unsafe.
+  func stageClipboardText(
+    _ text: String,
+    ifUnchangedSince acceptedChangeCount: Int
+  ) -> Int? {
+    guard !isClipboardReadActive() else { return nil }
+
+    let pasteboard = dependencies.pasteboard
+    guard pasteboard.changeCount == acceptedChangeCount else { return nil }
+    // Public pasteboard APIs cannot make this comparison and clear atomic. An
+    // external write in the remaining instruction-level gap is knowingly lost;
+    // insertion never waits on or aborts for it because delivery takes priority.
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+    return pasteboard.changeCount
+  }
+
+  /// Restores a saved snapshot only while Talkify still owns the staged value.
+  ///
+  /// - Parameters:
+  ///   - savedItems: The complete item snapshots accepted before insertion.
+  ///   - insertedChangeCount: The count produced by Talkify's staged text.
+  func restoreClipboard(
+    _ savedItems: [ClipboardItemSnapshot],
+    ifUnchangedSince insertedChangeCount: Int
+  ) {
+    guard !isClipboardReadActive() else { return }
+
+    let pasteboard = dependencies.pasteboard
+    // This guard preserves clipboard contents written after Talkify staged the
+    // dictated text.
+    guard pasteboard.changeCount == insertedChangeCount else { return }
+
+    pasteboard.clearContents()
+    if !savedItems.isEmpty {
+      let pasteboardItems = savedItems.map { snapshot in
+        let item = NSPasteboardItem()
+        for entry in snapshot.entries {
+          item.setData(entry.data, forType: entry.type)
+        }
+        return item
+      }
+      pasteboard.writeObjects(pasteboardItems)
+    }
+  }
+
+  /// Places finalized text on the clipboard when no target paste is safe.
+  ///
+  /// - Parameter text: The finalized text to retain for manual paste.
+  /// - Returns: `.copiedToClipboard`, or `.unavailable` while a reader owns the
+  ///   pasteboard lease and any same-instance write would be unsafe.
+  func copyToClipboard(_ text: String) -> InsertionOutcome {
+    guard !isClipboardReadActive() else { return .unavailable }
+
+    let pasteboard = dependencies.pasteboard
+    pasteboard.clearContents()
+    pasteboard.setString(text, forType: .string)
+    return .copiedToClipboard
+  }
+
+  /// Reports whether an actual background pasteboard read still owns the lease.
+  ///
+  /// - Returns: `true` until the reader closure returns, even after timeout.
+  private func isClipboardReadActive() -> Bool {
+    clipboardReadLease.withLock { $0 }
+  }
+}

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -15,6 +15,28 @@ final class TextInsertionService {
     let entries: [Entry]
   }
 
+  /// Copies each pasteboard item's ordered type payloads into Sendable values.
+  static nonisolated func snapshot(
+    of pasteboard: NSPasteboard
+  ) -> [ClipboardItemSnapshot] {
+    let sourceItems = pasteboard.pasteboardItems ?? []
+    return sourceItems.map { sourceItem in
+      let entries = sourceItem.types.compactMap { type in
+        sourceItem.data(forType: type).map {
+          ClipboardItemSnapshot.Entry(type: type, data: $0)
+        }
+      }
+      return ClipboardItemSnapshot(entries: entries)
+    }
+  }
+
+  // Serial access caps unresponsive pasteboard reads at one blocked worker;
+  // later snapshots keep their own timeout budgets while waiting in the queue.
+  private let clipboardReaderQueue = DispatchQueue(
+    label: "com.tgomareli.Talkify.clipboard-snapshot",
+    qos: .userInitiated
+  )
+
   struct Target {
     fileprivate let element: AXUIElement?
     fileprivate let processIdentifier: pid_t
@@ -57,15 +79,7 @@ final class TextInsertionService {
       return Self(
         pasteboard: pasteboard,
         readClipboardItems: {
-          let sourceItems = backgroundPasteboard.pasteboardItems ?? []
-          return sourceItems.map { sourceItem in
-            let entries = sourceItem.types.compactMap { type in
-              sourceItem.data(forType: type).map {
-                ClipboardItemSnapshot.Entry(type: type, data: $0)
-              }
-            }
-            return ClipboardItemSnapshot(entries: entries)
-          }
+          TextInsertionService.snapshot(of: backgroundPasteboard)
         },
         snapshotTimeout: .milliseconds(300),
         focusedElement: TextInsertionService.focusedElement,
@@ -282,21 +296,14 @@ final class TextInsertionService {
 
   /// Reads the clipboard away from the main actor within the configured budget.
   ///
-  /// On timeout, the snapshot is abandoned and the private queue's thread may
-  /// stay blocked until the pasteboard daemon gives up or the owner responds.
-  /// This is intentional and bounds the app impact to one private thread per
-  /// unresponsive-owner attempt. A late read is discarded without resuming the
-  /// continuation again.
+  /// On timeout, the snapshot is abandoned and a late read is discarded without
+  /// resuming the continuation again.
   ///
   /// - Returns: The complete ordered snapshot, or `nil` when the budget expires.
   private func snapshotClipboardItems() async -> [ClipboardItemSnapshot]? {
     let readClipboardItems = dependencies.readClipboardItems
     let timeout = dependencies.snapshotTimeout
     let completionLock = OSAllocatedUnfairLock(initialState: false)
-    let readQueue = DispatchQueue(
-      label: "com.tgomareli.Talkify.clipboard-snapshot",
-      qos: .userInitiated
-    )
 
     return await withCheckedContinuation { continuation in
       let complete: @Sendable ([ClipboardItemSnapshot]?) -> Void = { snapshot in
@@ -314,10 +321,12 @@ final class TextInsertionService {
         }
       }
 
-      readQueue.async {
+      clipboardReaderQueue.async {
         complete(readClipboardItems())
       }
       Task {
+        // Caller cancellation does not cancel this unstructured task, so nil
+        // still means that the full configured snapshot budget elapsed.
         try? await Task.sleep(for: timeout)
         complete(nil)
       }

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -4,38 +4,31 @@ import os
 
 @MainActor
 final class TextInsertionService {
-  /// A value copy of one pasteboard item's ordered type payloads.
-  struct ClipboardItemSnapshot: Sendable {
-    /// One pasteboard type and its byte-for-byte payload.
-    struct Entry: Sendable {
-      let type: NSPasteboard.PasteboardType
-      let data: Data
-    }
-
-    let entries: [Entry]
+  /// The terminal delivery state of one finalized Direct Dictation result.
+  enum InsertionOutcome: Equatable, Sendable {
+    /// The text was staged and pasted, or empty input completed as a no-op.
+    case inserted
+    /// Target delivery was unavailable, so the text was left for manual paste.
+    case copiedToClipboard
+    /// Neither target insertion nor a safe clipboard fallback was possible.
+    case unavailable
   }
 
-  /// Copies each pasteboard item's ordered type payloads into Sendable values.
-  static nonisolated func snapshot(
-    of pasteboard: NSPasteboard
-  ) -> [ClipboardItemSnapshot] {
-    let sourceItems = pasteboard.pasteboardItems ?? []
-    return sourceItems.map { sourceItem in
-      let entries = sourceItem.types.compactMap { type in
-        sourceItem.data(forType: type).map {
-          ClipboardItemSnapshot.Entry(type: type, data: $0)
-        }
-      }
-      return ClipboardItemSnapshot(entries: entries)
-    }
-  }
-
-  // Serial access caps unresponsive pasteboard reads at one blocked worker;
-  // later snapshots keep their own timeout budgets while waiting in the queue.
-  private let clipboardReaderQueue = DispatchQueue(
+  /// Runs the sole leased pasteboard read away from the main actor.
+  ///
+  /// Apple documents no thread-safety contract for `NSPasteboard`. Background
+  /// use is accepted only to keep promised-data resolution from blocking the
+  /// main actor. The serial queue and read lease prevent same-instance overlap.
+  let clipboardReaderQueue = DispatchQueue(
     label: "com.tgomareli.Talkify.clipboard-snapshot",
     qos: .userInitiated
   )
+
+  /// True from before a read is enqueued until its closure actually returns.
+  ///
+  /// A timeout never clears this lease: while AppKit remains inside a promised
+  /// data read, every later read and every write must remain excluded.
+  let clipboardReadLease = OSAllocatedUnfairLock(initialState: false)
 
   struct Target {
     fileprivate let element: AXUIElement?
@@ -57,11 +50,15 @@ final class TextInsertionService {
     }
   }
 
+  /// Injectable pasteboard, focus, event, and timing boundaries for insertion.
   struct Dependencies {
     let pasteboard: NSPasteboard
-    /// Reads every pasteboard item without moving AppKit item objects across threads.
-    let readClipboardItems: @Sendable () -> [ClipboardItemSnapshot]
-    /// The total time allowed for one complete clipboard snapshot.
+    /// Reads every pasteboard item into values that can cross back to the main actor.
+    ///
+    /// The service invokes this closure only on its serial reader queue while
+    /// holding the read lease. `nil` means the read was incomplete or failed.
+    let readClipboardItems: @Sendable () -> [ClipboardItemSnapshot]?
+    /// The total acquisition deadline shared by the first read and one reread.
     let snapshotTimeout: Duration
     let focusedElement: @MainActor () -> AXUIElement?
     let frontmostApplication: @MainActor () -> NSRunningApplication?
@@ -70,10 +67,14 @@ final class TextInsertionService {
     let postPasteShortcut: @MainActor () -> Bool
     let waitForPasteRead: @MainActor () async -> Void
 
+    /// Builds the production boundaries around the shared general pasteboard.
     static var live: Self {
       let pasteboard = NSPasteboard.general
-      // CFPasteboard supports background access, but AppKit does not declare
-      // NSPasteboard Sendable, so this same live instance needs an unsafe capture.
+      // Apple documents no NSPasteboard thread-safety contract. This background
+      // read is deliberate: promised data wedged the main actor in __dataForType
+      // -> CFPasteboardCopyData -> mach_msg, while same-instance overlap was
+      // proven to raise NSException "value not absent" in pasteboardItems. The
+      // serial reader queue and lease exclude every write until the read returns.
       nonisolated(unsafe) let backgroundPasteboard = pasteboard
 
       return Self(
@@ -81,7 +82,7 @@ final class TextInsertionService {
         readClipboardItems: {
           TextInsertionService.snapshot(of: backgroundPasteboard)
         },
-        snapshotTimeout: .milliseconds(300),
+        snapshotTimeout: .milliseconds(600),
         focusedElement: TextInsertionService.focusedElement,
         frontmostApplication: { NSWorkspace.shared.frontmostApplication },
         isProcessRunning: { processIdentifier in
@@ -101,7 +102,7 @@ final class TextInsertionService {
     }
   }
 
-  private let dependencies: Dependencies
+  let dependencies: Dependencies
 
   init(dependencies: Dependencies = .live) {
     self.dependencies = dependencies
@@ -131,23 +132,26 @@ final class TextInsertionService {
     )
   }
 
-  func insert(_ text: String, into target: Target?) async {
-    guard !text.isEmpty else { return }
+  /// Delivers finalized text to its captured target or the clipboard fallback.
+  ///
+  /// - Parameters:
+  ///   - text: The finalized text to deliver.
+  ///   - target: The focus boundary captured when Direct Dictation began.
+  /// - Returns: The terminal delivery outcome used by the session controller.
+  func insert(_ text: String, into target: Target?) async -> InsertionOutcome {
+    guard !text.isEmpty else { return .inserted }
     guard let target else {
-      copyToClipboard(text)
-      return
+      return copyToClipboard(text)
     }
 
     guard dependencies.isProcessRunning(target.processIdentifier) else {
-      copyToClipboard(text)
-      return
+      return copyToClipboard(text)
     }
 
     guard dependencies.isTargetFocused(target) else {
-      copyToClipboard(text)
-      return
+      return copyToClipboard(text)
     }
-    await pasteAndRestoreClipboard(text, into: target)
+    return await pasteAndRestoreClipboard(text, into: target)
   }
 
   private static func focusedElement() -> AXUIElement? {
@@ -262,81 +266,45 @@ final class TextInsertionService {
     return CFEqual(value, targetElement)
   }
 
-  private func pasteAndRestoreClipboard(_ text: String, into target: Target) async {
-    let pasteboard = dependencies.pasteboard
-    let savedItems = await snapshotClipboardItems()
+  /// Stages, pastes, and conditionally restores one finalized result.
+  ///
+  /// - Parameters:
+  ///   - text: The finalized text to insert.
+  ///   - target: The validated focus boundary that should receive the paste.
+  /// - Returns: The terminal delivery outcome after all safe fallbacks.
+  private func pasteAndRestoreClipboard(
+    _ text: String,
+    into target: Target
+  ) async -> InsertionOutcome {
+    let acquisition = await snapshotClipboardItems()
+    let savedItems: [ClipboardItemSnapshot]
+    let acceptedChangeCount: Int
 
-    pasteboard.clearContents()
-    pasteboard.setString(text, forType: .string)
-    let insertedChangeCount = pasteboard.changeCount
+    switch acquisition {
+    case let .accepted(items, changeCount):
+      savedItems = items
+      acceptedChangeCount = changeCount
+    case .failed:
+      return copyToClipboard(text)
+    case .timedOut, .unstable, .busy:
+      return .unavailable
+    }
 
-    guard dependencies.isTargetFocused(target),
-       dependencies.postPasteShortcut() else { return }
+    guard dependencies.isTargetFocused(target) else {
+      return copyToClipboard(text)
+    }
+    guard let insertedChangeCount = stageClipboardText(
+      text,
+      ifUnchangedSince: acceptedChangeCount
+    ) else { return .unavailable }
+
+    guard dependencies.postPasteShortcut() else {
+      restoreClipboard(savedItems, ifUnchangedSince: insertedChangeCount)
+      return .unavailable
+    }
     await dependencies.waitForPasteRead()
-
-    // Reads do not change changeCount. The delay gives asynchronous editors
-    // time to read; this guard protects newer clipboard contents.
-    guard pasteboard.changeCount == insertedChangeCount else { return }
-
-    // A timeout has no complete value to restore, while an empty snapshot
-    // represents a clipboard that must be restored to empty.
-    guard let savedItems else { return }
-    pasteboard.clearContents()
-    if !savedItems.isEmpty {
-      let pasteboardItems = savedItems.map { snapshot in
-        let item = NSPasteboardItem()
-        for entry in snapshot.entries {
-          item.setData(entry.data, forType: entry.type)
-        }
-        return item
-      }
-      pasteboard.writeObjects(pasteboardItems)
-    }
-  }
-
-  /// Reads the clipboard away from the main actor within the configured budget.
-  ///
-  /// On timeout, the snapshot is abandoned and a late read is discarded without
-  /// resuming the continuation again.
-  ///
-  /// - Returns: The complete ordered snapshot, or `nil` when the budget expires.
-  private func snapshotClipboardItems() async -> [ClipboardItemSnapshot]? {
-    let readClipboardItems = dependencies.readClipboardItems
-    let timeout = dependencies.snapshotTimeout
-    let completionLock = OSAllocatedUnfairLock(initialState: false)
-
-    return await withCheckedContinuation { continuation in
-      let complete: @Sendable ([ClipboardItemSnapshot]?) -> Void = { snapshot in
-        // The pasteboard read and timeout can finish together; only the winner
-        // owns the continuation.
-        let shouldResume = completionLock.withLock { didComplete in
-          if didComplete {
-            return false
-          }
-          didComplete = true
-          return true
-        }
-        if shouldResume {
-          continuation.resume(returning: snapshot)
-        }
-      }
-
-      clipboardReaderQueue.async {
-        complete(readClipboardItems())
-      }
-      Task {
-        // Caller cancellation does not cancel this unstructured task, so nil
-        // still means that the full configured snapshot budget elapsed.
-        try? await Task.sleep(for: timeout)
-        complete(nil)
-      }
-    }
-  }
-
-  private func copyToClipboard(_ text: String) {
-    let pasteboard = dependencies.pasteboard
-    pasteboard.clearContents()
-    pasteboard.setString(text, forType: .string)
+    restoreClipboard(savedItems, ifUnchangedSince: insertedChangeCount)
+    return .inserted
   }
 
   private static func postPasteShortcut() -> Bool {

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -1,8 +1,20 @@
 import AppKit
 import ApplicationServices
+import os
 
 @MainActor
 final class TextInsertionService {
+  /// A value copy of one pasteboard item's ordered type payloads.
+  struct ClipboardItemSnapshot: Sendable {
+    /// One pasteboard type and its byte-for-byte payload.
+    struct Entry: Sendable {
+      let type: NSPasteboard.PasteboardType
+      let data: Data
+    }
+
+    let entries: [Entry]
+  }
+
   struct Target {
     fileprivate let element: AXUIElement?
     fileprivate let processIdentifier: pid_t
@@ -25,6 +37,10 @@ final class TextInsertionService {
 
   struct Dependencies {
     let pasteboard: NSPasteboard
+    /// Reads every pasteboard item without moving AppKit item objects across threads.
+    let readClipboardItems: @Sendable () -> [ClipboardItemSnapshot]
+    /// The total time allowed for one complete clipboard snapshot.
+    let snapshotTimeout: Duration
     let focusedElement: @MainActor () -> AXUIElement?
     let frontmostApplication: @MainActor () -> NSRunningApplication?
     let isProcessRunning: @MainActor (pid_t) -> Bool
@@ -33,8 +49,25 @@ final class TextInsertionService {
     let waitForPasteRead: @MainActor () async -> Void
 
     static var live: Self {
-      Self(
-        pasteboard: .general,
+      let pasteboard = NSPasteboard.general
+      // CFPasteboard supports background access, but AppKit does not declare
+      // NSPasteboard Sendable, so this same live instance needs an unsafe capture.
+      nonisolated(unsafe) let backgroundPasteboard = pasteboard
+
+      return Self(
+        pasteboard: pasteboard,
+        readClipboardItems: {
+          let sourceItems = backgroundPasteboard.pasteboardItems ?? []
+          return sourceItems.map { sourceItem in
+            let entries = sourceItem.types.compactMap { type in
+              sourceItem.data(forType: type).map {
+                ClipboardItemSnapshot.Entry(type: type, data: $0)
+              }
+            }
+            return ClipboardItemSnapshot(entries: entries)
+          }
+        },
+        snapshotTimeout: .milliseconds(300),
         focusedElement: TextInsertionService.focusedElement,
         frontmostApplication: { NSWorkspace.shared.frontmostApplication },
         isProcessRunning: { processIdentifier in
@@ -217,19 +250,7 @@ final class TextInsertionService {
 
   private func pasteAndRestoreClipboard(_ text: String, into target: Target) async {
     let pasteboard = dependencies.pasteboard
-    let sourceItems = pasteboard.pasteboardItems ?? []
-    var savedItems: [NSPasteboardItem] = []
-    savedItems.reserveCapacity(sourceItems.count)
-
-    for sourceItem in sourceItems {
-      let savedItem = NSPasteboardItem()
-      for type in sourceItem.types {
-        if let data = sourceItem.data(forType: type) {
-          savedItem.setData(data, forType: type)
-        }
-      }
-      savedItems.append(savedItem)
-    }
+    let savedItems = await snapshotClipboardItems()
 
     pasteboard.clearContents()
     pasteboard.setString(text, forType: .string)
@@ -242,9 +263,64 @@ final class TextInsertionService {
     // Reads do not change changeCount. The delay gives asynchronous editors
     // time to read; this guard protects newer clipboard contents.
     guard pasteboard.changeCount == insertedChangeCount else { return }
+
+    // A timeout has no complete value to restore, while an empty snapshot
+    // represents a clipboard that must be restored to empty.
+    guard let savedItems else { return }
     pasteboard.clearContents()
     if !savedItems.isEmpty {
-      pasteboard.writeObjects(savedItems)
+      let pasteboardItems = savedItems.map { snapshot in
+        let item = NSPasteboardItem()
+        for entry in snapshot.entries {
+          item.setData(entry.data, forType: entry.type)
+        }
+        return item
+      }
+      pasteboard.writeObjects(pasteboardItems)
+    }
+  }
+
+  /// Reads the clipboard away from the main actor within the configured budget.
+  ///
+  /// On timeout, the snapshot is abandoned and the private queue's thread may
+  /// stay blocked until the pasteboard daemon gives up or the owner responds.
+  /// This is intentional and bounds the app impact to one private thread per
+  /// unresponsive-owner attempt. A late read is discarded without resuming the
+  /// continuation again.
+  ///
+  /// - Returns: The complete ordered snapshot, or `nil` when the budget expires.
+  private func snapshotClipboardItems() async -> [ClipboardItemSnapshot]? {
+    let readClipboardItems = dependencies.readClipboardItems
+    let timeout = dependencies.snapshotTimeout
+    let completionLock = OSAllocatedUnfairLock(initialState: false)
+    let readQueue = DispatchQueue(
+      label: "com.tgomareli.Talkify.clipboard-snapshot",
+      qos: .userInitiated
+    )
+
+    return await withCheckedContinuation { continuation in
+      let complete: @Sendable ([ClipboardItemSnapshot]?) -> Void = { snapshot in
+        // The pasteboard read and timeout can finish together; only the winner
+        // owns the continuation.
+        let shouldResume = completionLock.withLock { didComplete in
+          if didComplete {
+            return false
+          }
+          didComplete = true
+          return true
+        }
+        if shouldResume {
+          continuation.resume(returning: snapshot)
+        }
+      }
+
+      readQueue.async {
+        complete(readClipboardItems())
+      }
+      Task {
+        try? await Task.sleep(for: timeout)
+        complete(nil)
+      }
     }
   }
 

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -6,17 +6,7 @@ import Testing
 
 @MainActor
 struct TextInsertionServiceTests {
-  private enum InsertionRaceResult: Sendable {
-    case insertionCompleted
-    case deadlineExpired
-  }
-
-  private struct InsertionObservations: Sendable {
-    var readerStarted = false
-    var postedPaste = false
-    var textAvailableWhileTargetReads: String?
-  }
-
+  /// Verifies every validated target uses paste insertion and restores text.
   @Test func everyFocusedTargetUsesPasteInsertion() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
@@ -36,12 +26,14 @@ struct TextInsertionServiceTests {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
       }
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
+    #expect(outcome == .inserted)
     #expect(textAvailableWhileTargetReads == "dictated text")
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
   }
 
+  /// Verifies snapshot restoration preserves ordered multi-type item payloads.
   @Test func fastSnapshotRestoresEveryClipboardTypeInOrder() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
@@ -74,9 +66,10 @@ struct TextInsertionServiceTests {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
       }
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
     let restoredItem = pasteboard.pasteboardItems?.first
+    #expect(outcome == .inserted)
     #expect(postedPaste)
     #expect(textAvailableWhileTargetReads == "dictated text")
     #expect(pasteboard.pasteboardItems?.count == 1)
@@ -86,6 +79,7 @@ struct TextInsertionServiceTests {
     #expect(pasteboard.string(forType: .string) == previousString)
   }
 
+  /// Verifies a confirmed empty clipboard restores to empty after the paste.
   @Test func fastEmptySnapshotRestoresClipboardToEmpty() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
@@ -108,14 +102,83 @@ struct TextInsertionServiceTests {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
       }
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
+    #expect(outcome == .inserted)
     #expect(postedPaste)
     #expect(textAvailableWhileTargetReads == "dictated text")
     #expect((pasteboard.pasteboardItems ?? []).isEmpty)
     #expect(pasteboard.string(forType: .string) == nil)
   }
 
+  /// Verifies a completed nil read uses manual clipboard delivery without paste.
+  @Test func failedClipboardReadUsesCopyFallbackWithoutPostingPaste() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var postedPaste = false
+    var textAvailableWhileTargetReads: String?
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: { nil },
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {
+        textAvailableWhileTargetReads = pasteboard.string(forType: .string)
+      }
+    ))
+    let outcome = await service.insert("dictated text", into: makeTarget())
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(!postedPaste)
+    #expect(textAvailableWhileTargetReads == nil)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies a missing advertised payload rejects the partial snapshot.
+  @Test func missingClipboardRepresentationUsesCopyFallback() async {
+    let pasteboard = makePasteboard()
+    let missingType = NSPasteboard.PasteboardType(
+      "com.tgomareli.TalkifyTests.missing-data"
+    )
+    let provider = MissingPasteboardDataProvider()
+    let item = NSPasteboardItem()
+    item.setDataProvider(provider, forTypes: [missingType])
+    pasteboard.clearContents()
+    pasteboard.writeObjects([item])
+    var postedPaste = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+
+    let outcome = await service.insert("dictated text", into: makeTarget())
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies an external write after staging is not overwritten by restore.
   @Test func clipboardChangeDuringPasteIsNeverOverwritten() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
@@ -135,16 +198,177 @@ struct TextInsertionServiceTests {
         pasteboard.setString("new clipboard", forType: .string)
       }
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
+    #expect(outcome == .inserted)
     #expect(pasteboard.string(forType: .string) == "new clipboard")
   }
 
-  @Test func failedPasteShortcutLeavesTranscriptOnClipboard() async {
+  /// Verifies a healthy delayed read still pastes and restores within its budget.
+  @Test func delayedSnapshotWithinDeadlinePastesAndRestores() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    let delay = DispatchSemaphore(value: 0)
+    var pastedText: String?
+
+    nonisolated(unsafe) let backgroundPasteboard = pasteboard
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: {
+        _ = delay.wait(timeout: .now() + .milliseconds(40))
+        return TextInsertionService.snapshot(of: backgroundPasteboard)
+      },
+      snapshotTimeout: .milliseconds(150),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      waitForPasteRead: {
+        pastedText = pasteboard.string(forType: .string)
+      }
+    ))
+
+    let outcome = await service.insert("dictated text", into: makeTarget())
+
+    #expect(outcome == .inserted)
+    #expect(pastedText == "dictated text")
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  /// Verifies one changed read accepts and restores the stable second snapshot.
+  @Test func oneClipboardChangeUsesStableSecondSnapshot() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("first clipboard", forType: .string)
+    let readCount = OSAllocatedUnfairLock(initialState: 0)
+    var pastedText: String?
+
+    nonisolated(unsafe) let backgroundPasteboard = pasteboard
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: {
+        let attempt = readCount.withLock { count in
+          count += 1
+          return count
+        }
+        let snapshot = TextInsertionService.snapshot(of: backgroundPasteboard)
+        if attempt == 1 {
+          backgroundPasteboard.clearContents()
+          backgroundPasteboard.setString("second clipboard", forType: .string)
+        }
+        return snapshot
+      },
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      waitForPasteRead: {
+        pastedText = pasteboard.string(forType: .string)
+      }
+    ))
+
+    let outcome = await service.insert("dictated text", into: makeTarget())
+
+    #expect(outcome == .inserted)
+    #expect(readCount.withLock { $0 } == 2)
+    #expect(pastedText == "dictated text")
+    #expect(pasteboard.string(forType: .string) == "second clipboard")
+  }
+
+  /// Verifies two unstable reads leave the latest clipboard value untouched.
+  @Test func changesDuringBothSnapshotReadsLeaveLatestClipboardUntouched() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("first clipboard", forType: .string)
+    let readCount = OSAllocatedUnfairLock(initialState: 0)
+    var postedPaste = false
+
+    nonisolated(unsafe) let backgroundPasteboard = pasteboard
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: {
+        let attempt = readCount.withLock { count in
+          count += 1
+          return count
+        }
+        let snapshot = TextInsertionService.snapshot(of: backgroundPasteboard)
+        backgroundPasteboard.clearContents()
+        backgroundPasteboard.setString(
+          attempt == 1 ? "second clipboard" : "third clipboard",
+          forType: .string
+        )
+        return snapshot
+      },
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+
+    let outcome = await service.insert("dictated text", into: makeTarget())
+
+    #expect(outcome == .unavailable)
+    #expect(readCount.withLock { $0 } == 2)
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "third clipboard")
+  }
+
+  /// Verifies a count change after acquisition prevents any staging or paste.
+  @Test func clipboardChangeAfterAcceptedSnapshotPreventsStaging() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var focusCheckCount = 0
+    var postedPaste = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in
+        focusCheckCount += 1
+        if focusCheckCount == 2 {
+          pasteboard.clearContents()
+          pasteboard.setString("new clipboard", forType: .string)
+        }
+        return true
+      },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+
+    let outcome = await service.insert("dictated text", into: makeTarget())
+
+    #expect(outcome == .unavailable)
+    #expect(focusCheckCount == 2)
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "new clipboard")
+  }
+
+  /// Verifies shortcut construction failure restores immediately and reports it.
+  @Test func failedPasteShortcutRestoresClipboardAndReportsUnavailable() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
     pasteboard.setString("previous clipboard", forType: .string)
     var waitedForPasteRead = false
+    var attemptedPaste = false
+    var stagedTextAtPasteAttempt: String?
 
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
@@ -154,17 +378,25 @@ struct TextInsertionServiceTests {
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
       isTargetFocused: { _ in true },
-      postPasteShortcut: { false },
+      postPasteShortcut: {
+        attemptedPaste = true
+        stagedTextAtPasteAttempt = pasteboard.string(forType: .string)
+        return false
+      },
       waitForPasteRead: {
         waitedForPasteRead = true
       }
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
-    #expect(pasteboard.string(forType: .string) == "dictated text")
+    #expect(outcome == .unavailable)
+    #expect(attemptedPaste)
+    #expect(stagedTextAtPasteAttempt == "dictated text")
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
     #expect(!waitedForPasteRead)
   }
 
+  /// Verifies an invalid initial target uses manual clipboard delivery.
   @Test func changedTargetReceivesNoPasteEvent() async {
     let pasteboard = makePasteboard()
     var postedPaste = false
@@ -182,13 +414,15 @@ struct TextInsertionServiceTests {
       },
       waitForPasteRead: {}
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
+    #expect(outcome == .copiedToClipboard)
     #expect(!postedPaste)
     #expect(pasteboard.string(forType: .string) == "dictated text")
   }
 
-  @Test func targetChangedWhileStagingReceivesNoPasteEvent() async {
+  /// Verifies focus loss during acquisition uses manual clipboard delivery.
+  @Test func targetChangedAfterSnapshotUsesCopyFallback() async {
     let pasteboard = makePasteboard()
     var focusCheckCount = 0
     var postedPaste = false
@@ -209,13 +443,15 @@ struct TextInsertionServiceTests {
       },
       waitForPasteRead: {}
     ))
-    await service.insert("dictated text", into: makeTarget())
+    let outcome = await service.insert("dictated text", into: makeTarget())
 
+    #expect(outcome == .copiedToClipboard)
     #expect(focusCheckCount == 2)
     #expect(!postedPaste)
     #expect(pasteboard.string(forType: .string) == "dictated text")
   }
 
+  /// Verifies an exited frontmost target uses the existing clipboard fallback.
   @Test func missingFocusedElementCapturesFrontmostApplication() async {
     let pasteboard = makePasteboard()
     let application = NSRunningApplication.current
@@ -237,11 +473,13 @@ struct TextInsertionServiceTests {
 
     let target = service.captureFocusedTarget()
     #expect(target != nil)
-    await service.insert("dictated text", into: target)
+    let outcome = await service.insert("dictated text", into: target)
     #expect(checkedProcessIdentifier == application.processIdentifier)
+    #expect(outcome == .copiedToClipboard)
   }
 
-  @Test nonisolated func blockedClipboardReadDoesNotFreezeInsertion() async {
+  /// Verifies a timed-out result stays unavailable after its reader releases the lease.
+  @Test nonisolated func timeoutRemainsUnavailableAfterReaderReturnsBeforeRouting() async {
     let pasteboard = NSPasteboard(
       name: NSPasteboard.Name(
         "TextInsertionServiceTests-\(UUID().uuidString)"
@@ -250,11 +488,157 @@ struct TextInsertionServiceTests {
     pasteboard.clearContents()
     pasteboard.setString("previous clipboard", forType: .string)
 
+    let eventWaitBudget = DispatchTimeInterval.seconds(2)
+    let blockingWaitBudget = DispatchTimeInterval.seconds(10)
+    let snapshotTimeout = Duration.milliseconds(25)
+    let readerStartedForBlocker = DispatchSemaphore(value: 0)
+    let readerStartedForTest = DispatchSemaphore(value: 0)
     let allowReaderToFinish = DispatchSemaphore(value: 0)
-    let readerReleaseState = OSAllocatedUnfairLock(initialState: false)
-    let observations = OSAllocatedUnfairLock(
-      initialState: InsertionObservations()
+    let mainActorBlocked = DispatchSemaphore(value: 0)
+    let allowMainActorToResume = DispatchSemaphore(value: 0)
+    let blockerFinished = DispatchSemaphore(value: 0)
+    let blockerScheduled = OSAllocatedUnfairLock(initialState: false)
+    let blockerObservedReaderStart = OSAllocatedUnfairLock(initialState: false)
+    let blockerReleasedByTest = OSAllocatedUnfairLock(initialState: false)
+    let readerReleasedByTest = OSAllocatedUnfairLock(initialState: false)
+    let insertionCompleted = OSAllocatedUnfairLock(initialState: false)
+    let postedPaste = OSAllocatedUnfairLock(initialState: false)
+    defer {
+      allowReaderToFinish.signal()
+      allowMainActorToResume.signal()
+    }
+
+    nonisolated(unsafe) let observedPasteboard = pasteboard
+    let service = await MainActor.run {
+      TextInsertionService(dependencies: .init(
+        pasteboard: observedPasteboard,
+        readClipboardItems: {
+          readerStartedForBlocker.signal()
+          readerStartedForTest.signal()
+          let releaseResult = allowReaderToFinish.wait(
+            timeout: .now() + blockingWaitBudget
+          )
+          readerReleasedByTest.withLock {
+            $0 = releaseResult == .success
+          }
+          guard releaseResult == .success else { return nil }
+          return TextInsertionService.snapshot(of: observedPasteboard)
+        },
+        snapshotTimeout: snapshotTimeout,
+        focusedElement: { nil },
+        frontmostApplication: { nil },
+        isProcessRunning: { _ in true },
+        isTargetFocused: { _ in
+          let shouldScheduleBlocker = blockerScheduled.withLock { scheduled in
+            guard !scheduled else { return false }
+            scheduled = true
+            return true
+          }
+          if shouldScheduleBlocker {
+            DispatchQueue.main.async {
+              let readerStartResult = readerStartedForBlocker.wait(
+                timeout: .now() + eventWaitBudget
+              )
+              blockerObservedReaderStart.withLock {
+                $0 = readerStartResult == .success
+              }
+              mainActorBlocked.signal()
+
+              if readerStartResult == .success {
+                let releaseResult = allowMainActorToResume.wait(
+                  timeout: .now() + blockingWaitBudget
+                )
+                blockerReleasedByTest.withLock {
+                  $0 = releaseResult == .success
+                }
+              }
+              blockerFinished.signal()
+            }
+          }
+          return true
+        },
+        postPasteShortcut: {
+          postedPaste.withLock { $0 = true }
+          return true
+        },
+        waitForPasteRead: {}
+      ))
+    }
+    let clipboardReaderQueue = await MainActor.run {
+      service.clipboardReaderQueue
+    }
+
+    let insertion = Task { @MainActor in
+      let outcome = await service.insert("dictated text", into: makeTarget())
+      insertionCompleted.withLock { $0 = true }
+      return outcome
+    }
+    #expect(
+      wait(
+        for: readerStartedForTest,
+        timeout: .now() + eventWaitBudget
+      ) == .success
     )
+    #expect(
+      wait(for: mainActorBlocked, timeout: .now() + eventWaitBudget) == .success
+    )
+    #expect(blockerObservedReaderStart.withLock { $0 })
+    #expect(!insertionCompleted.withLock { $0 })
+
+    let snapshotDeadlineElapsed = DispatchSemaphore(value: 0)
+    DispatchQueue.global(qos: .userInitiated).asyncAfter(
+      deadline: .now() + .milliseconds(30)
+    ) {
+      snapshotDeadlineElapsed.signal()
+    }
+    #expect(
+      wait(
+        for: snapshotDeadlineElapsed,
+        timeout: .now() + eventWaitBudget
+      ) == .success
+    )
+
+    allowReaderToFinish.signal()
+    let readerQueueDrained = DispatchSemaphore(value: 0)
+    clipboardReaderQueue.async(flags: .barrier) {
+      readerQueueDrained.signal()
+    }
+    #expect(
+      wait(for: readerQueueDrained, timeout: .now() + eventWaitBudget)
+        == .success
+    )
+    #expect(readerReleasedByTest.withLock { $0 })
+    #expect(!insertionCompleted.withLock { $0 })
+
+    allowMainActorToResume.signal()
+    #expect(
+      wait(for: blockerFinished, timeout: .now() + eventWaitBudget) == .success
+    )
+    #expect(blockerReleasedByTest.withLock { $0 })
+
+    let outcome = await insertion.value
+    #expect(outcome == .unavailable)
+    #expect(!postedPaste.withLock { $0 })
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  /// Verifies a live read lease skips concurrent work and permits later recovery.
+  @Test nonisolated func activeReadSkipsLaterInsertionImmediatelyAndRecovers() async {
+    let pasteboard = NSPasteboard(
+      name: NSPasteboard.Name(
+        "TextInsertionServiceTests-\(UUID().uuidString)"
+      )
+    )
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+
+    let readerStarted = DispatchSemaphore(value: 0)
+    let allowFirstReadToFinish = DispatchSemaphore(value: 0)
+    let readerReturned = DispatchSemaphore(value: 0)
+    let readerReleaseState = OSAllocatedUnfairLock(initialState: false)
+    let readCount = OSAllocatedUnfairLock(initialState: 0)
+    let postedPasteCount = OSAllocatedUnfairLock(initialState: 0)
+    let pastedTexts = OSAllocatedUnfairLock(initialState: [String]())
     let releaseReader: @Sendable () -> Void = {
       let shouldSignal = readerReleaseState.withLock { wasReleased in
         if wasReleased {
@@ -264,23 +648,31 @@ struct TextInsertionServiceTests {
         return true
       }
       if shouldSignal {
-        allowReaderToFinish.signal()
+        allowFirstReadToFinish.signal()
       }
     }
     defer {
       releaseReader()
     }
 
-    // This named pasteboard belongs only to this test. AppKit does not declare
-    // NSPasteboard Sendable even though the production read runs off-main.
     nonisolated(unsafe) let observedPasteboard = pasteboard
-    let insert: @MainActor @Sendable () async -> Void = {
-      let service = TextInsertionService(dependencies: .init(
+    let service = await MainActor.run {
+      TextInsertionService(dependencies: .init(
         pasteboard: observedPasteboard,
         readClipboardItems: {
-          observations.withLock { $0.readerStarted = true }
-          allowReaderToFinish.wait()
-          return []
+          let attempt = readCount.withLock { count in
+            count += 1
+            return count
+          }
+          if attempt == 1 {
+            readerStarted.signal()
+            allowFirstReadToFinish.wait()
+          }
+          let snapshot = TextInsertionService.snapshot(of: observedPasteboard)
+          if attempt == 1 {
+            readerReturned.signal()
+          }
+          return snapshot
         },
         snapshotTimeout: .milliseconds(100),
         focusedElement: { nil },
@@ -288,97 +680,53 @@ struct TextInsertionServiceTests {
         isProcessRunning: { _ in true },
         isTargetFocused: { _ in true },
         postPasteShortcut: {
-          observations.withLock { $0.postedPaste = true }
+          postedPasteCount.withLock { $0 += 1 }
           return true
         },
         waitForPasteRead: {
-          let text = observedPasteboard.string(forType: .string)
-          observations.withLock {
-            $0.textAvailableWhileTargetReads = text
+          if let text = observedPasteboard.string(forType: .string) {
+            pastedTexts.withLock { $0.append(text) }
           }
         }
       ))
-      await service.insert("dictated text", into: makeTarget())
+    }
+    let insert: @MainActor @Sendable (String) async
+      -> TextInsertionService.InsertionOutcome = { text in
+      await service.insert(text, into: makeTarget())
     }
 
-    let result = await withTaskGroup(of: InsertionRaceResult.self) { group in
-      group.addTask {
-        await insert()
-        return .insertionCompleted
-      }
-      group.addTask {
-        try? await Task.sleep(for: .seconds(2))
-        return .deadlineExpired
-      }
-
-      let firstResult = await group.next() ?? .deadlineExpired
-      if case .deadlineExpired = firstResult {
-        releaseReader()
-      }
-      group.cancelAll()
-      return firstResult
+    let firstInsertion = Task {
+      await insert("first dictated text")
     }
+    #expect(wait(for: readerStarted, timeout: .now() + 1) == .success)
 
-    let finalObservations = observations.withLock { $0 }
-    #expect(result == .insertionCompleted)
-    #expect(finalObservations.readerStarted)
-    #expect(finalObservations.postedPaste)
-    #expect(
-      finalObservations.textAvailableWhileTargetReads == "dictated text"
-    )
-    #expect(pasteboard.string(forType: .string) == "dictated text")
-  }
+    let busySkipStarted = ContinuousClock.now
+    let secondOutcome = await insert("second dictated text")
+    let busySkipDuration = busySkipStarted.duration(to: .now)
 
-  @Test func successfulSnapshotFollowsTimedOutRead() async {
-    let pasteboard = makePasteboard()
-    pasteboard.clearContents()
-    pasteboard.setString("previous clipboard", forType: .string)
+    #expect(secondOutcome == .unavailable)
+    #expect(busySkipDuration < .milliseconds(50))
+    #expect(readCount.withLock { $0 } == 1)
+    #expect(postedPasteCount.withLock { $0 } == 0)
+    #expect(pastedTexts.withLock { $0 }.isEmpty)
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
 
-    let allowFirstReadToFinish = DispatchSemaphore(value: 0)
-    let readCount = OSAllocatedUnfairLock(initialState: 0)
-    var pastedTexts: [String] = []
+    let firstOutcome = await firstInsertion.value
+    #expect(firstOutcome == .unavailable)
+    #expect(readCount.withLock { $0 } == 1)
+    #expect(postedPasteCount.withLock { $0 } == 0)
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
 
-    // This named pasteboard belongs only to this test. AppKit does not declare
-    // NSPasteboard Sendable even though the production read runs off-main.
-    nonisolated(unsafe) let backgroundPasteboard = pasteboard
-    let service = TextInsertionService(dependencies: .init(
-      pasteboard: pasteboard,
-      readClipboardItems: {
-        let attempt = readCount.withLock { count in
-          count += 1
-          return count
-        }
-        if attempt == 1 {
-          allowFirstReadToFinish.wait()
-        }
-        return TextInsertionService.snapshot(of: backgroundPasteboard)
-      },
-      snapshotTimeout: .milliseconds(100),
-      focusedElement: { nil },
-      frontmostApplication: { nil },
-      isProcessRunning: { _ in true },
-      isTargetFocused: { _ in true },
-      postPasteShortcut: { true },
-      waitForPasteRead: {
-        if let text = pasteboard.string(forType: .string) {
-          pastedTexts.append(text)
-        }
-      }
-    ))
+    releaseReader()
+    #expect(wait(for: readerReturned, timeout: .now() + 1) == .success)
+    try? await Task.sleep(for: .milliseconds(10))
+    let recoveryOutcome = await insert("third dictated text")
 
-    defer {
-      allowFirstReadToFinish.signal()
-    }
-
-    await service.insert("first dictated text", into: makeTarget())
-    #expect(pasteboard.string(forType: .string) == "first dictated text")
-
-    allowFirstReadToFinish.signal()
-    await service.insert("second dictated text", into: makeTarget())
-
+    #expect(recoveryOutcome == .inserted)
     #expect(readCount.withLock { $0 } == 2)
-    #expect(pastedTexts == ["first dictated text", "second dictated text"])
-    #expect(pasteboard.string(forType: .string) == "first dictated text")
+    #expect(postedPasteCount.withLock { $0 } == 1)
+    #expect(pastedTexts.withLock { $0 } == ["third dictated text"])
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
   }
 
   private func makePasteboard() -> NSPasteboard {
@@ -387,9 +735,30 @@ struct TextInsertionServiceTests {
     )
   }
 
+  /// Waits for a test-only semaphore without invoking its no-async API from
+  /// the surrounding asynchronous test body.
+  ///
+  /// - Parameters:
+  ///   - semaphore: The synchronization point to wait for.
+  ///   - timeout: The absolute deadline that bounds the test wait.
+  /// - Returns: Whether the semaphore was signaled before the deadline.
+  private nonisolated func wait(
+    for semaphore: DispatchSemaphore,
+    timeout: DispatchTime
+  ) -> DispatchTimeoutResult {
+    semaphore.wait(timeout: timeout)
+  }
+
+  /// Builds the same optional all-or-nothing snapshot closure used in production.
+  ///
+  /// The closure retains the named pasteboard for background use so tests keep
+  /// the production reader's isolation and lifetime semantics.
+  ///
+  /// - Parameter pasteboard: The test pasteboard captured by the reader.
+  /// - Returns: A Sendable closure that distinguishes failure from empty state.
   private nonisolated func makeClipboardReader(
     for pasteboard: NSPasteboard
-  ) -> @Sendable () -> [TextInsertionService.ClipboardItemSnapshot] {
+  ) -> @Sendable () -> [TextInsertionService.ClipboardItemSnapshot]? {
     // Named test pasteboards are isolated to one test, but AppKit does not
     // declare NSPasteboard Sendable for this background-capable API.
     nonisolated(unsafe) let backgroundPasteboard = pasteboard
@@ -407,4 +776,21 @@ struct TextInsertionServiceTests {
       displayID: nil
     )
   }
+}
+
+/// Advertises a type while withholding its data to model a partial AppKit read.
+private final class MissingPasteboardDataProvider:
+  NSObject,
+  NSPasteboardItemDataProvider {
+  /// Deliberately supplies no value for the requested representation.
+  ///
+  /// - Parameters:
+  ///   - pasteboard: The pasteboard requesting its promised data.
+  ///   - item: The item whose advertised representation is requested.
+  ///   - type: The advertised type for which this provider withholds data.
+  func pasteboard(
+    _ pasteboard: NSPasteboard?,
+    item: NSPasteboardItem,
+    provideDataForType type: NSPasteboard.PasteboardType
+  ) {}
 }

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -298,13 +298,7 @@ struct TextInsertionServiceTests {
           }
         }
       ))
-      let target = TextInsertionService.Target(
-        element: AXUIElementCreateSystemWide(),
-        processIdentifier: 42,
-        isSecure: false,
-        displayID: nil
-      )
-      await service.insert("dictated text", into: target)
+      await service.insert("dictated text", into: makeTarget())
     }
 
     let result = await withTaskGroup(of: InsertionRaceResult.self) { group in
@@ -335,6 +329,58 @@ struct TextInsertionServiceTests {
     #expect(pasteboard.string(forType: .string) == "dictated text")
   }
 
+  @Test func successfulSnapshotFollowsTimedOutRead() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+
+    let allowFirstReadToFinish = DispatchSemaphore(value: 0)
+    let readCount = OSAllocatedUnfairLock(initialState: 0)
+    var pastedTexts: [String] = []
+
+    // This named pasteboard belongs only to this test. AppKit does not declare
+    // NSPasteboard Sendable even though the production read runs off-main.
+    nonisolated(unsafe) let backgroundPasteboard = pasteboard
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: {
+        let attempt = readCount.withLock { count in
+          count += 1
+          return count
+        }
+        if attempt == 1 {
+          allowFirstReadToFinish.wait()
+        }
+        return TextInsertionService.snapshot(of: backgroundPasteboard)
+      },
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      waitForPasteRead: {
+        if let text = pasteboard.string(forType: .string) {
+          pastedTexts.append(text)
+        }
+      }
+    ))
+
+    defer {
+      allowFirstReadToFinish.signal()
+    }
+
+    await service.insert("first dictated text", into: makeTarget())
+    #expect(pasteboard.string(forType: .string) == "first dictated text")
+
+    allowFirstReadToFinish.signal()
+    await service.insert("second dictated text", into: makeTarget())
+
+    #expect(readCount.withLock { $0 } == 2)
+    #expect(pastedTexts == ["first dictated text", "second dictated text"])
+    #expect(pasteboard.string(forType: .string) == "first dictated text")
+  }
+
   private func makePasteboard() -> NSPasteboard {
     NSPasteboard(
       name: NSPasteboard.Name("TextInsertionServiceTests-\(UUID().uuidString)")
@@ -349,17 +395,7 @@ struct TextInsertionServiceTests {
     nonisolated(unsafe) let backgroundPasteboard = pasteboard
 
     return {
-      (backgroundPasteboard.pasteboardItems ?? []).map { sourceItem in
-        let entries = sourceItem.types.compactMap { type in
-          sourceItem.data(forType: type).map {
-            TextInsertionService.ClipboardItemSnapshot.Entry(
-              type: type,
-              data: $0
-            )
-          }
-        }
-        return TextInsertionService.ClipboardItemSnapshot(entries: entries)
-      }
+      TextInsertionService.snapshot(of: backgroundPasteboard)
     }
   }
 

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -1,10 +1,22 @@
 import AppKit
 import ApplicationServices
+import os
 import Testing
 @testable import Talkify
 
 @MainActor
 struct TextInsertionServiceTests {
+  private enum InsertionRaceResult: Sendable {
+    case insertionCompleted
+    case deadlineExpired
+  }
+
+  private struct InsertionObservations: Sendable {
+    var readerStarted = false
+    var postedPaste = false
+    var textAvailableWhileTargetReads: String?
+  }
+
   @Test func everyFocusedTargetUsesPasteInsertion() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
@@ -13,6 +25,8 @@ struct TextInsertionServiceTests {
 
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -28,6 +42,80 @@ struct TextInsertionServiceTests {
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
   }
 
+  @Test func fastSnapshotRestoresEveryClipboardTypeInOrder() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    let customType = NSPasteboard.PasteboardType(
+      "com.tgomareli.TalkifyTests.custom-data"
+    )
+    let previousString = "previous clipboard"
+    let previousStringData = Data(previousString.utf8)
+    let previousCustomData = Data([0x00, 0x2A, 0x7F, 0xFF])
+    let previousItem = NSPasteboardItem()
+    previousItem.setData(previousStringData, forType: .string)
+    previousItem.setData(previousCustomData, forType: customType)
+    pasteboard.writeObjects([previousItem])
+    var postedPaste = false
+    var textAvailableWhileTargetReads: String?
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {
+        textAvailableWhileTargetReads = pasteboard.string(forType: .string)
+      }
+    ))
+    await service.insert("dictated text", into: makeTarget())
+
+    let restoredItem = pasteboard.pasteboardItems?.first
+    #expect(postedPaste)
+    #expect(textAvailableWhileTargetReads == "dictated text")
+    #expect(pasteboard.pasteboardItems?.count == 1)
+    #expect(restoredItem?.types == [.string, customType])
+    #expect(restoredItem?.data(forType: .string) == previousStringData)
+    #expect(restoredItem?.data(forType: customType) == previousCustomData)
+    #expect(pasteboard.string(forType: .string) == previousString)
+  }
+
+  @Test func fastEmptySnapshotRestoresClipboardToEmpty() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    var postedPaste = false
+    var textAvailableWhileTargetReads: String?
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {
+        textAvailableWhileTargetReads = pasteboard.string(forType: .string)
+      }
+    ))
+    await service.insert("dictated text", into: makeTarget())
+
+    #expect(postedPaste)
+    #expect(textAvailableWhileTargetReads == "dictated text")
+    #expect((pasteboard.pasteboardItems ?? []).isEmpty)
+    #expect(pasteboard.string(forType: .string) == nil)
+  }
+
   @Test func clipboardChangeDuringPasteIsNeverOverwritten() async {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
@@ -35,6 +123,8 @@ struct TextInsertionServiceTests {
 
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -58,6 +148,8 @@ struct TextInsertionServiceTests {
 
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -78,6 +170,8 @@ struct TextInsertionServiceTests {
     var postedPaste = false
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -100,6 +194,8 @@ struct TextInsertionServiceTests {
     var postedPaste = false
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -126,6 +222,8 @@ struct TextInsertionServiceTests {
     var checkedProcessIdentifier: pid_t?
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
       focusedElement: { nil },
       frontmostApplication: { application },
       isProcessRunning: { processIdentifier in
@@ -143,10 +241,126 @@ struct TextInsertionServiceTests {
     #expect(checkedProcessIdentifier == application.processIdentifier)
   }
 
+  @Test nonisolated func blockedClipboardReadDoesNotFreezeInsertion() async {
+    let pasteboard = NSPasteboard(
+      name: NSPasteboard.Name(
+        "TextInsertionServiceTests-\(UUID().uuidString)"
+      )
+    )
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+
+    let allowReaderToFinish = DispatchSemaphore(value: 0)
+    let readerReleaseState = OSAllocatedUnfairLock(initialState: false)
+    let observations = OSAllocatedUnfairLock(
+      initialState: InsertionObservations()
+    )
+    let releaseReader: @Sendable () -> Void = {
+      let shouldSignal = readerReleaseState.withLock { wasReleased in
+        if wasReleased {
+          return false
+        }
+        wasReleased = true
+        return true
+      }
+      if shouldSignal {
+        allowReaderToFinish.signal()
+      }
+    }
+    defer {
+      releaseReader()
+    }
+
+    // This named pasteboard belongs only to this test. AppKit does not declare
+    // NSPasteboard Sendable even though the production read runs off-main.
+    nonisolated(unsafe) let observedPasteboard = pasteboard
+    let insert: @MainActor @Sendable () async -> Void = {
+      let service = TextInsertionService(dependencies: .init(
+        pasteboard: observedPasteboard,
+        readClipboardItems: {
+          observations.withLock { $0.readerStarted = true }
+          allowReaderToFinish.wait()
+          return []
+        },
+        snapshotTimeout: .milliseconds(100),
+        focusedElement: { nil },
+        frontmostApplication: { nil },
+        isProcessRunning: { _ in true },
+        isTargetFocused: { _ in true },
+        postPasteShortcut: {
+          observations.withLock { $0.postedPaste = true }
+          return true
+        },
+        waitForPasteRead: {
+          let text = observedPasteboard.string(forType: .string)
+          observations.withLock {
+            $0.textAvailableWhileTargetReads = text
+          }
+        }
+      ))
+      let target = TextInsertionService.Target(
+        element: AXUIElementCreateSystemWide(),
+        processIdentifier: 42,
+        isSecure: false,
+        displayID: nil
+      )
+      await service.insert("dictated text", into: target)
+    }
+
+    let result = await withTaskGroup(of: InsertionRaceResult.self) { group in
+      group.addTask {
+        await insert()
+        return .insertionCompleted
+      }
+      group.addTask {
+        try? await Task.sleep(for: .seconds(2))
+        return .deadlineExpired
+      }
+
+      let firstResult = await group.next() ?? .deadlineExpired
+      if case .deadlineExpired = firstResult {
+        releaseReader()
+      }
+      group.cancelAll()
+      return firstResult
+    }
+
+    let finalObservations = observations.withLock { $0 }
+    #expect(result == .insertionCompleted)
+    #expect(finalObservations.readerStarted)
+    #expect(finalObservations.postedPaste)
+    #expect(
+      finalObservations.textAvailableWhileTargetReads == "dictated text"
+    )
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
   private func makePasteboard() -> NSPasteboard {
     NSPasteboard(
       name: NSPasteboard.Name("TextInsertionServiceTests-\(UUID().uuidString)")
     )
+  }
+
+  private nonisolated func makeClipboardReader(
+    for pasteboard: NSPasteboard
+  ) -> @Sendable () -> [TextInsertionService.ClipboardItemSnapshot] {
+    // Named test pasteboards are isolated to one test, but AppKit does not
+    // declare NSPasteboard Sendable for this background-capable API.
+    nonisolated(unsafe) let backgroundPasteboard = pasteboard
+
+    return {
+      (backgroundPasteboard.pasteboardItems ?? []).map { sourceItem in
+        let entries = sourceItem.types.compactMap { type in
+          sourceItem.data(forType: type).map {
+            TextInsertionService.ClipboardItemSnapshot.Entry(
+              type: type,
+              data: $0
+            )
+          }
+        }
+        return TextInsertionService.ClipboardItemSnapshot(entries: entries)
+      }
+    }
   }
 
   private func makeTarget() -> TextInsertionService.Target {


### PR DESCRIPTION
Fixes https://github.com/tornikegomareli/Talkify/issues/41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard restoration after text insertion, preserving all clipboard item types and their order.
  * Ensured initially empty clipboards are restored correctly.
  * Prevented delayed clipboard reads from blocking text insertion.
  * Added safeguards for clipboard read timeouts, retries, and concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->