### PR TITLE
[FIX] Sweep stranded transcripts and stage them 0600

### DIFF
--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -41,6 +41,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     guard !Self.isHostingTests else { return }
+
+    // Before anything can be staged: a crash or a force-quit while a
+    // transcript card was on screen leaves the user's speech in cleartext
+    // under $TMPDIR, and nothing else ever removes it.
+    StagedTranscript.sweep()
+
     let settings = AppSettings()
     self.settings = settings
     // One shape, two features. The stage owns the window and hands it out;

--- a/Talkify/DropTranscription/StagedTranscript.swift
+++ b/Talkify/DropTranscription/StagedTranscript.swift
@@ -18,19 +18,59 @@ struct StagedTranscript {
 
   private var stagingDirectory: URL { url.deletingLastPathComponent() }
 
+  /// Where staging folders live between the transcript being produced and the
+  /// user deciding where it goes.
+  static var defaultRoot: URL { URL.temporaryDirectory.appending(path: "Talkify") }
+
   /// Writes the text into a folder of its own, so the file can carry its real
   /// name without colliding with another job's.
+  ///
+  /// The folder is 0700 and the file 0600: a transcript is the user's speech
+  /// in cleartext, and Talkify is unsandboxed, so anything else running as the
+  /// same user could otherwise read it.
   static func stage(
     text: String,
     source: URL,
-    root: URL = URL.temporaryDirectory.appending(path: "Talkify")
+    root: URL = defaultRoot
   ) throws -> StagedTranscript {
+    try prepareRoot(root)
     let directory = root.appending(path: UUID().uuidString)
-    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700]
+    )
     let name = source.deletingPathExtension().lastPathComponent
     let url = directory.appending(path: "\(name).txt")
     try text.write(to: url, atomically: true, encoding: .utf8)
+    // After the write: `atomically` renames a temporary file into place, so
+    // permissions set beforehand would belong to a file that no longer exists.
+    try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     return StagedTranscript(url: url, source: source)
+  }
+
+  /// Clears anything left in the staging root.
+  ///
+  /// Cleanup otherwise only happens on `commit()` or `discard()`, so a crash
+  /// or a force-quit while a card was on screen left the transcript readable
+  /// under `$TMPDIR` indefinitely. Called at launch, before anything is
+  /// staged, so everything it finds belongs to a run that is already over.
+  static func sweep(root: URL = defaultRoot) {
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  /// Refuses to stage into a root that something replaced with a symlink,
+  /// which would put the transcript wherever that link points.
+  private static func prepareRoot(_ root: URL) throws {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: root.path)
+    if let type = attributes?[.type] as? FileAttributeType, type == .typeSymbolicLink {
+      try FileManager.default.removeItem(at: root)
+    }
+    try FileManager.default.createDirectory(
+      at: root,
+      withIntermediateDirectories: true,
+      attributes: [.posixPermissions: 0o700]
+    )
   }
 
   /// Moves the staged file to where the Save-to preference says it belongs,

--- a/TalkifyTests/DropTranscriptionTests.swift
+++ b/TalkifyTests/DropTranscriptionTests.swift
@@ -320,6 +320,67 @@ struct StagedTranscriptTests {
     return directory
   }
 
+  /// A transcript is the user's speech in cleartext and Talkify is
+  /// unsandboxed, so nothing else running as the same user should be able to
+  /// open it while it waits on the card.
+  @Test func stagedFilesAreReadableOnlyByTheirOwner() throws {
+    let root = try scratch("permissions")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let staged = try StagedTranscript.stage(text: "private", source: source, root: root)
+
+    let file = try FileManager.default.attributesOfItem(atPath: staged.url.path)
+    #expect(file[.posixPermissions] as? Int == 0o600)
+    let directory = try FileManager.default.attributesOfItem(
+      atPath: staged.url.deletingLastPathComponent().path
+    )
+    #expect(directory[.posixPermissions] as? Int == 0o700)
+  }
+
+  /// The gap this closes: cleanup only ran on commit or discard, so a crash
+  /// with a card on screen left the transcript under $TMPDIR forever.
+  @Test func sweepingClearsWhatACrashWouldHaveLeftBehind() throws {
+    let root = try scratch("sweep")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let staged = try StagedTranscript.stage(text: "stranded", source: source, root: root)
+    #expect(FileManager.default.fileExists(atPath: staged.url.path))
+
+    StagedTranscript.sweep(root: root)
+
+    #expect(!FileManager.default.fileExists(atPath: staged.url.path))
+    #expect(!FileManager.default.fileExists(atPath: root.path))
+  }
+
+  /// Sweeping runs at launch on a root that usually is not there, and staging
+  /// has to work straight afterwards.
+  @Test func sweepingAnAbsentRootIsHarmlessAndStagingStillWorks() throws {
+    let root = try scratch("absent")
+    try FileManager.default.removeItem(at: root)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    StagedTranscript.sweep(root: root)
+    let staged = try StagedTranscript.stage(text: "after", source: source, root: root)
+
+    #expect(try String(contentsOf: staged.url, encoding: .utf8) == "after")
+  }
+
+  /// A root replaced by a symlink would put the transcript wherever that link
+  /// points, so staging replaces it with a real directory instead.
+  @Test func aSymlinkedRootIsReplacedRatherThanFollowed() throws {
+    let parent = try scratch("symlink")
+    defer { try? FileManager.default.removeItem(at: parent) }
+    let elsewhere = parent.appending(path: "elsewhere")
+    try FileManager.default.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+    let root = parent.appending(path: "root")
+    try FileManager.default.createSymbolicLink(at: root, withDestinationURL: elsewhere)
+
+    let staged = try StagedTranscript.stage(text: "safe", source: source, root: root)
+
+    #expect(staged.url.path.hasPrefix(root.path))
+    #expect(try FileManager.default.contentsOfDirectory(atPath: elsewhere.path).isEmpty)
+  }
+
   /// Staged under the name it will keep, so what the user drags is already
   /// called what it will be called wherever they drop it.
   @Test func stagingKeepsTheNameTheTranscriptWillHave() throws {


### PR DESCRIPTION
Staged transcripts were only removed on `commit()` or `discard()`, so a crash or a force-quit while a card was on screen left the user's speech in cleartext under `$TMPDIR` with nothing to clean it up. `AppDelegate` now calls `StagedTranscript.sweep()` at launch, before anything can be staged, so everything it finds belongs to a run that is already over.

Also from the same issue: the staging folder is created 0700 and the file set to 0600 after the write (it has to be after, since `atomically` renames a temporary file into place), and a root that has been replaced by a symlink is removed rather than followed.

I left the third suggestion alone. Deferring the write until a drag begins would undo the "the file is real for the whole of the card's life" property that `StagedTranscript`'s own comment calls out, and quit-time commit depends on it.

Tested with four new cases in `StagedTranscriptTests` covering the permissions, the sweep clearing a staged file, sweeping an absent root and staging straight after, and a symlinked root being replaced rather than written through. Full suite passes locally.

Closes #58