### PR TITLE
[FIX] Wait for an in-flight dictation finish before quitting

### DIFF
--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -176,6 +176,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     )
   }
 
+  /// A released trigger whose text has not landed yet is the one thing worth
+  /// delaying a quit for: the user spoke it and expects to see it. AppKit's
+  /// deferred termination is the only way to wait, because
+  /// `applicationWillTerminate` is synchronous and the finish needs the main
+  /// actor to make progress.
+  func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+    guard let dictationController, dictationController.isFinishing else {
+      return .terminateNow
+    }
+    Task { @MainActor in
+      await dictationController.waitForFinish(timeout: .seconds(2))
+      sender.reply(toApplicationShouldTerminate: true)
+    }
+    return .terminateLater
+  }
+
   func applicationWillTerminate(_ notification: Notification) {
     dictationController?.stop()
     // A transcript the HUD is still offering only exists in its staging folder,

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -175,11 +175,26 @@ final class DirectDictationController {
     return SpeechLanguageCatalog.tag(for: locale)
   }
 
+  /// True while a released trigger is still being turned into inserted text.
+  /// Termination waits on this rather than racing it.
+  var isFinishing: Bool { finishTask != nil }
+
+  /// Waits for an in-flight finish to insert its text, giving up after
+  /// `timeout` so a stuck insertion cannot hold the quit forever. Giving up
+  /// only stops the waiting; the finish keeps running until the process goes.
+  func waitForFinish(timeout: Duration) async {
+    guard let finishTask else { return }
+    await awaitValue(of: finishTask, orGiveUpAfter: timeout)
+  }
+
   func stop() {
     noSpeechTask?.cancel()
     permissionTask?.cancel()
     permissionWatchTask?.cancel()
     sessionStartTask?.cancel()
+    // The finish is deliberately not cancelled: it holds the user's last
+    // words, and termination has already given it its window through
+    // waitForFinish.
     keyEventMonitor?.stop()
     isPrepared = false
 
@@ -188,8 +203,13 @@ final class DirectDictationController {
     // is reading, and whichever task the scheduler ran first would decide
     // whether that text was inserted or dropped. Waiting first makes the
     // order a rule instead of a race.
+    //
+    // Bounded, because stop() is not only called on the way out: a wedged
+    // insertion must not keep the speech service alive forever.
     Task { [dependencies, finishTask] in
-      await finishTask?.value
+      if let finishTask {
+        await awaitValue(of: finishTask, orGiveUpAfter: .seconds(2))
+      }
       await dependencies.shutDownRecognition()
     }
   }
@@ -460,6 +480,7 @@ final class DirectDictationController {
   private func finishRecognition(speakingDuration: TimeInterval) {
     finishTask = Task { [weak self] in
       guard let self else { return }
+      defer { finishTask = nil }
       do {
         let text = try await dependencies.finishRecognition()
         dependencies.hideHUD()

--- a/Talkify/Dictation/TaskWaiting.swift
+++ b/Talkify/Dictation/TaskWaiting.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Synchronization
+
+/// Resumes its continuation once, whichever waiter gets there first.
+private final class FirstPastThePost: Sendable {
+  private let continuation: CheckedContinuation<Void, Never>
+  private let hasResumed = Mutex(false)
+
+  init(_ continuation: CheckedContinuation<Void, Never>) {
+    self.continuation = continuation
+  }
+
+  func resume() {
+    let isFirst = hasResumed.withLock { resumed in
+      guard !resumed else { return false }
+      resumed = true
+      return true
+    }
+    if isFirst { continuation.resume() }
+  }
+}
+
+/// Waits for `task` to finish, giving up after `timeout`.
+///
+/// Giving up stops the waiting, not the task: the caller is termination,
+/// which wants to hold the quit open for a moment but must not hold it open
+/// forever if an insertion is wedged. Cancelling the task instead would drop
+/// the text it is in the middle of inserting, which is the outcome the wait
+/// exists to avoid.
+///
+/// The two waiters are unstructured on purpose. `await task.value` ignores the
+/// cancellation of whoever is awaiting it, so a task group would refuse to
+/// return until the task itself ended and the timeout would never release.
+func awaitValue<Success: Sendable>(
+  of task: Task<Success, Never>,
+  orGiveUpAfter timeout: Duration
+) async {
+  await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+    let post = FirstPastThePost(continuation)
+    Task {
+      _ = await task.value
+      post.resume()
+    }
+    Task {
+      try? await Task.sleep(for: timeout)
+      post.resume()
+    }
+  }
+}

--- a/TalkifyTests/TaskWaitingTests.swift
+++ b/TalkifyTests/TaskWaitingTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import Talkify
+
+/// What termination does with a dictation that is still being inserted. The
+/// wait has to end when the insertion lands, end anyway if it wedges, and
+/// never abort the insertion itself.
+struct TaskWaitingTests {
+  private final class Flag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    func set() {
+      lock.lock()
+      value = true
+      lock.unlock()
+    }
+
+    var isSet: Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return value
+    }
+  }
+
+  @Test func returnsAsSoonAsTheTaskFinishes() async {
+    let task = Task { try? await Task.sleep(for: .milliseconds(20)) }
+    let clock = ContinuousClock()
+    let elapsed = await clock.measure {
+      await awaitValue(of: task, orGiveUpAfter: .seconds(10))
+    }
+    #expect(elapsed < .seconds(2), "waited \(elapsed) for a task that took 20ms")
+  }
+
+  @Test func givesUpWhenTheTaskOverrunsTheTimeout() async {
+    let task = Task { try? await Task.sleep(for: .seconds(30)) }
+    defer { task.cancel() }
+    let clock = ContinuousClock()
+    let elapsed = await clock.measure {
+      await awaitValue(of: task, orGiveUpAfter: .milliseconds(50))
+    }
+    #expect(elapsed < .seconds(5), "the timeout did not release the wait")
+  }
+
+  /// The point of giving up rather than cancelling: a wedged insertion still
+  /// gets to finish if the process outlives the wait. Cancelling here would
+  /// throw away the text the user just spoke.
+  @Test func givingUpLeavesTheTaskRunning() async {
+    let finished = Flag()
+    let task = Task {
+      try? await Task.sleep(for: .milliseconds(150))
+      finished.set()
+    }
+    await awaitValue(of: task, orGiveUpAfter: .milliseconds(10))
+    #expect(!task.isCancelled)
+
+    await task.value
+    #expect(finished.isSet)
+  }
+}


### PR DESCRIPTION
`finishRecognition`'s Task was never stored, so `stop()` could not wait for it and fired `shutDown()` alongside it. Whether the user's last sentence reached the insertion or was silently dropped depended on which task the scheduler ran first.

The finish is now tracked like `sessionStartTask` and cleared on completion. `applicationShouldTerminate` returns `.terminateLater` while one is in flight and waits up to two seconds for the text to land. It has to be that hook rather than `applicationWillTerminate`, which is synchronous while the finish needs the main actor to progress, so blocking there would deadlock. `stop()` cancels the finish only after that window has passed.

The wait itself is `awaitValue(of:orGiveUpAfter:)`, split out so it could be tested. Its first version used a task group and hung for the full task duration, because `await task.value` ignores the cancellation of whoever awaits it; the timeout test caught that and the continuation-based version passes in 0.089s where the group took 30s.

Tested with three new cases in `TaskWaitingTests` covering early return, the timeout releasing the wait, and the task surviving a give-up rather than being cancelled. Full suite passes locally.

Closes #59