### PR TITLE
Keep the drop target open while the pointer is still on it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -243,6 +243,7 @@ _Avoid_: Transcript history, cloud analytics
 - Personal Voice requires the user's authorization, requested from the Read Aloud section; it is personal, non-commercial use by Apple's terms
 - Read Aloud uses Apple speech synthesis exclusively; local-inference voice models were researched and rejected to keep the app dependency-free — the project stays open source and integrations are left to contributors
 - Dragging a file toward the top edge of a display reveals the **Drop Target**, and the HUD opens as the pointer approaches the notch
+- An open **Drop Target** holds until the drag leaves the shape it opened into, not the narrower band that opened it, and it never falls back to a peek: collapsing while the pointer is still on the target reads as the target refusing the drop
 - The **Drop Target** appears only for a file the system reports as audio or video, so no list of file extensions is maintained
 - The **Drop Transcription** surfaces take their accent from the selected voice visual: Edge Glow lends its palette — its gradient on the target's edge, its one representative hue everywhere else — and every other visual keeps the Talkify blue
 - The status item ghost fills in that same accent while a **Drop Transcription** runs, so the HUD and the menu bar are never two different colors

--- a/Talkify/DropTranscription/DragWatcher.swift
+++ b/Talkify/DropTranscription/DragWatcher.swift
@@ -74,7 +74,7 @@ final class DragWatcher {
 
     let point = NSEvent.mouseLocation
     let frame = Self.screenFrame(containing: point)
-    let next = DropZone.at(point, in: frame)
+    let next = DropZone.next(after: zone, at: point, in: frame)
     guard next != zone else { return }
     zone = next
     onZoneChange?(next, draggedURL)

--- a/Talkify/DropTranscription/DropZone.swift
+++ b/Talkify/DropTranscription/DropZone.swift
@@ -22,13 +22,36 @@ enum DropZone: Equatable {
   static let openHeight: CGFloat = 64
   static let openReach: CGFloat = 260
 
+  /// How far the pointer may go before an open target gives up, measured the
+  /// same way.
+  ///
+  /// Deliberately much larger than the band that opens it, and for a concrete
+  /// reason: the band is a narrow strip near the notch, but what it opens is a
+  /// shape roughly 110 points deep and up to 540 wide. Judging both with one
+  /// number meant the target closed while the pointer was still on the shape it
+  /// had just opened — a small move mid-drag and the HUD vanished. These cover
+  /// the opened shape at full HUD size, plus margin so resting on its edge does
+  /// not flicker.
+  static let holdHeight: CGFloat = 170
+  static let holdReach: CGFloat = 330
+
+  /// The zone after moving to `point`, given where the drag already was.
+  ///
+  /// The gesture is progressive on the way in and sticky once it lands: an
+  /// open target holds until the pointer is clear of the shape, and it never
+  /// falls back to a peek. Collapsing to a hint while the user is still over
+  /// the thing they are aiming at reads as the target refusing them.
+  ///
   /// `point` and `frame` are both in AppKit screen coordinates, whose origin
   /// is the bottom-left of the main display, so the top edge is `maxY`.
-  static func at(_ point: CGPoint, in frame: CGRect) -> DropZone {
+  static func next(after current: DropZone, at point: CGPoint, in frame: CGRect) -> DropZone {
     let depth = frame.maxY - point.y
     let offset = abs(point.x - frame.midX)
     guard depth >= 0 else { return .outside }
 
+    if current == .open {
+      return depth <= holdHeight && offset <= holdReach ? .open : .outside
+    }
     if depth <= openHeight, offset <= openReach { return .open }
     if depth <= peekHeight, offset <= peekReach { return .peek }
     return .outside

--- a/TalkifyTests/DropTranscriptionTests.swift
+++ b/TalkifyTests/DropTranscriptionTests.swift
@@ -138,37 +138,62 @@ struct DropZoneTests {
   }
 
   @Test func rightAtTheNotchIsOpen() {
-    #expect(DropZone.at(point(depth: 4), in: screen) == .open)
-    #expect(DropZone.at(point(depth: 60, offset: 200), in: screen) == .open)
+    #expect(DropZone.next(after: .outside, at: point(depth: 4), in: screen) == .open)
+    #expect(DropZone.next(after: .outside, at: point(depth: 60, offset: 200), in: screen) == .open)
   }
 
   @Test func approachingFromBelowPeeksFirst() {
-    #expect(DropZone.at(point(depth: 100), in: screen) == .peek)
-    #expect(DropZone.at(point(depth: 130, offset: 400), in: screen) == .peek)
+    #expect(DropZone.next(after: .outside, at: point(depth: 100), in: screen) == .peek)
+    #expect(DropZone.next(after: .outside, at: point(depth: 130, offset: 400), in: screen) == .peek)
   }
 
   @Test func theMiddleOfTheScreenIsOutside() {
-    #expect(DropZone.at(point(depth: 500), in: screen) == .outside)
+    #expect(DropZone.next(after: .outside, at: point(depth: 500), in: screen) == .outside)
   }
 
   /// Wide of the notch but still near the top: the catch area is generous
   /// vertically and bounded horizontally, so dragging to a menu-bar item on
   /// the far right never arms the HUD.
   @Test func theFarEdgesOfTheMenuBarAreOutside() {
-    #expect(DropZone.at(point(depth: 10, offset: 700), in: screen) == .outside)
-    #expect(DropZone.at(point(depth: 10, offset: -700), in: screen) == .outside)
+    #expect(DropZone.next(after: .outside, at: point(depth: 10, offset: 700), in: screen) == .outside)
+    #expect(DropZone.next(after: .outside, at: point(depth: 10, offset: -700), in: screen) == .outside)
   }
 
   /// Directly under the notch but too far down to receive: it hints, it does
   /// not take the drop.
   @Test func justBelowTheOpenBandOnlyPeeks() {
-    #expect(DropZone.at(point(depth: DropZone.openHeight + 1), in: screen) == .peek)
+    #expect(DropZone.next(after: .outside, at: point(depth: DropZone.openHeight + 1), in: screen) == .peek)
   }
 
   /// A pointer above the top edge happens on a display whose frame sits below
   /// another one; it is not this display's business.
   @Test func aboveTheTopEdgeIsOutside() {
-    #expect(DropZone.at(point(depth: -5), in: screen) == .outside)
+    #expect(DropZone.next(after: .outside, at: point(depth: -5), in: screen) == .outside)
+  }
+
+  /// The bug this hysteresis exists for: the band that opens the target is a
+  /// narrow strip, but the shape it opens is far bigger, so judging both with
+  /// one number closed the target while the pointer was still on it.
+  @Test func anOpenTargetHoldsWhileThePointerIsStillOnTheShape() {
+    for depth in [70.0, 110.0, 165.0] {
+      #expect(DropZone.next(after: .open, at: point(depth: depth), in: screen) == .open)
+    }
+    #expect(DropZone.next(after: .open, at: point(depth: 60, offset: 300), in: screen) == .open)
+  }
+
+  /// It gives up only once the pointer is genuinely clear of the shape, and
+  /// it goes straight out rather than back to a hint: collapsing while the
+  /// user is still aiming at it reads as the target refusing them.
+  @Test func anOpenTargetLetsGoOnlyWhenTheDragLeaves() {
+    #expect(DropZone.next(after: .open, at: point(depth: 200), in: screen) == .outside)
+    #expect(DropZone.next(after: .open, at: point(depth: 60, offset: 400), in: screen) == .outside)
+  }
+
+  /// A peek is still free to grow into the target or fall away; only the open
+  /// state is sticky.
+  @Test func aPeekStillProgresses() {
+    #expect(DropZone.next(after: .peek, at: point(depth: 10), in: screen) == .open)
+    #expect(DropZone.next(after: .peek, at: point(depth: 300), in: screen) == .outside)
   }
 }
 


### PR DESCRIPTION
Moving the pointer a little mid-drag made the HUD vanish. The zone that decides
whether the target is open was judged with one set of numbers for entering and
leaving, but the band that opens the target is a narrow strip near the notch
while the shape it opens is around 110 points deep and up to 540 wide. Anywhere
on the lower half of that shape read as outside the band, so the target closed
under a drag that was still aimed at it.