### PR TITLE
Stop the HUD stuttering in and jolting out

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,6 +112,7 @@ _Avoid_: Transcript history, cloud analytics
 - HUD status and error messages dismiss themselves after about two seconds
 - The HUD writes nothing while it retracts and its bands do not resize: the shape leaves exactly as it stood, and its text and layout reset only once it is off screen
 - The wait between the last word and the recognized text is silent — no label stands in for it, and the voice visual comes to rest rather than reading the silence as a dead microphone
+- Compact opens with no text at all, because it is built around the live draft and a placeholder would be words nobody spoke
 - The HUD shows a live visual that reacts to microphone audio while listening
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,6 +113,7 @@ _Avoid_: Transcript history, cloud analytics
 - The HUD writes nothing while it retracts and its bands do not resize: the shape leaves exactly as it stood, and its text and layout reset only once it is off screen
 - The wait between the last word and the recognized text is silent — no label stands in for it, and the voice visual comes to rest rather than reading the silence as a dead microphone
 - Compact opens with no text at all, because it is built around the live draft and a placeholder would be words nobody spoke
+- The HUD's shaders and the particle cloud's compute kernels are compiled at launch, so the cost never lands on the first frames of a session
 - The HUD shows a live visual that reacts to microphone audio while listening
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,8 @@ _Avoid_: Transcript history, cloud analytics
 - If the HUD's display disconnects mid-session, the HUD moves to the pointer's display
 - The HUD is the only surface for dictation status and error messages
 - HUD status and error messages dismiss themselves after about two seconds
+- The HUD writes nothing while it retracts and its bands do not resize: the shape leaves exactly as it stood, and its text and layout reset only once it is off screen
+- The wait between the last word and the recognized text is silent — no label stands in for it, and the voice visual comes to rest rather than reading the silence as a dead microphone
 - The HUD shows a live visual that reacts to microphone audio while listening
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -72,6 +72,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       readAloudController?.toggle()
     }
 
+    // Compiles the HUD's shaders now, so the cost does not land on the first
+    // frames of the first dictation.
+    HUDShaderWarmUp.start()
+
     // Requests permissions and prepares the selected Speech Model
     // shortly after launch (CONTEXT.md).
     dictationController.start()

--- a/Talkify/HUD/DictationHUDController.swift
+++ b/Talkify/HUD/DictationHUDController.swift
@@ -43,7 +43,7 @@ final class DictationHUDController {
     renderedSettings = initialSettings
     sessionSettings = initialSettings
     sounds = DictationHUDSounds()
-    let placeholder = HUDScreenSnapshot(
+    let placeholderScreen = HUDScreenSnapshot(
       id: 0,
       frame: .zero,
       safeAreaTop: 0,
@@ -52,7 +52,7 @@ final class DictationHUDController {
     )
     hostingView = NSHostingView(
       rootView: DictationHUDShellView(
-        screen: placeholder,
+        screen: placeholderScreen,
         settings: initialSettings,
         content: content
       )
@@ -141,19 +141,34 @@ final class DictationHUDController {
     content.text = text
   }
 
+  /// Speech has stopped but the recognized text has not arrived yet.
+  ///
+  /// Nothing is written and nothing resizes. The watchdog stops, because the
+  /// silence that follows the last word is not a dead microphone, and the level
+  /// settles to zero so the visual comes to rest instead of freezing mid-wobble.
   func showFinalizing() {
     guard case .session = mode else { return }
-    stopVoiceVisual()
-    content.text = "Finalizing…"
+    micWatchdogTask?.cancel()
+    micWatchdogTask = nil
+    content.isAudioAlive = true
+    content.audioLevel = 0
   }
 
   func hide() {
     cancelMessageDismiss()
-    stopVoiceVisual()
     if case .session = mode {
       sounds.playEnd(using: sessionSettings.sounds)
     }
     mode = .hidden
+
+    // The shape retracts exactly as it stands. The visual stops reacting so a
+    // glow can play its drain, but the bands are pinned and the text is left
+    // alone: resizing or relabelling a shape that is already sliding away is
+    // the jolt this avoids.
+    micWatchdogTask?.cancel()
+    micWatchdogTask = nil
+    content.isDismissing = true
+    content.showsVoiceVisual = false
     content.isRevealed = false
 
     // Keep the panel front while the retract plays, then order out.
@@ -162,6 +177,10 @@ final class DictationHUDController {
       try? await Task.sleep(for: Self.dismissDuration)
       guard !Task.isCancelled, let self, case .hidden = mode else { return }
       panel.orderOut(nil)
+      // Only once it is off screen: clearing either of these earlier would
+      // show through the retract.
+      content.isDismissing = false
+      content.text = ""
     }
   }
 
@@ -208,6 +227,7 @@ final class DictationHUDController {
   /// watchdog: levels stopping for over 600ms while listening means the
   /// microphone is dead, which must look different from silence (CONTEXT.md).
   private func startVoiceVisual() {
+    content.isDismissing = false
     content.sessionEpoch += 1
     content.showsVoiceVisual = true
     content.audioLevel = 0

--- a/Talkify/HUD/DictationHUDController.swift
+++ b/Talkify/HUD/DictationHUDController.swift
@@ -120,12 +120,13 @@ final class DictationHUDController {
     mode = .session
     startVoiceVisual()
     sessionIsLatched = isLatched
-    present(isLatched ? Self.latchedText : Self.listeningText, on: screen)
+    present(placeholder, on: screen)
   }
 
   func showLatched() {
     guard case .session = mode else { return }
-    content.text = Self.latchedText
+    sessionIsLatched = true
+    content.text = placeholder
   }
 
   /// A session waiting on its language model. The band says what it is waiting
@@ -133,7 +134,21 @@ final class DictationHUDController {
   /// restores whatever the session was saying before.
   func showModelDownload(_ text: String?) {
     guard case .session = mode else { return }
-    content.text = text ?? (sessionIsLatched ? Self.latchedText : Self.listeningText)
+    content.text = text ?? placeholder
+  }
+
+  /// Exposed so the placeholder rules can be asserted without a window.
+  var textForTesting: String { content.text }
+
+  /// What the band says before any words arrive.
+  ///
+  /// Empty for Compact: it is the one visual built around the live draft, so a
+  /// placeholder there is words nobody spoke. Every path that would write one
+  /// asks here, rather than each deciding for itself — which is how "Listening
+  /// (latched)" kept coming back after the opening text was handled.
+  private var placeholder: String {
+    guard sessionSettings.voiceVisual != .compact else { return "" }
+    return sessionIsLatched ? Self.latchedText : Self.listeningText
   }
 
   func showLiveText(_ text: String) {

--- a/Talkify/HUD/Shell/DictationHUDContent.swift
+++ b/Talkify/HUD/Shell/DictationHUDContent.swift
@@ -23,6 +23,11 @@ final class DictationHUDContent {
   /// language is set up. Recognition in the wrong language returns confident
   /// nonsense rather than an error, so a two-key setup says which is live.
   var languageTag: String?
+  /// True from the moment the HUD starts retracting until it is off screen.
+  /// The layout is pinned to whatever it was showing: the voice visual stops
+  /// reacting so a glow can drain, but the bands must not resize underneath a
+  /// shape that is already sliding away.
+  var isDismissing = false
   /// Bumped once per session start; one-shot effects (the ripple) trigger
   /// on the change rather than on the listening state, so they never
   /// re-fire mid-session.

--- a/Talkify/HUD/Shell/DictationHUDShellView.swift
+++ b/Talkify/HUD/Shell/DictationHUDShellView.swift
@@ -65,7 +65,7 @@ struct DictationHUDShellView: View {
   /// waveform compresses to the slim strip so strip + wrapped text still
   /// fit the fixed window.
   private var visualBandHeight: CGFloat {
-    guard content.showsVoiceVisual else { return 0 }
+    guard keepsVisualLayout else { return 0 }
     if reduceMotion { return metrics.visualBandHeight }
     // Compact has no band of its own: its indicator lives inside the
     // text band, beside the draft.
@@ -77,8 +77,14 @@ struct DictationHUDShellView: View {
   /// listening; Compact is built around it. With Reduce Motion the draft
   /// text always shows.
   private var showsTextBand: Bool {
-    if !content.showsVoiceVisual || reduceMotion { return true }
+    if !keepsVisualLayout || reduceMotion { return true }
     return settings.voiceVisual == .compact
+  }
+
+  /// Whether the bands stay as a listening session laid them out. Held through
+  /// the retract so the shape never resizes while it is sliding away.
+  private var keepsVisualLayout: Bool {
+    content.showsVoiceVisual || content.isDismissing
   }
 
   /// Whether the text band renders the Compact layout: the voice indicator

--- a/Talkify/HUD/Visuals/HUDParticleCloudView.swift
+++ b/Talkify/HUD/Visuals/HUDParticleCloudView.swift
@@ -171,15 +171,29 @@ final class ParticleRenderer: NSObject {
     let particleBuffer: MTLBuffer
   }
 
+  /// Built once for the process rather than per renderer. Compiling the two
+  /// compute kernels costs real milliseconds, and it used to land on the first
+  /// frame of a session — every session, since the renderer is remade each time
+  /// the visual appears. Only one HUD exists at a time, so one particle buffer
+  /// is enough.
+  private static let sharedDevice = MTLCreateSystemDefaultDevice()
+  private static let sharedPipeline: Pipeline? = sharedDevice.flatMap { makePipeline(device: $0) }
+
+  /// Touches the shared pipeline so the kernels compile before a session wants
+  /// them.
+  static func warmUp() {
+    _ = sharedPipeline
+  }
+
   override init() {
-    device = MTLCreateSystemDefaultDevice()
-    pipeline = device.flatMap(Self.makePipeline)
+    device = Self.sharedDevice
+    pipeline = Self.sharedPipeline
     super.init()
   }
 
   /// Fail soft: a missing pipeline draws nothing instead of crashing a
   /// menu-bar app over a decorative effect.
-  private static func makePipeline(device: MTLDevice) -> Pipeline? {
+  nonisolated private static func makePipeline(device: MTLDevice) -> Pipeline? {
     guard
       let commandQueue = device.makeCommandQueue(),
       let library = try? device.makeDefaultLibrary(bundle: .main),

--- a/Talkify/HUD/Visuals/HUDShaderWarmUp.swift
+++ b/Talkify/HUD/Visuals/HUDShaderWarmUp.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Compiles the HUD's Metal shaders before a session needs them.
+///
+/// SwiftUI compiles a shader the first time it is drawn, and that lands on the
+/// first frames of a dictation — exactly when the HUD is descending and the
+/// visual is ramping in, so the whole reveal stutters. Doing it at launch moves
+/// the cost somewhere nobody is looking.
+///
+/// The arguments are placeholders: what is compiled is the function, and the
+/// values it happens to be handed here never reach a screen.
+enum HUDShaderWarmUp {
+  static let shaders: [(Shader, Shader.UsageType)] = [
+    (
+      ShaderLibrary.edgeGlow(.float2(CGPoint.zero), .float2(CGSize(width: 1, height: 1)), .float(0), .float(0)),
+      .colorEffect
+    ),
+    (
+      ShaderLibrary.waveformSheen(.float2(CGSize(width: 1, height: 1)), .float(0), .float(0)),
+      .layerEffect
+    ),
+    (
+      ShaderLibrary.ripple(
+        .float2(CGPoint.zero), .float(0), .float(3), .float(6), .float(6), .float(1200)
+      ),
+      .layerEffect
+    ),
+  ]
+
+  /// Exposed so a test can prove every name and argument list still matches
+  /// the Metal source.
+  static var shadersForTesting: [(Shader, Shader.UsageType)] { shaders }
+
+  /// Fire and forget. A failure here costs nothing but the stutter this exists
+  /// to avoid, so it is never surfaced.
+  @MainActor
+  static func start() {
+    // The particle cloud is its own Metal pipeline rather than a SwiftUI
+    // shader, and its two compute kernels compile the same way.
+    ParticleRenderer.warmUp()
+
+    Task.detached(priority: .utility) {
+      for (shader, usage) in shaders {
+        try? await shader.compile(as: usage)
+      }
+    }
+  }
+}

--- a/TalkifyTests/HUDPlaceholderTests.swift
+++ b/TalkifyTests/HUDPlaceholderTests.swift
@@ -1,0 +1,73 @@
+import Testing
+
+@testable import Talkify
+
+/// Compact is built around the live draft, so it opens with nothing. Three
+/// separate paths write the placeholder — opening, latching, and coming back
+/// from a model download — and fixing only the first left "Listening (latched)"
+/// still appearing.
+@MainActor
+@Suite("HUD placeholder text")
+struct HUDPlaceholderTests {
+  private func controller(_ visual: HUDVoiceVisualStyle) -> DictationHUDController {
+    let store = AppSettings.previewStore()
+    store.voiceVisual = visual
+    return DictationHUDController(settings: store)
+  }
+
+  private func session(_ store: AppSettings) -> DictationSessionSettings {
+    store.sessionSettings
+  }
+
+  @Test func compactOpensWithNoText() {
+    let store = AppSettings.previewStore()
+    store.voiceVisual = .compact
+    let hud = DictationHUDController(settings: store)
+
+    hud.showListening(on: nil, isLatched: false, settings: session(store))
+    #expect(hud.textForTesting.isEmpty)
+
+    hud.showLatched()
+    #expect(hud.textForTesting.isEmpty)
+
+    hud.showModelDownload(nil)
+    #expect(hud.textForTesting.isEmpty)
+  }
+
+  /// A latched Compact session still says nothing, which is the case that was
+  /// reported after the opening text was already handled.
+  @Test func compactLatchesWithNoText() {
+    let store = AppSettings.previewStore()
+    store.voiceVisual = .compact
+    let hud = DictationHUDController(settings: store)
+
+    hud.showListening(on: nil, isLatched: true, settings: session(store))
+    #expect(hud.textForTesting.isEmpty)
+  }
+
+  /// The other visuals replace the draft while listening, so their band is the
+  /// only place a session can say what it is doing.
+  @Test(arguments: [HUDVoiceVisualStyle.waveform, .glow])
+  func theOtherVisualsStillSayWhatTheyAreDoing(visual: HUDVoiceVisualStyle) {
+    let store = AppSettings.previewStore()
+    store.voiceVisual = visual
+    let hud = DictationHUDController(settings: store)
+
+    hud.showListening(on: nil, isLatched: false, settings: session(store))
+    #expect(hud.textForTesting == "Listening…")
+
+    hud.showLatched()
+    #expect(hud.textForTesting == "Listening (latched)")
+  }
+
+  /// A real draft always shows, whichever visual is selected.
+  @Test func aLiveDraftIsNeverSuppressed() {
+    let store = AppSettings.previewStore()
+    store.voiceVisual = .compact
+    let hud = DictationHUDController(settings: store)
+
+    hud.showListening(on: nil, isLatched: false, settings: session(store))
+    hud.showLiveText("hello there")
+    #expect(hud.textForTesting == "hello there")
+  }
+}

--- a/TalkifyTests/HUDShaderWarmUpTests.swift
+++ b/TalkifyTests/HUDShaderWarmUpTests.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import Testing
+
+@testable import Talkify
+
+/// The warm-up names shader functions and their argument lists by hand. If a
+/// name or an argument count drifts from the Metal source, `compile` throws —
+/// which is the whole point of asserting it here rather than discovering a
+/// silent no-op that leaves the stutter in place.
+@Suite("Shader warm-up")
+struct HUDShaderWarmUpTests {
+  @Test func everyHUDShaderCompiles() async throws {
+    for (shader, usage) in HUDShaderWarmUp.shadersForTesting {
+      try await shader.compile(as: usage)
+    }
+  }
+}


### PR DESCRIPTION
Four things people notice while dictating, three of which had one cause.

The shape morphed on its way out. Finalizing stopped the voice visual, and that same flag drives the layout, so the 64-point visual band collapsed and a 36-point text band opened, both spring animated, before the retract had even started. The HUD shrank, wrote "Finalizing…", and only then slid away. The wait between the last word and the recognized text is silent now, the watchdog stops because the silence after a sentence is not a dead microphone, and on dismissal the layout is pinned until the panel is off screen — a glow still plays its drain, but the bands cannot move underneath a shape that is already sliding away.

Compact opened with "Listening…" in the band. It is the one visual built around the live draft, so that is a placeholder standing in for words nobody spoke. Three separate paths wrote it and each decided for itself, which is why silencing the opening text left a quick tap putting "Listening (latched)" straight back.

The shaders compiled on first draw, which is the first frames of the first dictation — exactly when the HUD is descending and the visual is ramping in. They are compiled at launch now. The particle cloud was worse than a first-run cost: its two compute kernels were built per renderer, and SwiftUI remakes the renderer every time the visual appears, so that was paid on every Edge Glow session rather than once.

Four commits, one per fix, each building and passing on its own.