### PR TITLE
[CHORE] Harden the key export, the AX casts and the ADR path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 
 Everything is on-device: Apple's `SpeechAnalyzer`/`SpeechTranscriber` for recognition, `AVSpeechSynthesizer` for Read Aloud. Talkify makes no network requests, stores no audio, and keeps no history beyond the local usage metrics you can see in Insights.
 
+One thing worth knowing: dictated text is inserted by pasting it, so it passes through the system clipboard for up to about half a second before your previous clipboard is put back. A clipboard manager or Universal Clipboard can see it during that window.
+
 ## Requirements
 
 - macOS 26 (Tahoe) on Apple Silicon

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -154,18 +154,31 @@ final class TextInsertionService {
     return await pasteAndRestoreClipboard(text, into: target)
   }
 
-  private static func focusedElement() -> AXUIElement? {
-    let systemWideElement = AXUIElementCreateSystemWide()
+  /// An AX attribute read as an element.
+  ///
+  /// `.success` says the attribute was read, not that it holds the type its
+  /// name implies, so the type is checked before the cast. CFTypeRef has no
+  /// meaningful `as?`, which is why this is a type-ID check rather than a
+  /// conditional cast.
+  private static func element(
+    _ owner: AXUIElement,
+    _ attribute: String
+  ) -> AXUIElement? {
     var value: CFTypeRef?
     guard AXUIElementCopyAttributeValue(
-      systemWideElement,
-      kAXFocusedUIElementAttribute as CFString,
+      owner,
+      attribute as CFString,
       &value
     ) == .success,
-    let value else {
+    let value,
+    CFGetTypeID(value) == AXUIElementGetTypeID() else {
       return nil
     }
     return (value as! AXUIElement)
+  }
+
+  private static func focusedElement() -> AXUIElement? {
+    element(AXUIElementCreateSystemWide(), kAXFocusedUIElementAttribute)
   }
 
   private func isSecureTextField(_ element: AXUIElement) -> Bool {
@@ -201,17 +214,7 @@ final class TextInsertionService {
   }
 
   private func window(for element: AXUIElement) -> AXUIElement? {
-    var value: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(
-      element,
-      kAXWindowAttribute as CFString,
-      &value
-    ) == .success,
-    let value else {
-      return nil
-    }
-
-    return (value as! AXUIElement)
+    Self.element(element, kAXWindowAttribute)
   }
 
   private func frame(of element: AXUIElement) -> CGRect? {

--- a/docs/adr/0001-simulated-notch-hud-on-all-displays.md
+++ b/docs/adr/0001-simulated-notch-hud-on-all-displays.md
@@ -5,5 +5,5 @@ The Direct Dictation HUD always descends from the top center of its display. Dis
 ## Consequences
 
 - One surface, one behavior. Only the notch measurement differs per display.
-- The proven implementation pattern lives in Tilebar's `NotchIsland` module (`/Users/tgomareli/Development/work/Tilebar-dev/Tilebar/Tilebar/Tilebar/Modules/NotchIsland/`): fixed-size host window whose origin moves but never resizes, measured-vs-simulated notch split in `NotchGeometry`, fillets only against a real housing, interactive-rects hit testing.
+- The proven implementation pattern comes from Tilebar's `NotchIsland` module, which is not public: fixed-size host window whose origin moves but never resizes, measured-vs-simulated notch split in `NotchGeometry`, fillets only against a real housing, interactive-rects hit testing. Talkify's own version of it is `CoreHUD/`, and `HUDNotchGeometry` is where the measured-vs-simulated split now lives.
 - No private APIs: the surface needs only `NSWindow.Level.mainMenu + 3`. A CGS/SkyLight call would rule out App Store distribution.

--- a/scripts/setup-sparkle-keys.sh
+++ b/scripts/setup-sparkle-keys.sh
@@ -17,6 +17,11 @@
 
 set -euo pipefail
 
+# generate_keys -x creates the private key under the process umask before the
+# chmod below can narrow it. Narrow it first instead, so the file is never
+# group- or world-readable, even briefly.
+umask 077
+
 fail() { echo "error: $*" >&2; exit 1; }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
All four items from the issue.

`setup-sparkle-keys.sh` sets `umask 077` before `generate_keys -x`, so the private key cannot exist group-readable in the window before `chmod 600`.

The two unguarded `as! AXUIElement` casts now go through one helper that checks `CFGetTypeID` first. I left the two `AXValue` casts alone: they already sit behind exactly that check, and a type-ID check is the correct idiom for CF types, which have no meaningful `as?`. Swapping them for something that looks safer would not be.

ADR-0001 no longer contains `/Users/tgomareli/Development/work/...`; it names the Tilebar module as non-public and points at `CoreHUD/` and `HUDNotchGeometry`, which is where that pattern actually lives now.

The README's privacy section gains a sentence about dictated text passing through the clipboard for about half a second, since a clipboard manager can observe it there.

Tested by build and the full suite locally; the AX helper has no test because those paths need a live focused element, which is what #60 is about. The script change was checked by reading it, not by regenerating a key pair.

Closes #61