### PR TITLE
[FEATURE] Let the user choose where finished dictation text goes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -131,7 +131,7 @@ _Avoid_: Transcript history, cloud analytics
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation
 - Settings changes update the Appearance preview immediately, while an active Direct Dictation session keeps the choices captured at session start
-- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, and sound volume
+- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, sound volume, and insertion destination
 - A third voice visual, Compact, shows a small five-bar voice indicator beside the leading-aligned live draft inside the shape, after the iOS Dynamic Island caption look; the shape grows with the draft
 - Compact is the only visual that shows the live draft while listening; Waveform and Edge Glow replace the draft text entirely
 - An In the Shape live-draft placement for Waveform and Edge Glow was prototyped and removed; the draft-in-shape presentation belongs to Compact alone
@@ -197,6 +197,10 @@ _Avoid_: Transcript history, cloud analytics
 - If **Direct Dictation** hears no speech in the first 15 seconds, it closes and inserts nothing
 - Once speech has arrived, the session stays open until the user ends or cancels it
 - **Direct Dictation** ends by inserting text into the previously focused control
+- An insertion destination setting offers three deliveries: insert into the app, copy to the clipboard, or both
+- The default insertion destination inserts into the previously focused control exactly as before the setting existed
+- The clipboard-only destination skips the paste and the clipboard restore; the insert-and-copy destination pastes and leaves the text on the clipboard, skipping the restore
+- The insertion destination is captured in the Dictation session settings snapshot at session start
 - **Direct Dictation** inserts through clipboard paste after Accessibility validates the original target
 - If an app exposes no focused element, Talkify captures and later validates the frontmost application instead
 - Talkify sends the paste event globally only after the captured focus boundary passes validation

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -24,7 +24,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
  
  
 
+  /// True while this process hosts the test suite rather than a user.
+  ///
+  /// The live launch path requests microphone and speech permissions and
+  /// installs the event tap, which pops system permission dialogs over every
+  /// automated test run on a machine that has not granted them. Hosting
+  /// tests skips the launch entirely: tests build the objects they exercise,
+  /// and a test that means to see a permission prompt drives
+  /// PermissionService itself, on purpose.
+  private static var isHostingTests: Bool {
+    let environment = ProcessInfo.processInfo.environment
+    return environment["XCTestSessionIdentifier"] != nil
+      || environment["XCTestConfigurationFilePath"] != nil
+      || environment["XCTestBundlePath"] != nil
+  }
+
   func applicationDidFinishLaunching(_ notification: Notification) {
+    guard !Self.isHostingTests else { return }
     let settings = AppSettings()
     self.settings = settings
     // One shape, two features. The stage owns the window and hands it out;

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -31,6 +31,7 @@ final class AppSettings {
     static let secondaryTriggerBinding = "dictationTriggerBindingSecondary"
     static let transcriptDestination = "transcriptDestination"
     static let transcriptFolder = "transcriptFolder"
+    static let insertionDestination = "dictationInsertionDestination"
   }
 
   @ObservationIgnored
@@ -63,6 +64,12 @@ final class AppSettings {
 
   var transcriptFolder: URL? {
     didSet { defaults.set(transcriptFolder?.path(percentEncoded: false), forKey: Keys.transcriptFolder) }
+  }
+
+  /// Where a finished Direct Dictation session's text goes: the paste that
+  /// always happened, the clipboard alone, or both.
+  var insertionDestination: InsertionDestination {
+    didSet { defaults.set(insertionDestination.rawValue, forKey: Keys.insertionDestination) }
   }
 
   var voiceVisual: HUDVoiceVisualStyle {
@@ -179,6 +186,7 @@ final class AppSettings {
     storedDictationSoundVolume = DictationSoundSettings.normalizedVolume(storedSoundVolume)
     transcriptDestination = Self.stored(in: defaults, key: Keys.transcriptDestination) ?? .besideSource
     transcriptFolder = (defaults.string(forKey: Keys.transcriptFolder)).map { URL(filePath: $0) }
+    insertionDestination = Self.stored(in: defaults, key: Keys.insertionDestination) ?? .insert
     voiceVisual = Self.stored(in: defaults, key: Keys.voiceVisual) ?? .waveform
     waveformStyle = Self.stored(in: defaults, key: Keys.waveformStyle) ?? .chartLine
     revealStyle = Self.stored(in: defaults, key: Keys.revealStyle) ?? .slide
@@ -226,6 +234,7 @@ final class AppSettings {
 /// this value until its end and paste sounds have played.
 struct DictationSessionSettings: Equatable {
   let sounds: DictationSoundSettings
+  let insertionDestination: InsertionDestination
   let voiceVisual: HUDVoiceVisualStyle
   let waveformStyle: HUDWaveformStyle
   let revealStyle: HUDRevealStyle
@@ -249,6 +258,7 @@ struct DictationSessionSettings: Equatable {
       isEnabled: settings.dictationSoundsEnabled,
       volume: settings.dictationSoundVolume
     )
+    insertionDestination = settings.insertionDestination
     voiceVisual = settings.voiceVisual
     waveformStyle = settings.waveformStyle
     revealStyle = settings.revealStyle

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -1,0 +1,122 @@
+import AppKit
+
+/// Injectable speech, insertion, permission, HUD, and usage boundaries for
+/// Direct Dictation, following the TextInsertionService.Dependencies
+/// template: a struct of closures with a live default, so the controller's
+/// begin guards, outcome routing, and cancellation races can run against
+/// fakes instead of a live microphone, Accessibility, and pasteboard.
+extension DirectDictationController {
+  struct Dependencies {
+    // Speech recognition, wrapping the SpeechRecognitionService actor.
+    let setDownloadHandler: @Sendable (
+      @escaping @Sendable (SpeechRecognitionService.ModelDownload) -> Void
+    ) async -> Void
+    let resolveLocale: @Sendable (String?) async throws -> Locale
+    let supportedLocale: @Sendable (String) async -> Locale?
+    let retainOnly: @Sendable ([Locale]) async -> Void
+    let prewarm: @Sendable (Locale) async throws -> Void
+    let startRecognition: @Sendable (
+      Locale,
+      _ updateHandler: @escaping @Sendable (SpeechRecognitionService.Update) -> Void,
+      _ failureHandler: @escaping @Sendable (String) -> Void,
+      _ levelHandler: @escaping @Sendable (Float) -> Void
+    ) async throws -> Void
+    let finishRecognition: @Sendable () async throws -> String
+    let cancelRecognition: @Sendable () async -> Void
+    let shutDownRecognition: @Sendable () async -> Void
+
+    // Text insertion.
+    let captureFocusedTarget: @MainActor () -> TextInsertionService.Target?
+    let insertText: @MainActor (
+      String, TextInsertionService.Target?
+    ) async -> TextInsertionService.InsertionOutcome
+
+    // Permissions and the dialogs that explain them.
+    let requestMicrophoneAccess: @Sendable () async -> Bool
+    let requestSpeechAccess: @Sendable () async -> Bool
+    let requestAccessibilityAccess: @MainActor () -> Void
+    let hasAccessibilityAccess: @MainActor () -> Bool
+    let isPermissionAlertPresenting: @MainActor () -> Bool
+    let showAccessibilitySetupAlert: @MainActor () -> Void
+    let showRelaunchAlert: @MainActor () -> Void
+
+    // The HUD surface dictation drives.
+    let showListening: @MainActor (
+      _ displayID: CGDirectDisplayID?,
+      _ isLatched: Bool,
+      _ settings: DictationSessionSettings,
+      _ languageTag: String?
+    ) -> Void
+    let showLatched: @MainActor () -> Void
+    let showLiveText: @MainActor (String) -> Void
+    let showFinalizing: @MainActor () -> Void
+    let showMessage: @MainActor (String, CGDirectDisplayID?) -> Void
+    let showModelDownload: @MainActor (String?) -> Void
+    let showAudioLevel: @MainActor (Float) -> Void
+    let hideHUD: @MainActor () -> Void
+    let playPasteSound: @MainActor () -> Void
+
+    // Usage aggregation.
+    let recordSession: @MainActor (
+      _ wordCount: Int, _ speakingDuration: TimeInterval
+    ) async -> Void
+
+    /// Builds the production boundaries around the live services the
+    /// controller previously constructed itself.
+    @MainActor
+    static func live(
+      hudController: DictationHUDController,
+      usageTracker: UsageTracker
+    ) -> Self {
+      let speechService = SpeechRecognitionService()
+      let textInsertionService = TextInsertionService()
+
+      return Self(
+        setDownloadHandler: { await speechService.setDownloadHandler($0) },
+        resolveLocale: { try await speechService.resolveLocale(identifier: $0) },
+        supportedLocale: { await speechService.supportedLocale(identifier: $0) },
+        retainOnly: { await speechService.retainOnly(locales: $0) },
+        prewarm: { try await speechService.prewarm(locale: $0) },
+        startRecognition: { locale, updateHandler, failureHandler, levelHandler in
+          try await speechService.start(
+            locale: locale,
+            updateHandler: updateHandler,
+            failureHandler: failureHandler,
+            levelHandler: levelHandler
+          )
+        },
+        finishRecognition: { try await speechService.finish() },
+        cancelRecognition: { await speechService.cancel() },
+        shutDownRecognition: { await speechService.shutDown() },
+        captureFocusedTarget: { textInsertionService.captureFocusedTarget() },
+        insertText: { await textInsertionService.insert($0, into: $1) },
+        requestMicrophoneAccess: { await PermissionService.requestMicrophoneAccess() },
+        requestSpeechAccess: { await PermissionService.requestSpeechAccess() },
+        requestAccessibilityAccess: { PermissionService.requestAccessibilityAccess() },
+        hasAccessibilityAccess: { PermissionService.hasAccessibilityAccess },
+        isPermissionAlertPresenting: { PermissionAlert.isPresenting },
+        showAccessibilitySetupAlert: { PermissionAlert.requestAccessibilitySetup() },
+        showRelaunchAlert: { PermissionAlert.requestRelaunch() },
+        showListening: { displayID, isLatched, settings, languageTag in
+          hudController.showListening(
+            on: displayID,
+            isLatched: isLatched,
+            settings: settings,
+            languageTag: languageTag
+          )
+        },
+        showLatched: { hudController.showLatched() },
+        showLiveText: { hudController.showLiveText($0) },
+        showFinalizing: { hudController.showFinalizing() },
+        showMessage: { hudController.showMessage($0, on: $1) },
+        showModelDownload: { hudController.showModelDownload($0) },
+        showAudioLevel: { hudController.showAudioLevel($0) },
+        hideHUD: { hudController.hide() },
+        playPasteSound: { hudController.playPasteSound() },
+        recordSession: {
+          await usageTracker.recordSession(wordCount: $0, speakingDuration: $1)
+        }
+      )
+    }
+  }
+}

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -28,7 +28,7 @@ extension DirectDictationController {
     // Text insertion.
     let captureFocusedTarget: @MainActor () -> TextInsertionService.Target?
     let insertText: @MainActor (
-      String, TextInsertionService.Target?
+      String, TextInsertionService.Target?, InsertionDestination
     ) async -> TextInsertionService.InsertionOutcome
 
     // Permissions and the dialogs that explain them.
@@ -89,7 +89,7 @@ extension DirectDictationController {
         cancelRecognition: { await speechService.cancel() },
         shutDownRecognition: { await speechService.shutDown() },
         captureFocusedTarget: { textInsertionService.captureFocusedTarget() },
-        insertText: { await textInsertionService.insert($0, into: $1) },
+        insertText: { await textInsertionService.insert($0, into: $1, destination: $2) },
         requestMicrophoneAccess: { await PermissionService.requestMicrophoneAccess() },
         requestSpeechAccess: { await PermissionService.requestSpeechAccess() },
         requestAccessibilityAccess: { PermissionService.requestAccessibilityAccess() },

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -453,7 +453,11 @@ final class DirectDictationController {
       do {
         let text = try await dependencies.finishRecognition()
         dependencies.hideHUD()
-        let outcome = await dependencies.insertText(text, focusedTarget)
+        // The destination rides in the session snapshot, so a Settings change
+        // mid-session applies to the next session (ADR-0004).
+        let destination = currentSessionSettings?.insertionDestination
+          ?? settings.insertionDestination
+        let outcome = await dependencies.insertText(text, focusedTarget, destination)
         switch outcome {
         case .inserted, .copiedToClipboard:
           dependencies.playPasteSound()

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -21,10 +21,7 @@ final class DirectDictationController {
   private static let noSpeechTimeout = Duration.seconds(15)
 
   private let settings: AppSettings
-  private let speechService = SpeechRecognitionService()
-  private let hudController: DictationHUDController
-  private let textInsertionService = TextInsertionService()
-  private let usageTracker: UsageTracker
+  private let dependencies: Dependencies
 
   private var keyEventMonitor: GlobalKeyEventMonitor?
   private var machine = DictationSessionMachine()
@@ -44,14 +41,20 @@ final class DirectDictationController {
   /// the language of the key that started it even if Settings change.
   private var activeSlot: GlobalKeyEventMonitor.TriggerSlot = .primary
 
-  init(
+  convenience init(
     settings: AppSettings,
     hudController: DictationHUDController,
     usageTracker: UsageTracker
   ) {
+    self.init(
+      settings: settings,
+      dependencies: .live(hudController: hudController, usageTracker: usageTracker)
+    )
+  }
+
+  init(settings: AppSettings, dependencies: Dependencies) {
     self.settings = settings
-    self.hudController = hudController
-    self.usageTracker = usageTracker
+    self.dependencies = dependencies
     keyEventMonitor = GlobalKeyEventMonitor { [weak self] event in
       Task { @MainActor [weak self] in
         self?.handle(event)
@@ -74,8 +77,8 @@ final class DirectDictationController {
       }
     }
 
-    Task { [speechService] in
-      await speechService.setDownloadHandler(handler)
+    Task { [dependencies] in
+      await dependencies.setDownloadHandler(handler)
     }
   }
 
@@ -86,11 +89,11 @@ final class DirectDictationController {
     guard machine.isSessionActive, locale(for: activeSlot) == download.locale else { return }
 
     guard let fraction = download.fraction else {
-      hudController.showModelDownload(nil)
+      dependencies.showModelDownload(nil)
       return
     }
     let name = SpeechLanguageCatalog.shortName(for: download.locale)
-    hudController.showModelDownload(
+    dependencies.showModelDownload(
       "Downloading \(name)… \(Int(fraction * 100))%"
     )
   }
@@ -129,8 +132,8 @@ final class DirectDictationController {
   /// the primary language. The second warms behind it and never throws: a
   /// model that still needs downloading must not delay the primary key.
   private func prepareLanguages() async throws {
-    let primary = try await speechService.resolveLocale(
-      identifier: settings.recognitionLocaleIdentifier
+    let primary = try await dependencies.resolveLocale(
+      settings.recognitionLocaleIdentifier
     )
     primaryLocale = primary
 
@@ -139,19 +142,19 @@ final class DirectDictationController {
     // would dictate in a language the user never chose.
     var secondary: Locale?
     if settings.isSecondLanguageEnabled {
-      secondary = await speechService.supportedLocale(
-        identifier: settings.secondaryRecognitionLocaleIdentifier
+      secondary = await dependencies.supportedLocale(
+        settings.secondaryRecognitionLocaleIdentifier
       )
     }
     // A second language equal to the first is not a second language.
     secondaryLocale = secondary == primary ? nil : secondary
 
     let bound = [primary, secondaryLocale].compactMap(\.self)
-    await speechService.retainOnly(locales: bound)
-    try await speechService.prewarm(locale: primary)
+    await dependencies.retainOnly(bound)
+    try await dependencies.prewarm(primary)
 
     if let secondaryLocale {
-      try? await speechService.prewarm(locale: secondaryLocale)
+      try? await dependencies.prewarm(secondaryLocale)
     }
   }
 
@@ -177,8 +180,8 @@ final class DirectDictationController {
     keyEventMonitor?.stop()
     isPrepared = false
 
-    Task {
-      await speechService.shutDown()
+    Task { [dependencies] in
+      await dependencies.shutDownRecognition()
     }
   }
 
@@ -198,14 +201,14 @@ final class DirectDictationController {
     permissionTask = Task { [weak self] in
       guard let self else { return }
 
-      let microphoneGranted = await PermissionService.requestMicrophoneAccess()
+      let microphoneGranted = await dependencies.requestMicrophoneAccess()
       guard !Task.isCancelled else { return }
       guard microphoneGranted else {
         preparationFailed(message: "Microphone permission required")
         return
       }
 
-      let speechGranted = await PermissionService.requestSpeechAccess()
+      let speechGranted = await dependencies.requestSpeechAccess()
       guard !Task.isCancelled else { return }
       guard speechGranted else {
         preparationFailed(message: "Speech permission required")
@@ -214,7 +217,7 @@ final class DirectDictationController {
 
       // Ask for one privacy permission at a time. Requesting Accessibility
       // beside the microphone prompt makes macOS stack or suppress dialogs.
-      PermissionService.requestAccessibilityAccess()
+      dependencies.requestAccessibilityAccess()
 
       do {
         try await prepareLanguages()
@@ -244,21 +247,25 @@ final class DirectDictationController {
         try? await Task.sleep(for: .seconds(1))
         guard !Task.isCancelled, let self else { return }
         // Never interrupt the dialog the user is reading.
-        guard !PermissionAlert.isPresenting else { continue }
-        guard PermissionService.hasAccessibilityAccess else { continue }
+        guard !dependencies.isPermissionAlertPresenting() else { continue }
+        guard dependencies.hasAccessibilityAccess() else { continue }
 
         permissionWatchTask = nil
         if keyEventMonitor?.start() == true {
-          hudController.showMessage("Talkify is ready")
+          dependencies.showMessage("Talkify is ready", nil)
         } else {
-          PermissionAlert.requestRelaunch()
+          dependencies.showRelaunchAlert()
         }
         return
       }
     }
   }
 
-  private func handle(_ event: GlobalKeyEventMonitor.Event) {
+  /// The machine's current state, so tests can pin transitions the
+  /// controller's effects produce.
+  var sessionStateForTesting: DictationSessionMachine.State { machine.state }
+
+  func handle(_ event: GlobalKeyEventMonitor.Event) {
     switch event {
     case let .triggerPressed(slot):
       // While a session runs, only the key that started it controls it. The
@@ -301,7 +308,7 @@ final class DirectDictationController {
     case .cancelRecognition:
       Task { [weak self] in
         guard let self else { return }
-        await speechService.cancel()
+        await dependencies.cancelRecognition()
         send(.sessionEnded)
       }
     case .cancelStartTask:
@@ -315,22 +322,22 @@ final class DirectDictationController {
     case let .showListening(latched):
       let session = settings.sessionSettings
       currentSessionSettings = session
-      hudController.showListening(
-        on: focusedTarget?.displayID,
-        isLatched: latched,
-        settings: session,
-        languageTag: activeLanguageTag
+      dependencies.showListening(
+        focusedTarget?.displayID,
+        latched,
+        session,
+        activeLanguageTag
       )
     case .showLatched:
-      hudController.showLatched()
+      dependencies.showLatched()
     case .showLiveText:
       if let pendingLiveText {
-        hudController.showLiveText(pendingLiveText)
+        dependencies.showLiveText(pendingLiveText)
       }
     case .showFinalizing:
-      hudController.showFinalizing()
+      dependencies.showFinalizing()
     case .hideHUD:
-      hudController.hide()
+      dependencies.hideHUD()
     case let .notifyRecording(isRecording):
       if !isRecording {
         focusedTarget = nil
@@ -349,22 +356,22 @@ final class DirectDictationController {
 
   private func checkAndBegin() {
     guard isPrepared else {
-      hudController.showMessage(preparationFailureMessage ?? "Preparing speech…")
+      dependencies.showMessage(preparationFailureMessage ?? "Preparing speech…", nil)
       send(.beginRejected)
       return
     }
 
-    if !PermissionService.hasAccessibilityAccess {
+    if !dependencies.hasAccessibilityAccess() {
       // One dialog that explains it, not the system prompt again on every press.
-      PermissionAlert.requestAccessibilitySetup()
+      dependencies.showAccessibilitySetupAlert()
       startPermissionWatch()
       send(.beginRejected)
       return
     }
 
-    let target = textInsertionService.captureFocusedTarget()
+    let target = dependencies.captureFocusedTarget()
     if target?.isSecure == true {
-      hudController.showMessage("Secure field", on: target?.displayID)
+      dependencies.showMessage("Secure field", target?.displayID)
       send(.beginRejected)
       return
     }
@@ -382,26 +389,26 @@ final class DirectDictationController {
     sessionStartTask = Task { [weak self] in
       guard let self else { return }
       do {
-        try await speechService.start(
-          locale: locale,
-          updateHandler: { [weak self] update in
+        try await dependencies.startRecognition(
+          locale,
+          { [weak self] update in
             Task { @MainActor [weak self] in
               self?.receive(update)
             }
           },
-          failureHandler: { [weak self] message in
+          { [weak self] message in
             Task { @MainActor [weak self] in
               self?.fail(message: message, wasCancelled: false)
             }
           },
-          levelHandler: { [weak self] level in
+          { [weak self] level in
             Task { @MainActor [weak self] in
-              self?.hudController.showAudioLevel(level)
+              self?.dependencies.showAudioLevel(level)
             }
           }
         )
         guard !Task.isCancelled else {
-          await speechService.cancel()
+          await dependencies.cancelRecognition()
           send(.sessionEnded)
           return
         }
@@ -435,21 +442,18 @@ final class DirectDictationController {
     Task { [weak self] in
       guard let self else { return }
       do {
-        let text = try await speechService.finish()
-        hudController.hide()
-        let outcome = await textInsertionService.insert(text, into: focusedTarget)
+        let text = try await dependencies.finishRecognition()
+        dependencies.hideHUD()
+        let outcome = await dependencies.insertText(text, focusedTarget)
         switch outcome {
         case .inserted, .copiedToClipboard:
-          hudController.playPasteSound()
+          dependencies.playPasteSound()
           send(.sessionEnded)
           let wordCount = UsageMetrics.wordCount(in: text)
-          await usageTracker.recordSession(
-            wordCount: wordCount,
-            speakingDuration: speakingDuration
-          )
+          await dependencies.recordSession(wordCount, speakingDuration)
         case .unavailable:
           send(.sessionEnded)
-          hudController.showMessage("Couldn't insert text")
+          dependencies.showMessage("Couldn't insert text", nil)
         }
       } catch {
         fail(message: error.localizedDescription, wasCancelled: false)
@@ -470,9 +474,9 @@ final class DirectDictationController {
       }
       Task { [weak self] in
         guard let self else { return }
-        await speechService.cancel()
+        await dependencies.cancelRecognition()
         send(.sessionEnded)
-        hudController.showMessage(message)
+        dependencies.showMessage(message, nil)
       }
     } else {
       perform(effects)
@@ -494,8 +498,8 @@ final class DirectDictationController {
   }
 
   private func installTriggerMonitor() {
-    guard PermissionService.hasAccessibilityAccess else {
-      PermissionService.requestAccessibilityAccess()
+    guard dependencies.hasAccessibilityAccess() else {
+      dependencies.requestAccessibilityAccess()
       startPermissionWatch()
       return
     }
@@ -504,13 +508,13 @@ final class DirectDictationController {
     // the tap can still be refused. Only a fresh launch clears that, and saying
     // so is the whole point of the dialog.
     guard keyEventMonitor?.start() == true else {
-      PermissionAlert.requestRelaunch()
+      dependencies.showRelaunchAlert()
       return
     }
   }
 
   private func preparationFailed(message: String) {
     preparationFailureMessage = message
-    hudController.showMessage(message)
+    dependencies.showMessage(message, nil)
   }
 }

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -30,6 +30,9 @@ final class DirectDictationController {
   private var permissionTask: Task<Void, Never>?
   private var permissionWatchTask: Task<Void, Never>?
   private var sessionStartTask: Task<Void, Never>?
+  /// The finish in flight, carrying the session's last words to insertion.
+  /// Tracked so teardown can wait for it instead of racing it.
+  private var finishTask: Task<Void, Never>?
   private var isPrepared = false
   private var preparationFailureMessage: String?
   private var currentSessionSettings: DictationSessionSettings?
@@ -180,7 +183,13 @@ final class DirectDictationController {
     keyEventMonitor?.stop()
     isPrepared = false
 
-    Task { [dependencies] in
+    // A finish still in flight holds the user's last words. Shutting the
+    // speech service down beside it would cancel the very session the finish
+    // is reading, and whichever task the scheduler ran first would decide
+    // whether that text was inserted or dropped. Waiting first makes the
+    // order a rule instead of a race.
+    Task { [dependencies, finishTask] in
+      await finishTask?.value
       await dependencies.shutDownRecognition()
     }
   }
@@ -439,7 +448,7 @@ final class DirectDictationController {
   ///
   /// - Parameter speakingDuration: The completed session's measured speech time.
   private func finishRecognition(speakingDuration: TimeInterval) {
-    Task { [weak self] in
+    finishTask = Task { [weak self] in
       guard let self else { return }
       do {
         let text = try await dependencies.finishRecognition()
@@ -458,6 +467,7 @@ final class DirectDictationController {
       } catch {
         fail(message: error.localizedDescription, wasCancelled: false)
       }
+      finishTask = nil
     }
   }
 

--- a/Talkify/Dictation/InsertionDestination.swift
+++ b/Talkify/Dictation/InsertionDestination.swift
@@ -1,0 +1,23 @@
+/// Where a finished Direct Dictation session's text is delivered.
+///
+/// Inserting into the previously focused control is how every session ended
+/// before this setting existed, and stays the default. The rawValues are
+/// stored in UserDefaults, so renaming a case silently resets the preference.
+enum InsertionDestination: String, CaseIterable {
+  /// Paste into the captured target, then restore the previous clipboard.
+  case insert
+  /// Place the text on the clipboard and never paste, for users who want to
+  /// decide where it lands.
+  case clipboardOnly
+  /// Paste into the captured target and leave the text on the clipboard,
+  /// skipping the restore.
+  case both
+
+  var title: String {
+    switch self {
+    case .insert: "Insert into the app"
+    case .clipboardOnly: "Copy to the clipboard"
+    case .both: "Insert and copy"
+    }
+  }
+}

--- a/Talkify/Dictation/TextInsertionService+Clipboard.swift
+++ b/Talkify/Dictation/TextInsertionService+Clipboard.swift
@@ -231,6 +231,34 @@ extension TextInsertionService {
     }
   }
 
+  /// Stages and pastes one finalized result, leaving the text on the clipboard.
+  ///
+  /// The insert-and-copy destination skips the snapshot and the restore on
+  /// purpose: the text staying on the clipboard is what the user asked for,
+  /// so there is nothing to put back and no acquisition budget to spend.
+  ///
+  /// - Parameters:
+  ///   - text: The finalized text to insert and keep on the clipboard.
+  ///   - target: The validated focus boundary that should receive the paste.
+  /// - Returns: The terminal delivery outcome after all safe fallbacks.
+  func pasteLeavingClipboard(
+    _ text: String,
+    into target: Target
+  ) async -> InsertionOutcome {
+    guard stageClipboardText(
+      text,
+      ifUnchangedSince: dependencies.pasteboard.changeCount
+    ) != nil else { return .unavailable }
+
+    guard dependencies.postPasteShortcut() else {
+      // The paste never fired, but the text is already on the clipboard,
+      // which is exactly the manual-paste fallback.
+      return .copiedToClipboard
+    }
+    await dependencies.waitForPasteRead()
+    return .inserted
+  }
+
   /// Places finalized text on the clipboard when no target paste is safe.
   ///
   /// - Parameter text: The finalized text to retain for manual paste.

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -132,14 +132,22 @@ final class TextInsertionService {
     )
   }
 
-  /// Delivers finalized text to its captured target or the clipboard fallback.
+  /// Delivers finalized text to its captured target, the clipboard, or both.
   ///
   /// - Parameters:
   ///   - text: The finalized text to deliver.
   ///   - target: The focus boundary captured when Direct Dictation began.
+  ///   - destination: Where the session's settings say the text goes.
   /// - Returns: The terminal delivery outcome used by the session controller.
-  func insert(_ text: String, into target: Target?) async -> InsertionOutcome {
+  func insert(
+    _ text: String,
+    into target: Target?,
+    destination: InsertionDestination = .insert
+  ) async -> InsertionOutcome {
     guard !text.isEmpty else { return .inserted }
+    guard destination != .clipboardOnly else {
+      return copyToClipboard(text)
+    }
     guard let target else {
       return copyToClipboard(text)
     }
@@ -150,6 +158,9 @@ final class TextInsertionService {
 
     guard dependencies.isTargetFocused(target) else {
       return copyToClipboard(text)
+    }
+    if destination == .both {
+      return await pasteLeavingClipboard(text, into: target)
     }
     return await pasteAndRestoreClipboard(text, into: target)
   }

--- a/Talkify/Settings/Sections/DictationSettingsView.swift
+++ b/Talkify/Settings/Sections/DictationSettingsView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// The Dictation section: where a finished Direct Dictation session's text
+/// goes. The choice is captured into the session settings snapshot at
+/// session start (CONTEXT.md).
+struct DictationSettingsView: View {
+  @Bindable var settings: AppSettings
+
+  var body: some View {
+    SettingsCard(title: "Insertion") {
+      SettingsPickerRow(
+        title: "Deliver text by",
+        description: "Insert into the app pastes into the control you were "
+          + "typing in and restores your clipboard, as Direct Dictation has "
+          + "always worked. Copy to the clipboard never pastes. Insert and "
+          + "copy pastes and leaves the text on the clipboard.",
+        options: InsertionDestination.allCases,
+        optionLabel: { $0.title },
+        selection: $settings.insertionDestination
+      )
+    }
+  }
+}

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -15,6 +15,7 @@ enum SettingsSectionGroup: String, CaseIterable, Identifiable {
 enum SettingsSection: String, CaseIterable, Identifiable {
   case appearance
   case sounds
+  case dictation
   case dropTranscription
   case readAloud
   case language
@@ -29,6 +30,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .appearance: "Appearance"
     case .sounds: "Sounds"
+    case .dictation: "Dictation"
     case .dropTranscription: "Drop Transcription"
     case .readAloud: "Read Aloud"
     case .language: "Language"
@@ -42,6 +44,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .appearance: "Customize the Direct Dictation HUD"
     case .sounds: "Choose and preview the session sounds"
+    case .dictation: "Choose where finished dictation text goes"
     case .dropTranscription: "Transcribe audio and video files"
     case .readAloud: "Choose the voice that reads selected text"
     case .language: "Pick your dictation languages and their keys"
@@ -55,6 +58,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     switch self {
     case .appearance: "sparkles"
     case .sounds: "waveform"
+    case .dictation: "text.cursor"
     case .dropTranscription: "square.and.arrow.down"
     case .readAloud: "speaker.wave.2"
     case .language: "globe"

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -244,6 +244,8 @@ private struct SettingsContent: View {
           AppearanceSettingsView(settings: settings)
         case .sounds:
           SoundsSettingsView(settings: settings, sounds: sounds)
+        case .dictation:
+          DictationSettingsView(settings: settings)
         case .dropTranscription:
           DropTranscriptionSettingsView(settings: settings)
         case .readAloud:

--- a/TalkifyTests/AppSettingsTests.swift
+++ b/TalkifyTests/AppSettingsTests.swift
@@ -223,6 +223,28 @@ struct AppSettingsTests {
     #expect(snapshot.sounds.volume == 0.25)
   }
 
+  @Test func insertionDestinationDefaultsToInsertAndRoundTrips() {
+    let defaults = freshDefaults()
+    let settings = AppSettings(defaults: defaults)
+    #expect(settings.insertionDestination == .insert)
+
+    settings.insertionDestination = .both
+    #expect(defaults.string(forKey: "dictationInsertionDestination") == "both")
+
+    let reloaded = AppSettings(defaults: defaults)
+    #expect(reloaded.insertionDestination == .both)
+  }
+
+  @Test func sessionSnapshotCapturesTheInsertionDestination() {
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.insertionDestination = .clipboardOnly
+
+    let snapshot = settings.sessionSettings
+    settings.insertionDestination = .both
+
+    #expect(snapshot.insertionDestination == .clipboardOnly)
+  }
+
   /// The stored value is a plain number rather than a named case, so a
   /// value outside the supported range has to survive the trip.
   @Test func storedHUDSizeOutsideTheRangeComesBackClamped() {

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -57,6 +57,7 @@ struct DirectDictationControllerTests {
       = { DirectDictationControllerTests.makeTarget() },
     startRecognitionBody: (@Sendable (Locale) async throws -> Void)? = nil,
     finishRecognition: @escaping @Sendable () async throws -> String = { "" },
+    shutDownRecognition: @escaping @Sendable () async -> Void = {},
     insertOutcome: TextInsertionService.InsertionOutcome = .inserted
   ) -> DirectDictationController.Dependencies {
     DirectDictationController.Dependencies(
@@ -71,7 +72,7 @@ struct DirectDictationControllerTests {
       },
       finishRecognition: finishRecognition,
       cancelRecognition: { cancelCount.withLock { $0 += 1 } },
-      shutDownRecognition: {},
+      shutDownRecognition: shutDownRecognition,
       captureFocusedTarget: captureFocusedTarget,
       insertText: { text, _ in
         recorder.events.append("insertText")
@@ -414,5 +415,48 @@ struct DirectDictationControllerTests {
     #expect(recorder.insertedTexts == [""])
     #expect(recorder.recordedSessions.first?.wordCount == 0)
     controller.stop()
+  }
+
+  /// stop() during an in-flight finish must wait for the finish before
+  /// shutting the speech service down: shutting down beside it made a
+  /// scheduler race decide whether the last words were inserted or dropped.
+  @Test func stopDuringFinishInsertsTheTextBeforeShutDown() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let order = OSAllocatedUnfairLock<[String]>(initialState: [])
+    let finishEntered = OSAllocatedUnfairLock(initialState: false)
+    let finishReleased = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: {
+          finishEntered.withLock { $0 = true }
+          while !finishReleased.withLock({ $0 }) {
+            try await Task.sleep(for: .milliseconds(5))
+          }
+          order.withLock { $0.append("finish") }
+          return "held words"
+        },
+        shutDownRecognition: { order.withLock { $0.append("shutDown") } }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    controller.toggleFromMenu()
+    await waitUntil("Finish never began") { finishEntered.withLock { $0 } }
+
+    controller.stop()
+    finishReleased.withLock { $0 = true }
+    await waitUntil("Shut down never ran") {
+      order.withLock { $0.contains("shutDown") }
+    }
+
+    #expect(recorder.insertedTexts == ["held words"])
+    #expect(order.withLock { $0 } == ["finish", "shutDown"])
   }
 }

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -16,6 +16,7 @@ struct DirectDictationControllerTests {
     var messages: [String] = []
     var listeningLatched: [Bool] = []
     var insertedTexts: [String] = []
+    var insertedDestinations: [InsertionDestination] = []
     var recordedSessions: [(wordCount: Int, speakingDuration: TimeInterval)] = []
     var accessibilityAlerts = 0
 
@@ -74,9 +75,10 @@ struct DirectDictationControllerTests {
       cancelRecognition: { cancelCount.withLock { $0 += 1 } },
       shutDownRecognition: shutDownRecognition,
       captureFocusedTarget: captureFocusedTarget,
-      insertText: { text, _ in
+      insertText: { text, _, destination in
         recorder.events.append("insertText")
         recorder.insertedTexts.append(text)
+        recorder.insertedDestinations.append(destination)
         return insertOutcome
       },
       requestMicrophoneAccess: { true },
@@ -112,10 +114,11 @@ struct DirectDictationControllerTests {
   }
 
   private func makeController(
+    settings: AppSettings? = nil,
     dependencies: DirectDictationController.Dependencies
   ) -> DirectDictationController {
     DirectDictationController(
-      settings: AppSettings(defaults: freshDefaults()),
+      settings: settings ?? AppSettings(defaults: freshDefaults()),
       dependencies: dependencies
     )
   }
@@ -458,5 +461,36 @@ struct DirectDictationControllerTests {
 
     #expect(recorder.insertedTexts == ["held words"])
     #expect(order.withLock { $0 } == ["finish", "shutDown"])
+  }
+
+  /// The destination rides in the session snapshot: a Settings change made
+  /// mid-session must not redirect the finish already under way.
+  @Test func finishDeliversWithTheDestinationCapturedAtSessionStart() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.insertionDestination = .clipboardOnly
+    let controller = makeController(
+      settings: settings,
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "captured words" }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    settings.insertionDestination = .both
+    controller.toggleFromMenu()
+    await waitUntil("Finish never delivered") {
+      controller.sessionStateForTesting == .idle && !recorder.insertedTexts.isEmpty
+    }
+
+    #expect(recorder.insertedDestinations == [.clipboardOnly])
+    controller.stop()
   }
 }

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -1,0 +1,418 @@
+import Foundation
+import os
+import Testing
+@testable import Talkify
+
+/// Pins the controller's impure half through its Dependencies seam: the
+/// begin guards, the finish outcome routing, and the cancellation races
+/// that the pure machine tests cannot reach.
+@MainActor
+struct DirectDictationControllerTests {
+  /// Every MainActor boundary call the controller makes, in order, plus
+  /// the arguments the routing decisions carry.
+  @MainActor
+  private final class Recorder {
+    var events: [String] = []
+    var messages: [String] = []
+    var listeningLatched: [Bool] = []
+    var insertedTexts: [String] = []
+    var recordedSessions: [(wordCount: Int, speakingDuration: TimeInterval)] = []
+    var accessibilityAlerts = 0
+
+    func count(of event: String) -> Int {
+      events.filter { $0 == event }.count
+    }
+  }
+
+  private struct FinishError: LocalizedError {
+    var errorDescription: String? { "finish failed" }
+  }
+
+  private func freshDefaults() -> UserDefaults {
+    let name = "DirectDictationControllerTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
+  }
+
+  private static func makeTarget(isSecure: Bool = false) -> TextInsertionService.Target {
+    TextInsertionService.Target(
+      element: nil,
+      processIdentifier: 1,
+      isSecure: isSecure,
+      displayID: nil
+    )
+  }
+
+  /// Builds fake dependencies around the recorder. The Sendable speech
+  /// closures report through lock-guarded counters because they cannot
+  /// touch the MainActor recorder synchronously.
+  private func makeDependencies(
+    recorder: Recorder,
+    prewarmed: OSAllocatedUnfairLock<Bool> = .init(initialState: false),
+    startEntries: OSAllocatedUnfairLock<Int> = .init(initialState: 0),
+    cancelCount: OSAllocatedUnfairLock<Int> = .init(initialState: 0),
+    hasAccessibilityAccess: @escaping @MainActor () -> Bool = { true },
+    captureFocusedTarget: @escaping @MainActor () -> TextInsertionService.Target?
+      = { DirectDictationControllerTests.makeTarget() },
+    startRecognitionBody: (@Sendable (Locale) async throws -> Void)? = nil,
+    finishRecognition: @escaping @Sendable () async throws -> String = { "" },
+    insertOutcome: TextInsertionService.InsertionOutcome = .inserted
+  ) -> DirectDictationController.Dependencies {
+    DirectDictationController.Dependencies(
+      setDownloadHandler: { _ in },
+      resolveLocale: { _ in Locale(identifier: "en_US") },
+      supportedLocale: { _ in nil },
+      retainOnly: { _ in },
+      prewarm: { _ in prewarmed.withLock { $0 = true } },
+      startRecognition: { locale, _, _, _ in
+        startEntries.withLock { $0 += 1 }
+        try await startRecognitionBody?(locale)
+      },
+      finishRecognition: finishRecognition,
+      cancelRecognition: { cancelCount.withLock { $0 += 1 } },
+      shutDownRecognition: {},
+      captureFocusedTarget: captureFocusedTarget,
+      insertText: { text, _ in
+        recorder.events.append("insertText")
+        recorder.insertedTexts.append(text)
+        return insertOutcome
+      },
+      requestMicrophoneAccess: { true },
+      requestSpeechAccess: { true },
+      requestAccessibilityAccess: {},
+      hasAccessibilityAccess: hasAccessibilityAccess,
+      isPermissionAlertPresenting: { false },
+      showAccessibilitySetupAlert: {
+        recorder.events.append("showAccessibilitySetupAlert")
+        recorder.accessibilityAlerts += 1
+      },
+      showRelaunchAlert: { recorder.events.append("showRelaunchAlert") },
+      showListening: { _, isLatched, _, _ in
+        recorder.events.append("showListening")
+        recorder.listeningLatched.append(isLatched)
+      },
+      showLatched: { recorder.events.append("showLatched") },
+      showLiveText: { _ in recorder.events.append("showLiveText") },
+      showFinalizing: { recorder.events.append("showFinalizing") },
+      showMessage: { message, _ in
+        recorder.events.append("showMessage")
+        recorder.messages.append(message)
+      },
+      showModelDownload: { _ in },
+      showAudioLevel: { _ in },
+      hideHUD: { recorder.events.append("hideHUD") },
+      playPasteSound: { recorder.events.append("playPasteSound") },
+      recordSession: { wordCount, speakingDuration in
+        recorder.events.append("recordSession")
+        recorder.recordedSessions.append((wordCount, speakingDuration))
+      }
+    )
+  }
+
+  private func makeController(
+    dependencies: DirectDictationController.Dependencies
+  ) -> DirectDictationController {
+    DirectDictationController(
+      settings: AppSettings(defaults: freshDefaults()),
+      dependencies: dependencies
+    )
+  }
+
+  /// Polls the condition until it holds, or records a failure after ~1 s.
+  /// The sleeps yield the main actor so the controller's tasks can run.
+  private func waitUntil(
+    _ comment: Comment,
+    _ condition: @MainActor () -> Bool
+  ) async {
+    for _ in 0..<200 {
+      if condition() { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+    Issue.record(comment)
+  }
+
+  /// Prepares the controller through applyLanguages, then lets the
+  /// preparation task run to completion past the prewarm it signals.
+  private func prepare(
+    _ controller: DirectDictationController,
+    prewarmed: OSAllocatedUnfairLock<Bool>
+  ) async {
+    controller.applyLanguages()
+    await waitUntil("Preparation never reached prewarm") {
+      prewarmed.withLock { $0 }
+    }
+    try? await Task.sleep(for: .milliseconds(20))
+  }
+
+  @Test func triggerBeforePreparationShowsPreparingAndStaysIdle() {
+    let recorder = Recorder()
+    let startEntries = OSAllocatedUnfairLock(initialState: 0)
+    let controller = makeController(
+      dependencies: makeDependencies(recorder: recorder, startEntries: startEntries)
+    )
+
+    controller.handle(.triggerPressed(.primary))
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.messages == ["Preparing speech…"])
+    #expect(startEntries.withLock { $0 } == 0)
+  }
+
+  @Test func missingAccessibilityAccessShowsSetupAlertAndStaysIdle() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        hasAccessibilityAccess: { false }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.accessibilityAlerts == 1)
+    controller.stop()
+  }
+
+  @Test func secureFocusedFieldShowsSecureFieldAndStaysIdle() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        captureFocusedTarget: { Self.makeTarget(isSecure: true) }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.messages == ["Secure field"])
+    controller.stop()
+  }
+
+  @Test func approvedMenuToggleBeginsALatchedRecording() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(recorder: recorder, prewarmed: prewarmed)
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    #expect(recorder.listeningLatched == [true])
+    controller.stop()
+  }
+
+  @Test func insertedFinishPlaysPasteSoundAndRecordsUsage() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "hello world" }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Usage was never recorded") {
+      recorder.recordedSessions.count == 1
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.insertedTexts == ["hello world"])
+    #expect(recorder.recordedSessions.first?.wordCount == 2)
+    #expect((recorder.recordedSessions.first?.speakingDuration ?? -1) >= 0)
+    let hideIndex = recorder.events.firstIndex(of: "hideHUD")
+    let soundIndex = recorder.events.firstIndex(of: "playPasteSound")
+    #expect(hideIndex != nil && soundIndex != nil)
+    if let hideIndex, let soundIndex {
+      #expect(hideIndex < soundIndex)
+    }
+    controller.stop()
+  }
+
+  @Test func clipboardFallbackStillPlaysPasteSoundAndRecordsUsage() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "hello world" },
+        insertOutcome: .copiedToClipboard
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Usage was never recorded") {
+      recorder.recordedSessions.count == 1
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.count(of: "playPasteSound") == 1)
+    controller.stop()
+  }
+
+  @Test func unavailableInsertionShowsMessageWithoutSoundOrUsage() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "hello world" },
+        insertOutcome: .unavailable
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Insertion failure message never shown") {
+      recorder.messages.contains("Couldn't insert text")
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.count(of: "playPasteSound") == 0)
+    #expect(recorder.recordedSessions.isEmpty)
+    controller.stop()
+  }
+
+  @Test func finishFailureShowsTheErrorAndInsertsNothing() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { throw FinishError() }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Finish failure message never shown") {
+      recorder.messages.contains("finish failed")
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.insertedTexts.isEmpty)
+    controller.stop()
+  }
+
+  @Test func escapeWhileStartingHidesTheHUDAndInsertsNothing() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let startEntries = OSAllocatedUnfairLock(initialState: 0)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        startEntries: startEntries,
+        startRecognitionBody: { _ in
+          // Held open until the controller cancels the start task; the
+          // CancellationError propagates as the torn-down start.
+          try await Task.sleep(for: .seconds(10))
+        }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Recognition start was never entered") {
+      startEntries.withLock { $0 } >= 1
+    }
+    controller.handle(.cancelPressed)
+    await waitUntil("Cancelled start never reset to idle") {
+      controller.sessionStateForTesting == .idle
+    }
+
+    #expect(recorder.count(of: "hideHUD") == 1)
+    #expect(recorder.insertedTexts.isEmpty)
+    controller.stop()
+  }
+
+  @Test func escapeWhileRecordingCancelsRecognitionAndHidesTheHUD() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let cancelCount = OSAllocatedUnfairLock(initialState: 0)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        cancelCount: cancelCount
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.handle(.cancelPressed)
+    await waitUntil("Cancelled recording never reset to idle") {
+      controller.sessionStateForTesting == .idle
+    }
+
+    #expect(cancelCount.withLock { $0 } >= 1)
+    #expect(recorder.count(of: "hideHUD") == 1)
+    #expect(recorder.insertedTexts.isEmpty)
+    controller.stop()
+  }
+
+  @Test func emptyFinishTextStillRecordsAZeroWordSession() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = makeController(
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "" }
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+
+    controller.toggleFromMenu()
+    await waitUntil("Usage was never recorded") {
+      recorder.recordedSessions.count == 1
+    }
+
+    #expect(controller.sessionStateForTesting == .idle)
+    #expect(recorder.insertedTexts == [""])
+    #expect(recorder.recordedSessions.first?.wordCount == 0)
+    controller.stop()
+  }
+}

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -29,8 +29,8 @@ struct SettingsWindowTests {
 
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
     let expected: [SettingsSection] = [
-      .appearance, .sounds, .dropTranscription, .readAloud, .language, .shortcuts,
-      .updates, .insights,
+      .appearance, .sounds, .dictation, .dropTranscription, .readAloud, .language,
+      .shortcuts, .updates, .insights,
     ]
     #expect(SettingsSection.allCases == expected)
     #expect(SettingsSectionGroup.settings.sections == expected)

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -744,6 +744,280 @@ struct TextInsertionServiceTests {
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
   }
 
+  /// Verifies clipboard-only delivery replaces the clipboard without pasting.
+  @Test func clipboardOnlyReplacesClipboardWithoutPosting() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var postedPaste = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .clipboardOnly
+    )
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies clipboard-only delivery never consults the target guards.
+  @Test func clipboardOnlySkipsEveryTargetGuard() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in false },
+      isTargetFocused: { _ in false },
+      postPasteShortcut: { true },
+      waitForPasteRead: {}
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .clipboardOnly
+    )
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies clipboard-only delivery succeeds without any captured target.
+  @Test func clipboardOnlyDeliversWithoutTarget() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      waitForPasteRead: {}
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: nil,
+      destination: .clipboardOnly
+    )
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies insert-and-copy pastes once and leaves the text on the clipboard.
+  @Test func bothPastesAndLeavesTextOnClipboard() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var postedPasteCount = 0
+    var textAvailableWhileTargetReads: String?
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPasteCount += 1
+        return true
+      },
+      waitForPasteRead: {
+        textAvailableWhileTargetReads = pasteboard.string(forType: .string)
+      }
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .both
+    )
+
+    #expect(outcome == .inserted)
+    #expect(postedPasteCount == 1)
+    #expect(textAvailableWhileTargetReads == "dictated text")
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies insert-and-copy falls back to manual delivery on lost focus.
+  @Test func bothWithUnfocusedTargetUsesCopyFallback() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    var postedPaste = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in false },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .both
+    )
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies a failed paste shortcut leaves staged text as manual delivery.
+  @Test func bothWithFailedPasteShortcutKeepsStagedText() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var waitedForPasteRead = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { false },
+      waitForPasteRead: {
+        waitedForPasteRead = true
+      }
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .both
+    )
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(!waitedForPasteRead)
+    #expect(pasteboard.string(forType: .string) == "dictated text")
+  }
+
+  /// Verifies insert-and-copy refuses to stage while a read owns the lease.
+  @Test func bothWithHeldReadLeaseReportsUnavailable() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var postedPaste = false
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: {
+        postedPaste = true
+        return true
+      },
+      waitForPasteRead: {}
+    ))
+    service.clipboardReadLease.withLock { $0 = true }
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .both
+    )
+    service.clipboardReadLease.withLock { $0 = false }
+
+    #expect(outcome == .unavailable)
+    #expect(!postedPaste)
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  /// Verifies an explicit insert destination matches the default behavior.
+  @Test func explicitInsertDestinationPastesThenRestores() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    var textAvailableWhileTargetReads: String?
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      waitForPasteRead: {
+        textAvailableWhileTargetReads = pasteboard.string(forType: .string)
+      }
+    ))
+    let outcome = await service.insert(
+      "dictated text",
+      into: makeTarget(),
+      destination: .insert
+    )
+
+    #expect(outcome == .inserted)
+    #expect(textAvailableWhileTargetReads == "dictated text")
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  /// Verifies empty text completes as a no-op before destination handling.
+  @Test func emptyTextWithClipboardOnlyLeavesClipboardUntouched() async {
+    let pasteboard = makePasteboard()
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+
+    let service = TextInsertionService(dependencies: .init(
+      pasteboard: pasteboard,
+      readClipboardItems: makeClipboardReader(for: pasteboard),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: { _ in true },
+      postPasteShortcut: { true },
+      waitForPasteRead: {}
+    ))
+    let outcome = await service.insert(
+      "",
+      into: makeTarget(),
+      destination: .clipboardOnly
+    )
+
+    #expect(outcome == .inserted)
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
   private func makePasteboard() -> NSPasteboard {
     NSPasteboard(
       name: NSPasteboard.Name("TextInsertionServiceTests-\(UUID().uuidString)")

--- a/docs/adr/0006-insertion-destination.md
+++ b/docs/adr/0006-insertion-destination.md
@@ -1,0 +1,27 @@
+# Three-way insertion destination
+
+Direct Dictation gains an insertion destination setting with three
+deliveries: insert into the app (paste, then restore the previous
+clipboard), copy to the clipboard (never paste), and insert and copy
+(paste and leave the text on the clipboard). Inserting stays the default,
+so nothing changes for anyone who never opens the setting. The choice is
+plumbed through the immutable session settings snapshot (ADR-0004) and
+delivered by `TextInsertionService`: clipboard-only returns before focus
+validation, since there is no target to validate, and insert-and-copy
+skips both the clipboard snapshot acquisition and the restore.
+
+Two kinds of users asked for this. Some prefer owning the paste: they
+want dictated text staged where they can place it deliberately rather
+than landing wherever focus sat. Others run clipboard-history managers
+and were losing every dictation to the restore step, which put the old
+clipboard back over the text they had just spoken.
+
+## Consequences
+
+- Clipboard-only reports `.copiedToClipboard`, which still plays the
+  paste sound and records usage; delivery to the clipboard is a
+  completed session, not a fallback.
+- Insert-and-copy deliberately leaves the clipboard dirty; that is the
+  point, not a bug to fix.
+- The Settings window gains its first behavior section, named Dictation,
+  alongside the existing look-and-feel sections.


### PR DESCRIPTION
Stacked on #65.

Some users want to own the paste, and clipboard-history users were losing every dictation to the restore step. This adds a three-way insertion destination, plumbed through the session settings snapshot per ADR-0004: insert into the app (the unchanged default), copy to the clipboard (never pastes, skips focus validation), and insert and copy (pastes and leaves the text on the clipboard, skipping snapshot acquisition and restore). The Settings window gains its first behavior section, Dictation; docs/adr/0006-insertion-destination.md in this diff records the decision, and CONTEXT.md carries the new rules. Written with Claude Code under my direction and reviewed line by line; all three destinations are pinned by new insertion-service and controller tests, green on an Apple Silicon Mac running macOS 26, though I have not yet put the two new modes through a live dictation session, which I flag here per the contributing guide.

Closes #63
