### PR TITLE
[FIX] Wait for an in-flight finish before shutting speech down

### DIFF
--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -24,7 +24,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
  
  
 
+  /// True while this process hosts the test suite rather than a user.
+  ///
+  /// The live launch path requests microphone and speech permissions and
+  /// installs the event tap, which pops system permission dialogs over every
+  /// automated test run on a machine that has not granted them. Hosting
+  /// tests skips the launch entirely: tests build the objects they exercise,
+  /// and a test that means to see a permission prompt drives
+  /// PermissionService itself, on purpose.
+  private static var isHostingTests: Bool {
+    let environment = ProcessInfo.processInfo.environment
+    return environment["XCTestSessionIdentifier"] != nil
+      || environment["XCTestConfigurationFilePath"] != nil
+      || environment["XCTestBundlePath"] != nil
+  }
+
   func applicationDidFinishLaunching(_ notification: Notification) {
+    guard !Self.isHostingTests else { return }
     let settings = AppSettings()
     self.settings = settings
     // One shape, two features. The stage owns the window and hands it out;

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -1,0 +1,122 @@
+import AppKit
+
+/// Injectable speech, insertion, permission, HUD, and usage boundaries for
+/// Direct Dictation, following the TextInsertionService.Dependencies
+/// template: a struct of closures with a live default, so the controller's
+/// begin guards, outcome routing, and cancellation races can run against
+/// fakes instead of a live microphone, Accessibility, and pasteboard.
+extension DirectDictationController {
+  struct Dependencies {
+    // Speech recognition, wrapping the SpeechRecognitionService actor.
+    let setDownloadHandler: @Sendable (
+      @escaping @Sendable (SpeechRecognitionService.ModelDownload) -> Void
+    ) async -> Void
+    let resolveLocale: @Sendable (String?) async throws -> Locale
+    let supportedLocale: @Sendable (String) async -> Locale?
+    let retainOnly: @Sendable ([Locale]) async -> Void
+    let prewarm: @Sendable (Locale) async throws -> Void
+    let startRecognition: @Sendable (
+      Locale,
+      _ updateHandler: @escaping @Sendable (SpeechRecognitionService.Update) -> Void,
+      _ failureHandler: @escaping @Sendable (String) -> Void,
+      _ levelHandler: @escaping @Sendable (Float) -> Void
+    ) async throws -> Void
+    let finishRecognition: @Sendable () async throws -> String
+    let cancelRecognition: @Sendable () async -> Void
+    let shutDownRecognition: @Sendable () async -> Void
+
+    // Text insertion.
+    let captureFocusedTarget: @MainActor () -> TextInsertionService.Target?
+    let insertText: @MainActor (
+      String, TextInsertionService.Target?
+    ) async -> TextInsertionService.InsertionOutcome
+
+    // Permissions and the dialogs that explain them.
+    let requestMicrophoneAccess: @Sendable () async -> Bool
+    let requestSpeechAccess: @Sendable () async -> Bool
+    let requestAccessibilityAccess: @MainActor () -> Void
+    let hasAccessibilityAccess: @MainActor () -> Bool
+    let isPermissionAlertPresenting: @MainActor () -> Bool
+    let showAccessibilitySetupAlert: @MainActor () -> Void
+    let showRelaunchAlert: @MainActor () -> Void
+
+    // The HUD surface dictation drives.
+    let showListening: @MainActor (
+      _ displayID: CGDirectDisplayID?,
+      _ isLatched: Bool,
+      _ settings: DictationSessionSettings,
+      _ languageTag: String?
+    ) -> Void
+    let showLatched: @MainActor () -> Void
+    let showLiveText: @MainActor (String) -> Void
+    let showFinalizing: @MainActor () -> Void
+    let showMessage: @MainActor (String, CGDirectDisplayID?) -> Void
+    let showModelDownload: @MainActor (String?) -> Void
+    let showAudioLevel: @MainActor (Float) -> Void
+    let hideHUD: @MainActor () -> Void
+    let playPasteSound: @MainActor () -> Void
+
+    // Usage aggregation.
+    let recordSession: @MainActor (
+      _ wordCount: Int, _ speakingDuration: TimeInterval
+    ) async -> Void
+
+    /// Builds the production boundaries around the live services the
+    /// controller previously constructed itself.
+    @MainActor
+    static func live(
+      hudController: DictationHUDController,
+      usageTracker: UsageTracker
+    ) -> Self {
+      let speechService = SpeechRecognitionService()
+      let textInsertionService = TextInsertionService()
+
+      return Self(
+        setDownloadHandler: { await speechService.setDownloadHandler($0) },
+        resolveLocale: { try await speechService.resolveLocale(identifier: $0) },
+        supportedLocale: { await speechService.supportedLocale(identifier: $0) },
+        retainOnly: { await speechService.retainOnly(locales: $0) },
+        prewarm: { try await speechService.prewarm(locale: $0) },
+        startRecognition: { locale, updateHandler, failureHandler, levelHandler in
+          try await speechService.start(
+            locale: locale,
+            updateHandler: updateHandler,
+            failureHandler: failureHandler,
+            levelHandler: levelHandler
+          )
+        },
+        finishRecognition: { try await speechService.finish() },
+        cancelRecognition: { await speechService.cancel() },
+        shutDownRecognition: { await speechService.shutDown() },
+        captureFocusedTarget: { textInsertionService.captureFocusedTarget() },
+        insertText: { await textInsertionService.insert($0, into: $1) },
+        requestMicrophoneAccess: { await PermissionService.requestMicrophoneAccess() },
+        requestSpeechAccess: { await PermissionService.requestSpeechAccess() },
+        requestAccessibilityAccess: { PermissionService.requestAccessibilityAccess() },
+        hasAccessibilityAccess: { PermissionService.hasAccessibilityAccess },
+        isPermissionAlertPresenting: { PermissionAlert.isPresenting },
+        showAccessibilitySetupAlert: { PermissionAlert.requestAccessibilitySetup() },
+        showRelaunchAlert: { PermissionAlert.requestRelaunch() },
+        showListening: { displayID, isLatched, settings, languageTag in
+          hudController.showListening(
+            on: displayID,
+            isLatched: isLatched,
+            settings: settings,
+            languageTag: languageTag
+          )
+        },
+        showLatched: { hudController.showLatched() },
+        showLiveText: { hudController.showLiveText($0) },
+        showFinalizing: { hudController.showFinalizing() },
+        showMessage: { hudController.showMessage($0, on: $1) },
+        showModelDownload: { hudController.showModelDownload($0) },
+        showAudioLevel: { hudController.showAudioLevel($0) },
+        hideHUD: { hudController.hide() },
+        playPasteSound: { hudController.playPasteSound() },
+        recordSession: {
+          await usageTracker.recordSession(wordCount: $0, speakingDuration: $1)
+        }
+      )
+    }
+  }
+}

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -21,10 +21,7 @@ final class DirectDictationController {
   private static let noSpeechTimeout = Duration.seconds(15)
 
   private let settings: AppSettings
-  private let speechService = SpeechRecognitionService()
-  private let hudController: DictationHUDController
-  private let textInsertionService = TextInsertionService()
-  private let usageTracker: UsageTracker
+  private let dependencies: Dependencies
 
   private var keyEventMonitor: GlobalKeyEventMonitor?
   private var machine = DictationSessionMachine()
@@ -44,14 +41,20 @@ final class DirectDictationController {
   /// the language of the key that started it even if Settings change.
   private var activeSlot: GlobalKeyEventMonitor.TriggerSlot = .primary
 
-  init(
+  convenience init(
     settings: AppSettings,
     hudController: DictationHUDController,
     usageTracker: UsageTracker
   ) {
+    self.init(
+      settings: settings,
+      dependencies: .live(hudController: hudController, usageTracker: usageTracker)
+    )
+  }
+
+  init(settings: AppSettings, dependencies: Dependencies) {
     self.settings = settings
-    self.hudController = hudController
-    self.usageTracker = usageTracker
+    self.dependencies = dependencies
     keyEventMonitor = GlobalKeyEventMonitor { [weak self] event in
       Task { @MainActor [weak self] in
         self?.handle(event)
@@ -74,8 +77,8 @@ final class DirectDictationController {
       }
     }
 
-    Task { [speechService] in
-      await speechService.setDownloadHandler(handler)
+    Task { [dependencies] in
+      await dependencies.setDownloadHandler(handler)
     }
   }
 
@@ -86,11 +89,11 @@ final class DirectDictationController {
     guard machine.isSessionActive, locale(for: activeSlot) == download.locale else { return }
 
     guard let fraction = download.fraction else {
-      hudController.showModelDownload(nil)
+      dependencies.showModelDownload(nil)
       return
     }
     let name = SpeechLanguageCatalog.shortName(for: download.locale)
-    hudController.showModelDownload(
+    dependencies.showModelDownload(
       "Downloading \(name)… \(Int(fraction * 100))%"
     )
   }
@@ -129,8 +132,8 @@ final class DirectDictationController {
   /// the primary language. The second warms behind it and never throws: a
   /// model that still needs downloading must not delay the primary key.
   private func prepareLanguages() async throws {
-    let primary = try await speechService.resolveLocale(
-      identifier: settings.recognitionLocaleIdentifier
+    let primary = try await dependencies.resolveLocale(
+      settings.recognitionLocaleIdentifier
     )
     primaryLocale = primary
 
@@ -139,19 +142,19 @@ final class DirectDictationController {
     // would dictate in a language the user never chose.
     var secondary: Locale?
     if settings.isSecondLanguageEnabled {
-      secondary = await speechService.supportedLocale(
-        identifier: settings.secondaryRecognitionLocaleIdentifier
+      secondary = await dependencies.supportedLocale(
+        settings.secondaryRecognitionLocaleIdentifier
       )
     }
     // A second language equal to the first is not a second language.
     secondaryLocale = secondary == primary ? nil : secondary
 
     let bound = [primary, secondaryLocale].compactMap(\.self)
-    await speechService.retainOnly(locales: bound)
-    try await speechService.prewarm(locale: primary)
+    await dependencies.retainOnly(bound)
+    try await dependencies.prewarm(primary)
 
     if let secondaryLocale {
-      try? await speechService.prewarm(locale: secondaryLocale)
+      try? await dependencies.prewarm(secondaryLocale)
     }
   }
 
@@ -177,8 +180,8 @@ final class DirectDictationController {
     keyEventMonitor?.stop()
     isPrepared = false
 
-    Task {
-      await speechService.shutDown()
+    Task { [dependencies] in
+      await dependencies.shutDownRecognition()
     }
   }
 
@@ -198,14 +201,14 @@ final class DirectDictationController {
     permissionTask = Task { [weak self] in
       guard let self else { return }
 
-      let microphoneGranted = await PermissionService.requestMicrophoneAccess()
+      let microphoneGranted = await dependencies.requestMicrophoneAccess()
       guard !Task.isCancelled else { return }
       guard microphoneGranted else {
         preparationFailed(message: "Microphone permission required")
         return
       }
 
-      let speechGranted = await PermissionService.requestSpeechAccess()
+      let speechGranted = await dependencies.requestSpeechAccess()
       guard !Task.isCancelled else { return }
       guard speechGranted else {
         preparationFailed(message: "Speech permission required")
@@ -214,7 +217,7 @@ final class DirectDictationController {
 
       // Ask for one privacy permission at a time. Requesting Accessibility
       // beside the microphone prompt makes macOS stack or suppress dialogs.
-      PermissionService.requestAccessibilityAccess()
+      dependencies.requestAccessibilityAccess()
 
       do {
         try await prepareLanguages()
@@ -244,21 +247,25 @@ final class DirectDictationController {
         try? await Task.sleep(for: .seconds(1))
         guard !Task.isCancelled, let self else { return }
         // Never interrupt the dialog the user is reading.
-        guard !PermissionAlert.isPresenting else { continue }
-        guard PermissionService.hasAccessibilityAccess else { continue }
+        guard !dependencies.isPermissionAlertPresenting() else { continue }
+        guard dependencies.hasAccessibilityAccess() else { continue }
 
         permissionWatchTask = nil
         if keyEventMonitor?.start() == true {
-          hudController.showMessage("Talkify is ready")
+          dependencies.showMessage("Talkify is ready", nil)
         } else {
-          PermissionAlert.requestRelaunch()
+          dependencies.showRelaunchAlert()
         }
         return
       }
     }
   }
 
-  private func handle(_ event: GlobalKeyEventMonitor.Event) {
+  /// The machine's current state, so tests can pin transitions the
+  /// controller's effects produce.
+  var sessionStateForTesting: DictationSessionMachine.State { machine.state }
+
+  func handle(_ event: GlobalKeyEventMonitor.Event) {
     switch event {
     case let .triggerPressed(slot):
       // While a session runs, only the key that started it controls it. The
@@ -301,7 +308,7 @@ final class DirectDictationController {
     case .cancelRecognition:
       Task { [weak self] in
         guard let self else { return }
-        await speechService.cancel()
+        await dependencies.cancelRecognition()
         send(.sessionEnded)
       }
     case .cancelStartTask:
@@ -315,22 +322,22 @@ final class DirectDictationController {
     case let .showListening(latched):
       let session = settings.sessionSettings
       currentSessionSettings = session
-      hudController.showListening(
-        on: focusedTarget?.displayID,
-        isLatched: latched,
-        settings: session,
-        languageTag: activeLanguageTag
+      dependencies.showListening(
+        focusedTarget?.displayID,
+        latched,
+        session,
+        activeLanguageTag
       )
     case .showLatched:
-      hudController.showLatched()
+      dependencies.showLatched()
     case .showLiveText:
       if let pendingLiveText {
-        hudController.showLiveText(pendingLiveText)
+        dependencies.showLiveText(pendingLiveText)
       }
     case .showFinalizing:
-      hudController.showFinalizing()
+      dependencies.showFinalizing()
     case .hideHUD:
-      hudController.hide()
+      dependencies.hideHUD()
     case let .notifyRecording(isRecording):
       if !isRecording {
         focusedTarget = nil
@@ -349,22 +356,22 @@ final class DirectDictationController {
 
   private func checkAndBegin() {
     guard isPrepared else {
-      hudController.showMessage(preparationFailureMessage ?? "Preparing speech…")
+      dependencies.showMessage(preparationFailureMessage ?? "Preparing speech…", nil)
       send(.beginRejected)
       return
     }
 
-    if !PermissionService.hasAccessibilityAccess {
+    if !dependencies.hasAccessibilityAccess() {
       // One dialog that explains it, not the system prompt again on every press.
-      PermissionAlert.requestAccessibilitySetup()
+      dependencies.showAccessibilitySetupAlert()
       startPermissionWatch()
       send(.beginRejected)
       return
     }
 
-    let target = textInsertionService.captureFocusedTarget()
+    let target = dependencies.captureFocusedTarget()
     if target?.isSecure == true {
-      hudController.showMessage("Secure field", on: target?.displayID)
+      dependencies.showMessage("Secure field", target?.displayID)
       send(.beginRejected)
       return
     }
@@ -382,26 +389,26 @@ final class DirectDictationController {
     sessionStartTask = Task { [weak self] in
       guard let self else { return }
       do {
-        try await speechService.start(
-          locale: locale,
-          updateHandler: { [weak self] update in
+        try await dependencies.startRecognition(
+          locale,
+          { [weak self] update in
             Task { @MainActor [weak self] in
               self?.receive(update)
             }
           },
-          failureHandler: { [weak self] message in
+          { [weak self] message in
             Task { @MainActor [weak self] in
               self?.fail(message: message, wasCancelled: false)
             }
           },
-          levelHandler: { [weak self] level in
+          { [weak self] level in
             Task { @MainActor [weak self] in
-              self?.hudController.showAudioLevel(level)
+              self?.dependencies.showAudioLevel(level)
             }
           }
         )
         guard !Task.isCancelled else {
-          await speechService.cancel()
+          await dependencies.cancelRecognition()
           send(.sessionEnded)
           return
         }
@@ -435,21 +442,18 @@ final class DirectDictationController {
     Task { [weak self] in
       guard let self else { return }
       do {
-        let text = try await speechService.finish()
-        hudController.hide()
-        let outcome = await textInsertionService.insert(text, into: focusedTarget)
+        let text = try await dependencies.finishRecognition()
+        dependencies.hideHUD()
+        let outcome = await dependencies.insertText(text, focusedTarget)
         switch outcome {
         case .inserted, .copiedToClipboard:
-          hudController.playPasteSound()
+          dependencies.playPasteSound()
           send(.sessionEnded)
           let wordCount = UsageMetrics.wordCount(in: text)
-          await usageTracker.recordSession(
-            wordCount: wordCount,
-            speakingDuration: speakingDuration
-          )
+          await dependencies.recordSession(wordCount, speakingDuration)
         case .unavailable:
           send(.sessionEnded)
-          hudController.showMessage("Couldn't insert text")
+          dependencies.showMessage("Couldn't insert text", nil)
         }
       } catch {
         fail(message: error.localizedDescription, wasCancelled: false)
@@ -470,9 +474,9 @@ final class DirectDictationController {
       }
       Task { [weak self] in
         guard let self else { return }
-        await speechService.cancel()
+        await dependencies.cancelRecognition()
         send(.sessionEnded)
-        hudController.showMessage(message)
+        dependencies.showMessage(message, nil)
       }
     } else {
       perform(effects)
@@ -494,8 +498,8 @@ final class DirectDictationController {
   }
 
   private func installTriggerMonitor() {
-    guard PermissionService.hasAccessibilityAccess else {
-      PermissionService.requestAccessibilityAccess()
+    guard dependencies.hasAccessibilityAccess() else {
+      dependencies.requestAccessibilityAccess()
       startPermissionWatch()
       return
     }
@@ -504,13 +508,13 @@ final class DirectDictationController {
     // the tap can still be refused. Only a fresh launch clears that, and saying
     // so is the whole point of the dialog.
     guard keyEventMonitor?.start() == true else {
-      PermissionAlert.requestRelaunch()
+      dependencies.showRelaunchAlert()
       return
     }
   }
 
   private func preparationFailed(message: String) {
     preparationFailureMessage = message
-    hudController.showMessage(message)
+    dependencies.showMessage(message, nil)
   }
 }

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -30,6 +30,9 @@ final class DirectDictationController {
   private var permissionTask: Task<Void, Never>?
   private var permissionWatchTask: Task<Void, Never>?
   private var sessionStartTask: Task<Void, Never>?
+  /// The finish in flight, carrying the session's last words to insertion.
+  /// Tracked so teardown can wait for it instead of racing it.
+  private var finishTask: Task<Void, Never>?
   private var isPrepared = false
   private var preparationFailureMessage: String?
   private var currentSessionSettings: DictationSessionSettings?
@@ -180,7 +183,13 @@ final class DirectDictationController {
     keyEventMonitor?.stop()
     isPrepared = false
 
-    Task { [dependencies] in
+    // A finish still in flight holds the user's last words. Shutting the
+    // speech service down beside it would cancel the very session the finish
+    // is reading, and whichever task the scheduler ran first would decide
+    // whether that text was inserted or dropped. Waiting first makes the
+    // order a rule instead of a race.
+    Task { [dependencies, finishTask] in
+      await finishTask?.value
       await dependencies.shutDownRecognition()
     }
   }
@@ -439,7 +448,7 @@ final class DirectDictationController {
   ///
   /// - Parameter speakingDuration: The completed session's measured speech time.
   private func finishRecognition(speakingDuration: TimeInterval) {
-    Task { [weak self] in
+    finishTask = Task { [weak self] in
       guard let self else { return }
       do {
         let text = try await dependencies.finishRecognition()
@@ -458,6 +467,7 @@ final class DirectDictationController {
       } catch {
         fail(message: error.localizedDescription, wasCancelled: false)
       }
+      finishTask = nil
     }
   }
 

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -57,6 +57,7 @@ struct DirectDictationControllerTests {
       = { DirectDictationControllerTests.makeTarget() },
     startRecognitionBody: (@Sendable (Locale) async throws -> Void)? = nil,
     finishRecognition: @escaping @Sendable () async throws -> String = { "" },
+    shutDownRecognition: @escaping @Sendable () async -> Void = {},
     insertOutcome: TextInsertionService.InsertionOutcome = .inserted
   ) -> DirectDictationController.Dependencies {
     DirectDictationController.Dependencies(
@@ -71,7 +72,7 @@ struct DirectDictationControllerTests {
       },
       finishRecognition: finishRecognition,
       cancelRecognition: { cancelCount.withLock { $0 += 1 } },
-      shutDownRecognition: {},
+      shutDownRecognition: shutDownRecognition,
       captureFocusedTarget: captureFocusedTarget,
       insertText: { text, _ in
         recorder.events.append("insertText")
@@ -414,5 +415,48 @@ struct DirectDictationControllerTests {
     #expect(recorder.insertedTexts == [""])
     #expect(recorder.recordedSessions.first?.wordCount == 0)
     controller.stop()
+  }
+
+  /// stop() during an in-flight finish must wait for the finish before
+  /// shutting the speech service down: shutting down beside it made a
+  /// scheduler race decide whether the last words were inserted or dropped.
+  @Test func stopDuringFinishInsertsTheTextBeforeShutDown() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let order = OSAllocatedUnfairLock<[String]>(initialState: [])
+    let finishEntered = OSAllocatedUnfairLock(initialState: false)
+    let finishReleased = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: {
+          finishEntered.withLock { $0 = true }
+          while !finishReleased.withLock({ $0 }) {
+            try await Task.sleep(for: .milliseconds(5))
+          }
+          order.withLock { $0.append("finish") }
+          return "held words"
+        },
+        shutDownRecognition: { order.withLock { $0.append("shutDown") } }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    controller.toggleFromMenu()
+    await waitUntil("Finish never began") { finishEntered.withLock { $0 } }
+
+    controller.stop()
+    finishReleased.withLock { $0 = true }
+    await waitUntil("Shut down never ran") {
+      order.withLock { $0.contains("shutDown") }
+    }
+
+    #expect(recorder.insertedTexts == ["held words"])
+    #expect(order.withLock { $0 } == ["finish", "shutDown"])
   }
 }

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -1,0 +1,418 @@
+import Foundation
+import os
+import Testing
+@testable import Talkify
+
+/// Pins the controller's impure half through its Dependencies seam: the
+/// begin guards, the finish outcome routing, and the cancellation races
+/// that the pure machine tests cannot reach.
+@MainActor
+struct DirectDictationControllerTests {
+  /// Every MainActor boundary call the controller makes, in order, plus
+  /// the arguments the routing decisions carry.
+  @MainActor
+  private final class Recorder {
+    var events: [String] = []
+    var messages: [String] = []
+    var listeningLatched: [Bool] = []
+    var insertedTexts: [String] = []
+    var recordedSessions: [(wordCount: Int, speakingDuration: TimeInterval)] = []
+    var accessibilityAlerts = 0
+
+    func count(of event: String) -> Int {
+      events.filter { $0 == event }.count
+    }
+  }
+
+  private struct FinishError: LocalizedError {
+    var errorDescription: String? { "finish failed" }
+  }
+
+  private func freshDefaults() -> UserDefaults {
+    let name = "DirectDictationControllerTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
+  }
+
+  private static func makeTarget(isSecure: Bool = false) -> TextInsertionService.Target {
+    TextInsertionService.Target(
+      element: nil,
+      processIdentifier: 1,
+      isSecure: isSecure,
+      displayID: nil
+    )
+  }
+
+  /// Builds fake dependencies around the recorder. The Sendable speech
+  /// closures report through lock-guarded counters because they cannot
+  /// touch the MainActor recorder synchronously.
+  private func makeDependencies(
+    recorder: Recorder,
+    prewarmed: OSAllocatedUnfairLock<Bool> = .init(initialState: false),
+    startEntries: OSAllocatedUnfairLock<Int> = .init(initialState: 0),
+    cancelCount: OSAllocatedUnfairLock<Int> = .init(initialState: 0),
+    hasAccessibilityAccess: @escaping @MainActor () -> Bool = { true },
+    captureFocusedTarget: @escaping @MainActor () -> TextInsertionService.Target?
+      = { DirectDictationControllerTests.makeTarget() },
+    startRecognitionBody: (@Sendable (Locale) async throws -> Void)? = nil,
+    finishRecognition: @escaping @Sendable () async throws -> String = { "" },
+    insertOutcome: TextInsertionService.InsertionOutcome = .inserted
+  ) -> DirectDictationController.Dependencies {
+    DirectDictationController.Dependencies(
+      setDownloadHandler: { _ in },
+      resolveLocale: { _ in Locale(identifier: "en_US") },
+      supportedLocale: { _ in nil },
+      retainOnly: { _ in },
+      prewarm: { _ in prewarmed.withLock { $0 = true } },
+      startRecognition: { locale, _, _, _ in
+        startEntries.withLock { $0 += 1 }
+        try await startRecognitionBody?(locale)
+      },
+      finishRecognition: finishRecognition,
+      cancelRecognition: { cancelCount.withLock { $0 += 1 } },
+      shutDownRecognition: {},
+      captureFocusedTarget: captureFocusedTarget,
+      insertText: { text, _ in
+        recorder.events.append("insertText")
+        recorder.insertedTexts.append(text)
+        return insertOutcome
+      },
+      requestMicrophoneAccess: { true },
+      requestSpeechAccess: { true },
+      requestAccessibilityAccess: {},
+      hasAccessibilityAccess: hasAccessibilityAccess,
+      isPermissionAlertPresenting: { false },
+      showAccessibilitySetupAlert: {
+        recorder.events.append("showAccessibilitySetupAlert")
+        recorder.accessibilityAlerts += 1
+      },
+      showRelaunchAlert: { recorder.events.append("showRelaunchAlert") },
+      showListening: { _, isLatched, _, _ in
+        recorder.events.append("showListening")
+        recorder.listeningLatched.append(isLatched)
+      },
+      showLatched: { recorder.events.append("showLatched") },
+      showLiveText: { _ in recorder.events.append("showLiveText") },
+      showFinalizing: { recorder.events.append("showFinalizing") },
+      showMessage: { message, _ in
+        recorder.events.append("showMessage")
+        recorder.messages.append(message)
+      },
+      showModelDownload: { _ in },
+      showAudioLevel: { _ in },
+      hideHUD: { recorder.events.append("hideHUD") },
+      playPasteSound: { recorder.events.append("playPasteSound") },
+      recordSession: { wordCount, speakingDuration in
+        recorder.events.append("recordSession")
+        recorder.recordedSessions.append((wordCount, speakingDuration))
+      }
+    )
+  }
+
+  private func makeController(
+    dependencies: DirectDictationController.Dependencies
+  ) -> DirectDictationController {
+    DirectDictationController(
+      settings: AppSettings(defaults: freshDefaults()),
+      dependencies: dependencies
+    )
+  }
+
+  /// Polls the condition until it holds, or records a failure after ~1 s.
+  /// The sleeps yield the main actor so the controller's tasks can run.
+  private func waitUntil(
+    _ comment: Comment,
+    _ condition: @MainActor () -> Bool
+  ) async {
+    for _ in 0..<200 {
+      if condition() { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+    Issue.record(comment)
+  }
+
+  /// Prepares the controller through applyLanguages, then lets the
+  /// preparation task run to completion past the prewarm it signals.
+  private func prepare(
+    _ controller: DirectDictationController,
+    prewarmed: OSAllocatedUnfairLock<Bool>
+  ) async {
+    controller.applyLanguages()
+    await waitUntil("Preparation never reached prewarm") {
+      prewarmed.withLock { $0 }
+    }
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+
+  @Test func triggerBeforePreparationShowsPreparingAndStaysIdle() {
+    let recorder = Recorder()
+    let startEntries = OSAllocatedUnfairLock(initialState: 0)
+    let controller = makeController(
+      dependencies: makeDependencies(recorder: recorder, startEntries: startEntries)
+    )
+
+    controller.handle(.triggerPressed(.primary))
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.messages == ["Preparing speech…"])
+    #expect(startEntries.withLock { $0 } == 0)
+  }
+
+  @Test func missingAccessibilityAccessShowsSetupAlertAndStaysIdle() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        hasAccessibilityAccess: { false }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.accessibilityAlerts == 1)
+    controller.stop()
+  }
+
+  @Test func secureFocusedFieldShowsSecureFieldAndStaysIdle() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        captureFocusedTarget: { Self.makeTarget(isSecure: true) }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.messages == ["Secure field"])
+    controller.stop()
+  }
+
+  @Test func approvedMenuToggleBeginsALatchedRecording() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(recorder: recorder, prewarmed: prewarmed)
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    #expect(recorder.listeningLatched == [true])
+    controller.stop()
+  }
+
+  @Test func insertedFinishPlaysPasteSoundAndRecordsUsage() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "hello world" }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Usage was never recorded") {
+      recorder.recordedSessions.count == 1
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.insertedTexts == ["hello world"])
+    #expect(recorder.recordedSessions.first?.wordCount == 2)
+    #expect((recorder.recordedSessions.first?.speakingDuration ?? -1) >= 0)
+    let hideIndex = recorder.events.firstIndex(of: "hideHUD")
+    let soundIndex = recorder.events.firstIndex(of: "playPasteSound")
+    #expect(hideIndex != nil && soundIndex != nil)
+    if let hideIndex, let soundIndex {
+      #expect(hideIndex < soundIndex)
+    }
+    controller.stop()
+  }
+
+  @Test func clipboardFallbackStillPlaysPasteSoundAndRecordsUsage() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "hello world" },
+        insertOutcome: .copiedToClipboard
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Usage was never recorded") {
+      recorder.recordedSessions.count == 1
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.count(of: "playPasteSound") == 1)
+    controller.stop()
+  }
+
+  @Test func unavailableInsertionShowsMessageWithoutSoundOrUsage() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "hello world" },
+        insertOutcome: .unavailable
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Insertion failure message never shown") {
+      recorder.messages.contains("Couldn't insert text")
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.count(of: "playPasteSound") == 0)
+    #expect(recorder.recordedSessions.isEmpty)
+    controller.stop()
+  }
+
+  @Test func finishFailureShowsTheErrorAndInsertsNothing() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { throw FinishError() }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Finish failure message never shown") {
+      recorder.messages.contains("finish failed")
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.insertedTexts.isEmpty)
+    controller.stop()
+  }
+
+  @Test func escapeWhileStartingHidesTheHUDAndInsertsNothing() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let startEntries = OSAllocatedUnfairLock(initialState: 0)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        startEntries: startEntries,
+        startRecognitionBody: { _ in
+          // Held open until the controller cancels the start task; the
+          // CancellationError propagates as the torn-down start.
+          try await Task.sleep(for: .seconds(10))
+        }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Recognition start was never entered") {
+      startEntries.withLock { $0 } >= 1
+    }
+    controller.handle(.cancelPressed)
+    await waitUntil("Cancelled start never reset to idle") {
+      controller.sessionStateForTesting == .idle
+    }
+
+    #expect(recorder.count(of: "hideHUD") == 1)
+    #expect(recorder.insertedTexts.isEmpty)
+    controller.stop()
+  }
+
+  @Test func escapeWhileRecordingCancelsRecognitionAndHidesTheHUD() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let cancelCount = OSAllocatedUnfairLock(initialState: 0)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        cancelCount: cancelCount
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.handle(.cancelPressed)
+    await waitUntil("Cancelled recording never reset to idle") {
+      controller.sessionStateForTesting == .idle
+    }
+
+    #expect(cancelCount.withLock { $0 } >= 1)
+    #expect(recorder.count(of: "hideHUD") == 1)
+    #expect(recorder.insertedTexts.isEmpty)
+    controller.stop()
+  }
+
+  @Test func emptyFinishTextStillRecordsAZeroWordSession() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "" }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Usage was never recorded") {
+      recorder.recordedSessions.count == 1
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.insertedTexts == [""])
+    #expect(recorder.recordedSessions.first?.wordCount == 0)
+    controller.stop()
+  }
+}


### PR DESCRIPTION
Stacked on #64.

finishRecognition's task was never stored, and stop() fired shutDown() unawaited beside it, so app teardown during finalization let the scheduler decide whether the user's last words were inserted or dropped. The finish task is now tracked, and stop() awaits it before shutting the speech service down, making the order a rule instead of a race. The regression test fails deterministically on the old code. Written with Claude Code under my direction and reviewed line by line; the full suite, including that regression test, is green at this commit on an Apple Silicon Mac running macOS 26.

Closes #59
