### PR TITLE
Handle missing microphone input without crashing

### DIFF
--- a/Talkify/Dictation/MicrophoneInput.swift
+++ b/Talkify/Dictation/MicrophoneInput.swift
@@ -79,6 +79,11 @@ final class MicrophoneInput: @unchecked Sendable {
 
   func start(outputFormat: AVAudioFormat) throws {
     let inputNode = audioEngine.inputNode
+    let hardwareFormat = inputNode.inputFormat(forBus: 0)
+    guard Self.hasUsableHardwareInput(hardwareFormat) else {
+      throw InputError.unavailable
+    }
+
     let inputFormat = inputNode.outputFormat(forBus: 0)
     guard inputFormat.channelCount > 0, inputFormat.sampleRate > 0 else {
       throw InputError.unavailable
@@ -107,6 +112,10 @@ final class MicrophoneInput: @unchecked Sendable {
       inputNode.removeTap(onBus: 0)
       throw error
     }
+  }
+
+  static func hasUsableHardwareInput(_ format: AVAudioFormat) -> Bool {
+    format.channelCount > 0 && format.sampleRate > 0
   }
 
   func stop() {

--- a/TalkifyTests/MicrophoneInputTests.swift
+++ b/TalkifyTests/MicrophoneInputTests.swift
@@ -1,0 +1,25 @@
+import AVFAudio
+import Testing
+@testable import Talkify
+
+struct MicrophoneInputTests {
+  @Test func rejectsMissingHardwareInput() throws {
+    let format = try #require(AVAudioFormat(
+      commonFormat: .pcmFormatFloat32,
+      sampleRate: 0,
+      channels: 0,
+      interleaved: false
+    ))
+
+    #expect(!MicrophoneInput.hasUsableHardwareInput(format))
+  }
+
+  @Test func acceptsAvailableHardwareInput() throws {
+    let format = try #require(AVAudioFormat(
+      standardFormatWithSampleRate: 48_000,
+      channels: 1
+    ))
+
+    #expect(MicrophoneInput.hasUsableHardwareInput(format))
+  }
+}


### PR DESCRIPTION
Talkify checked the input node's output format before installing its recording tap. With no default input device, that format still reports 2 channels at 44.1 kHz even though the hardware format is 0 channels at 0 Hz, so the guard passed and AVFAudio raised an uncaught exception.

This checks the hardware-side input format first and uses the existing `InputError.unavailable` path, so the HUD reports “No microphone input is available.” instead of the app aborting. Tests cover missing and valid hardware formats; the full macOS test suite passes with local signing disabled.
