### PR TITLE
[FIX] Refuse to read a secure field aloud

### DIFF
--- a/Talkify/ReadAloud/FocusedSelectionReader.swift
+++ b/Talkify/ReadAloud/FocusedSelectionReader.swift
@@ -5,29 +5,76 @@ import ApplicationServices
 /// TextInsertionService's target validation and clipboard machinery.
 @MainActor
 struct FocusedSelectionReader {
-  /// Nil when nothing is focused, the element exposes no selection, or
-  /// the selection is empty.
-  func selectedText() -> String? {
-    let systemWideElement = AXUIElementCreateSystemWide()
-    var focused: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(
-      systemWideElement,
-      kAXFocusedUIElementAttribute as CFString,
-      &focused
-    ) == .success,
-    let focused else {
-      return nil
+  /// What the focused element is offering. A secure field is its own case
+  /// rather than an empty selection: Direct Dictation refuses those and says
+  /// so, and Read Aloud speaks into the room, so it has to refuse them too.
+  enum Selection: Equatable {
+    case text(String)
+    case secureField
+    case none
+  }
+
+  /// What the focused element reports, flattened to plain values so the
+  /// decision below can be tested without a live element. Follows the
+  /// `TextInsertionService.Dependencies` pattern already used in-tree.
+  struct Focus: Equatable {
+    var subrole: String?
+    var selectedText: String?
+  }
+
+  struct Dependencies {
+    var focus: @MainActor () -> Focus?
+
+    static let live = Dependencies(focus: Self.readFocus)
+
+    private static func readFocus() -> Focus? {
+      let systemWide = AXUIElementCreateSystemWide()
+      guard let value = copyAttribute(systemWide, kAXFocusedUIElementAttribute),
+         CFGetTypeID(value) == AXUIElementGetTypeID()
+      else {
+        // The success code says the attribute was read, not that it holds the
+        // type its name implies, so the type is checked before the cast.
+        return nil
+      }
+      let element = value as! AXUIElement
+      return Focus(
+        subrole: copyAttribute(element, kAXSubroleAttribute) as? String,
+        selectedText: copyAttribute(element, kAXSelectedTextAttribute) as? String
+      )
     }
 
-    var value: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(
-      focused as! AXUIElement,
-      kAXSelectedTextAttribute as CFString,
-      &value
-    ) == .success else {
-      return nil
+    private static func copyAttribute(
+      _ element: AXUIElement,
+      _ attribute: String
+    ) -> CFTypeRef? {
+      var value: CFTypeRef?
+      guard AXUIElementCopyAttributeValue(
+        element,
+        attribute as CFString,
+        &value
+      ) == .success else {
+        return nil
+      }
+      return value
     }
+  }
 
-    return value as? String
+  let dependencies: Dependencies
+
+  init(dependencies: Dependencies = .live) {
+    self.dependencies = dependencies
+  }
+
+  func selection() -> Selection {
+    guard let focus = dependencies.focus() else { return .none }
+    guard focus.subrole != kAXSecureTextFieldSubrole as String else {
+      return .secureField
+    }
+    guard let text = focus.selectedText,
+       !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else {
+      return .none
+    }
+    return .text(text)
   }
 }

--- a/Talkify/ReadAloud/ReadAloudController.swift
+++ b/Talkify/ReadAloud/ReadAloudController.swift
@@ -40,14 +40,21 @@ final class ReadAloudController: NSObject {
       return
     }
 
-    let selection = selectionReader.selectedText()?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    guard let selection, !selection.isEmpty else {
+    let text: String
+    switch selectionReader.selection() {
+    case let .text(selected):
+      text = selected
+    case .secureField:
+      // Speaking a password out loud is a worse leak than pasting one, so
+      // Read Aloud refuses the same fields Direct Dictation does.
+      hudController.showMessage("Secure field")
+      return
+    case .none:
       hudController.showMessage("No text selected")
       return
     }
 
-    let utterance = AVSpeechUtterance(string: selection)
+    let utterance = AVSpeechUtterance(string: text)
     if !settings.readAloudVoiceID.isEmpty,
      let voice = AVSpeechSynthesisVoice(identifier: settings.readAloudVoiceID) {
       utterance.voice = voice

--- a/TalkifyTests/FocusedSelectionReaderTests.swift
+++ b/TalkifyTests/FocusedSelectionReaderTests.swift
@@ -1,0 +1,55 @@
+import ApplicationServices
+import Testing
+@testable import Talkify
+
+/// What Read Aloud is allowed to speak. Direct Dictation already refuses a
+/// secure field and says so; speech goes into the room, so this path has to
+/// refuse the same fields rather than reading a password out loud.
+@MainActor
+struct FocusedSelectionReaderTests {
+  private func reader(
+    subrole: String? = nil,
+    selectedText: String? = nil,
+    focused: Bool = true
+  ) -> FocusedSelectionReader {
+    FocusedSelectionReader(
+      dependencies: .init(
+        focus: {
+          guard focused else { return nil }
+          return .init(subrole: subrole, selectedText: selectedText)
+        }
+      )
+    )
+  }
+
+  @Test func aSecureFieldIsRefusedEvenWhenItHasASelection() {
+    let secure = reader(
+      subrole: kAXSecureTextFieldSubrole as String,
+      selectedText: "hunter2"
+    )
+    #expect(secure.selection() == .secureField)
+  }
+
+  @Test func anOrdinarySelectionIsSpoken() {
+    #expect(reader(subrole: "AXStandardWindow", selectedText: "hello").selection()
+      == .text("hello"))
+    #expect(reader(selectedText: "no subrole reported").selection()
+      == .text("no subrole reported"))
+  }
+
+  /// Whitespace is not a selection worth speaking, and it must not be
+  /// mistaken for one now that the empty case also covers "nothing focused".
+  @Test func blankAndMissingSelectionsBothReadAsNone() {
+    #expect(reader(selectedText: nil).selection() == .none)
+    #expect(reader(selectedText: "").selection() == .none)
+    #expect(reader(selectedText: "  \n\t ").selection() == .none)
+    #expect(reader(focused: false).selection() == .none)
+  }
+
+  /// The secure check runs before the selection check, so a secure field with
+  /// nothing selected still reports as secure rather than as empty.
+  @Test func anEmptySecureFieldStillReportsSecure() {
+    let secure = reader(subrole: kAXSecureTextFieldSubrole as String, selectedText: nil)
+    #expect(secure.selection() == .secureField)
+  }
+}


### PR DESCRIPTION
Read Aloud spoke whatever the focused element reported as selected text, including a password field. Direct Dictation has always refused those and shown "Secure field", so this mirrors that check: `FocusedSelectionReader` now returns a three-case `Selection`, and the controller shows the same message rather than speaking.

The reader gained a small `Dependencies` seam copied from `TextInsertionService`, which is what makes the refusal testable without a live password field.

Tested with four new cases in `FocusedSelectionReaderTests` covering a secure field with and without a selection, an ordinary selection, and blank or absent ones. Full suite passes locally.

Closes #57