### PR TITLE
[FEATURE] Lower other audio while dictating

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -135,6 +135,7 @@ _Avoid_: Transcript history, cloud analytics
 - **Direct Dictation** can lower other audio while it listens and put it back when the session ends, cancels or fails; it is off by default because the control it moves is system-wide
 - macOS has no per-application ducking, so lowering other audio moves the default output device's own volume and quiets Talkify's session sounds along with everything else
 - A lowered volume is restored only while it is still the value Talkify set: a volume the user changed mid-session is theirs, the same rule the clipboard restore follows
+- The device that was lowered is the one restored, not whichever output is default when the session ends: the default can change mid-session, and the volume that needs putting back belongs to the device that was quieted
 - An output with no settable volume does not duck, and neither does one already at silence
 - A third voice visual, Compact, shows a small five-bar voice indicator beside the leading-aligned live draft inside the shape, after the iOS Dynamic Island caption look; the shape grows with the draft
 - Compact is the only visual that shows the live draft while listening; Waveform and Edge Glow replace the draft text entirely

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -131,7 +131,11 @@ _Avoid_: Transcript history, cloud analytics
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation
 - Settings changes update the Appearance preview immediately, while an active Direct Dictation session keeps the choices captured at session start
-- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, sound volume, insertion destination, and the transcription history choice
+- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, sound volume, insertion destination, the transcription history choice, and whether the session lowers other audio
+- **Direct Dictation** can lower other audio while it listens and put it back when the session ends, cancels or fails; it is off by default because the control it moves is system-wide
+- macOS has no per-application ducking, so lowering other audio moves the default output device's own volume and quiets Talkify's session sounds along with everything else
+- A lowered volume is restored only while it is still the value Talkify set: a volume the user changed mid-session is theirs, the same rule the clipboard restore follows
+- An output with no settable volume does not duck, and neither does one already at silence
 - A third voice visual, Compact, shows a small five-bar voice indicator beside the leading-aligned live draft inside the shape, after the iOS Dynamic Island caption look; the shape grows with the draft
 - Compact is the only visual that shows the live draft while listening; Waveform and Edge Glow replace the draft text entirely
 - An In the Shape live-draft placement for Waveform and Edge Glow was prototyped and removed; the draft-in-shape presentation belongs to Compact alone

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -15,6 +15,7 @@ final class AppSettings {
   private enum Keys {
     static let soundSet = "dictationSoundSet"
     static let soundsEnabled = "dictationSoundsEnabled"
+    static let duckOtherAudio = "duckOtherAudioWhileDictating"
     static let soundVolume = "dictationSoundVolume"
     static let voiceVisual = "hudVoiceVisual"
     static let waveformStyle = "hudWaveformStyle"
@@ -41,6 +42,13 @@ final class AppSettings {
 
   var soundSet: DictationSoundSet {
     didSet { defaults.set(soundSet.rawValue, forKey: Keys.soundSet) }
+  }
+
+  /// Lowers the system output while a session listens. Off by default: it
+  /// moves a system-wide control, which is not something to start doing to
+  /// someone who did not ask for it.
+  var duckOtherAudioWhileDictating: Bool {
+    didSet { defaults.set(duckOtherAudioWhileDictating, forKey: Keys.duckOtherAudio) }
   }
 
   var dictationSoundsEnabled: Bool {
@@ -202,6 +210,7 @@ final class AppSettings {
     self.defaults = defaults
     soundSet = Self.stored(in: defaults, key: Keys.soundSet) ?? .synth8
     dictationSoundsEnabled = defaults.object(forKey: Keys.soundsEnabled) as? Bool ?? true
+    duckOtherAudioWhileDictating = defaults.object(forKey: Keys.duckOtherAudio) as? Bool ?? false
     let storedSoundVolume = defaults.object(forKey: Keys.soundVolume) as? Double ?? 0.5
     storedDictationSoundVolume = DictationSoundSettings.normalizedVolume(storedSoundVolume)
     transcriptDestination = Self.stored(in: defaults, key: Keys.transcriptDestination) ?? .besideSource
@@ -259,6 +268,9 @@ struct DictationSessionSettings: Equatable {
   let insertionDestination: InsertionDestination
   let historyEnabled: Bool
   let historyFolder: URL
+  /// Captured with everything else: a session that started while ducking was
+  /// on has to restore the volume even if the toggle flips mid-session.
+  let ducksOtherAudio: Bool
   let voiceVisual: HUDVoiceVisualStyle
   let waveformStyle: HUDWaveformStyle
   let revealStyle: HUDRevealStyle
@@ -285,6 +297,7 @@ struct DictationSessionSettings: Equatable {
     insertionDestination = settings.insertionDestination
     historyEnabled = settings.dictationHistoryEnabled
     historyFolder = settings.resolvedHistoryFolder
+    ducksOtherAudio = settings.duckOtherAudioWhileDictating
     voiceVisual = settings.voiceVisual
     waveformStyle = settings.waveformStyle
     revealStyle = settings.revealStyle

--- a/Talkify/Dictation/AudioDucker.swift
+++ b/Talkify/Dictation/AudioDucker.swift
@@ -1,0 +1,129 @@
+import CoreAudio
+import Foundation
+
+/// Lowers the system output while a Direct Dictation session listens, and puts
+/// it back afterwards.
+///
+/// macOS has no per-application ducking. `kAudioSessionProperty_Other`
+/// `MixableAudioShouldDuck`, which is how this is done on iOS, is
+/// `API_UNAVAILABLE(macos)`, and nothing has replaced it. What is available is
+/// the default output device's own volume, so that is what moves. The cost is
+/// that it moves for everything, Talkify's own session sounds included, which
+/// is why the ducking starts after the Begin sound and ends before the End one.
+///
+/// Restoring is guarded the way the clipboard restore is: if the volume is no
+/// longer the value this type set, the user moved it during the session and
+/// their number wins. Better to leave the volume alone than to overwrite a
+/// deliberate change with a stale one.
+struct AudioDucker {
+  /// What the output drops to while listening, as a fraction of where it was.
+  static let duckedFraction: Float = 0.2
+
+  /// A device with no settable main volume, an aggregate or some HDMI outputs,
+  /// simply does not duck.
+  private var device: AudioDeviceID? {
+    var deviceID = AudioDeviceID(0)
+    var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+    var address = AudioObjectPropertyAddress(
+      mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+      mScope: kAudioObjectPropertyScopeGlobal,
+      mElement: kAudioObjectPropertyElementMain
+    )
+    let status = AudioObjectGetPropertyData(
+      AudioObjectID(kAudioObjectSystemObject),
+      &address,
+      0,
+      nil,
+      &size,
+      &deviceID
+    )
+    guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+    return deviceID
+  }
+
+  private func volumeAddress() -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(
+      mSelector: kAudioDevicePropertyVolumeScalar,
+      mScope: kAudioDevicePropertyScopeOutput,
+      mElement: kAudioObjectPropertyElementMain
+    )
+  }
+
+  func volume() -> Float? {
+    guard let device else { return nil }
+    var address = volumeAddress()
+    guard AudioObjectHasProperty(device, &address) else { return nil }
+    var value = Float(0)
+    var size = UInt32(MemoryLayout<Float>.size)
+    let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value)
+    guard status == noErr else { return nil }
+    return value
+  }
+
+  @discardableResult
+  func setVolume(_ value: Float) -> Bool {
+    guard let device else { return false }
+    var address = volumeAddress()
+    guard AudioObjectHasProperty(device, &address) else { return false }
+    var settable = DarwinBoolean(false)
+    guard AudioObjectIsPropertySettable(device, &address, &settable) == noErr,
+       settable.boolValue
+    else {
+      return false
+    }
+    var value = max(0, min(1, value))
+    let size = UInt32(MemoryLayout<Float>.size)
+    return AudioObjectSetPropertyData(device, &address, 0, nil, size, &value) == noErr
+  }
+}
+
+/// Holds the one duck in flight. Separate from the pure device access above so
+/// the decisions — when to duck, when to leave the volume alone — can be
+/// tested without a sound card.
+@MainActor
+final class AudioDuckingSession {
+  /// The volume before ducking, and what this type set it to. Both are needed:
+  /// the first to restore, the second to notice the user moving it in between.
+  private var original: Float?
+  private var applied: Float?
+
+  private let readVolume: () -> Float?
+  private let writeVolume: (Float) -> Bool
+
+  init(
+    readVolume: @escaping () -> Float? = { AudioDucker().volume() },
+    writeVolume: @escaping (Float) -> Bool = { AudioDucker().setVolume($0) }
+  ) {
+    self.readVolume = readVolume
+    self.writeVolume = writeVolume
+  }
+
+  var isDucked: Bool { original != nil }
+
+  func duck(to fraction: Float = AudioDucker.duckedFraction) {
+    // Already ducked: a second session must not stack, or restoring would put
+    // back a volume that was itself already lowered.
+    guard original == nil, let current = readVolume() else { return }
+    // Nothing playing loudly enough to be in the way, and ducking silence
+    // only risks restoring over a change the user makes meanwhile.
+    guard current > 0 else { return }
+
+    let target = current * fraction
+    guard writeVolume(target) else { return }
+    original = current
+    applied = target
+  }
+
+  func restore() {
+    defer {
+      original = nil
+      applied = nil
+    }
+    guard let original, let applied else { return }
+    // The user reached for the volume during the session, so their number
+    // wins. Same rule as the clipboard restore: never overwrite a deliberate
+    // change with a stale one.
+    guard let current = readVolume(), abs(current - applied) < 0.001 else { return }
+    _ = writeVolume(original)
+  }
+}

--- a/Talkify/Dictation/AudioDucker.swift
+++ b/Talkify/Dictation/AudioDucker.swift
@@ -7,9 +7,9 @@ import Foundation
 /// macOS has no per-application ducking. `kAudioSessionProperty_Other`
 /// `MixableAudioShouldDuck`, which is how this is done on iOS, is
 /// `API_UNAVAILABLE(macos)`, and nothing has replaced it. What is available is
-/// the default output device's own volume, so that is what moves. The cost is
-/// that it moves for everything, Talkify's own session sounds included, which
-/// is why the ducking starts after the Begin sound and ends before the End one.
+/// an output device's own volume, so that is what moves. The cost is that it
+/// moves for everything, Talkify's own session sounds included, which is why
+/// the ducking starts after the Begin sound and ends before the End one.
 ///
 /// Restoring is guarded the way the clipboard restore is: if the volume is no
 /// longer the value this type set, the user moved it during the session and
@@ -19,9 +19,10 @@ struct AudioDucker {
   /// What the output drops to while listening, as a fraction of where it was.
   static let duckedFraction: Float = 0.2
 
-  /// A device with no settable main volume, an aggregate or some HDMI outputs,
-  /// simply does not duck.
-  private var device: AudioDeviceID? {
+  /// The default output right now. Only read when a duck begins: the device is
+  /// then remembered, because the default can change mid-session and the
+  /// volume that needs putting back belongs to the device that was lowered.
+  static func defaultOutputDevice() -> AudioDeviceID? {
     var deviceID = AudioDeviceID(0)
     var size = UInt32(MemoryLayout<AudioDeviceID>.size)
     var address = AudioObjectPropertyAddress(
@@ -41,7 +42,7 @@ struct AudioDucker {
     return deviceID
   }
 
-  private func volumeAddress() -> AudioObjectPropertyAddress {
+  private static func volumeAddress() -> AudioObjectPropertyAddress {
     AudioObjectPropertyAddress(
       mSelector: kAudioDevicePropertyVolumeScalar,
       mScope: kAudioDevicePropertyScopeOutput,
@@ -49,20 +50,21 @@ struct AudioDucker {
     )
   }
 
-  func volume() -> Float? {
-    guard let device else { return nil }
+  /// A device with no settable main volume, an aggregate or some HDMI outputs,
+  /// answers nil and simply does not duck.
+  static func volume(of device: AudioDeviceID) -> Float? {
     var address = volumeAddress()
     guard AudioObjectHasProperty(device, &address) else { return nil }
     var value = Float(0)
     var size = UInt32(MemoryLayout<Float>.size)
-    let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value)
-    guard status == noErr else { return nil }
+    guard AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value) == noErr else {
+      return nil
+    }
     return value
   }
 
   @discardableResult
-  func setVolume(_ value: Float) -> Bool {
-    guard let device else { return false }
+  static func setVolume(_ value: Float, of device: AudioDeviceID) -> Bool {
     var address = volumeAddress()
     guard AudioObjectHasProperty(device, &address) else { return false }
     var settable = DarwinBoolean(false)
@@ -77,53 +79,66 @@ struct AudioDucker {
   }
 }
 
-/// Holds the one duck in flight. Separate from the pure device access above so
-/// the decisions — when to duck, when to leave the volume alone — can be
-/// tested without a sound card.
+/// Holds the one duck in flight. Separate from the device access above so the
+/// decisions — when to duck, when to leave the volume alone — can be tested
+/// without a sound card.
 @MainActor
 final class AudioDuckingSession {
-  /// The volume before ducking, and what this type set it to. Both are needed:
-  /// the first to restore, the second to notice the user moving it in between.
-  private var original: Float?
-  private var applied: Float?
+  /// The device that was lowered, the volume it had, and what this type set it
+  /// to. The device is remembered because the default output can change during
+  /// a session: restoring against whatever is default at the end would read a
+  /// volume this type never set, decline to touch it, and leave the device it
+  /// actually lowered quiet.
+  private var ducked: (device: AudioDeviceID, original: Float, applied: Float)?
 
-  private let readVolume: () -> Float?
-  private let writeVolume: (Float) -> Bool
+  private let defaultDevice: () -> AudioDeviceID?
+  private let readVolume: (AudioDeviceID) -> Float?
+  private let writeVolume: (AudioDeviceID, Float) -> Bool
 
   init(
-    readVolume: @escaping () -> Float? = { AudioDucker().volume() },
-    writeVolume: @escaping (Float) -> Bool = { AudioDucker().setVolume($0) }
+    defaultDevice: @escaping () -> AudioDeviceID? = AudioDucker.defaultOutputDevice,
+    readVolume: @escaping (AudioDeviceID) -> Float? = AudioDucker.volume(of:),
+    writeVolume: @escaping (AudioDeviceID, Float) -> Bool = { device, value in
+      AudioDucker.setVolume(value, of: device)
+    }
   ) {
+    self.defaultDevice = defaultDevice
     self.readVolume = readVolume
     self.writeVolume = writeVolume
   }
 
-  var isDucked: Bool { original != nil }
+  var isDucked: Bool { ducked != nil }
 
   func duck(to fraction: Float = AudioDucker.duckedFraction) {
     // Already ducked: a second session must not stack, or restoring would put
     // back a volume that was itself already lowered.
-    guard original == nil, let current = readVolume() else { return }
+    guard ducked == nil,
+       let device = defaultDevice(),
+       let current = readVolume(device)
+    else {
+      return
+    }
     // Nothing playing loudly enough to be in the way, and ducking silence
     // only risks restoring over a change the user makes meanwhile.
     guard current > 0 else { return }
 
     let target = current * fraction
-    guard writeVolume(target) else { return }
-    original = current
-    applied = target
+    guard writeVolume(device, target) else { return }
+    ducked = (device: device, original: current, applied: target)
   }
 
   func restore() {
-    defer {
-      original = nil
-      applied = nil
-    }
-    guard let original, let applied else { return }
+    guard let ducked else { return }
+    self.ducked = nil
     // The user reached for the volume during the session, so their number
     // wins. Same rule as the clipboard restore: never overwrite a deliberate
-    // change with a stale one.
-    guard let current = readVolume(), abs(current - applied) < 0.001 else { return }
-    _ = writeVolume(original)
+    // change with a stale one. Read from the device that was lowered, not from
+    // whatever is default now.
+    guard let current = readVolume(ducked.device),
+       abs(current - ducked.applied) < 0.001
+    else {
+      return
+    }
+    _ = writeVolume(ducked.device, ducked.original)
   }
 }

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -25,6 +25,7 @@ final class DirectDictationController {
 
   private var keyEventMonitor: GlobalKeyEventMonitor?
   private var machine = DictationSessionMachine()
+  private let ducking = AudioDuckingSession()
   private var focusedTarget: TextInsertionService.Target?
   private var noSpeechTask: Task<Void, Never>?
   private var permissionTask: Task<Void, Never>?
@@ -176,6 +177,8 @@ final class DirectDictationController {
   }
 
   func stop() {
+    // Before anything else: quitting mid-session must not leave the Mac quiet.
+    ducking.restore()
     noSpeechTask?.cancel()
     permissionTask?.cancel()
     permissionWatchTask?.cancel()
@@ -348,7 +351,13 @@ final class DirectDictationController {
     case .hideHUD:
       dependencies.hideHUD()
     case let .notifyRecording(isRecording):
-      if !isRecording {
+      // Ducking rides this effect because it is the one signal that fires on
+      // every terminal path — inserted, cancelled, failed, or timed out — so
+      // the volume cannot be left down by a route nobody thought about.
+      if isRecording {
+        if currentSessionSettings?.ducksOtherAudio == true { ducking.duck() }
+      } else {
+        ducking.restore()
         focusedTarget = nil
         sessionStartTask = nil
         currentSessionSettings = nil

--- a/Talkify/Settings/Sections/SoundsSettingsView.swift
+++ b/Talkify/Settings/Sections/SoundsSettingsView.swift
@@ -11,6 +11,18 @@ struct SoundsSettingsView: View {
   @State private var previewTask: Task<Void, Never>?
 
   var body: some View {
+    SettingsCard(title: "While dictating") {
+      SettingsRow(
+        title: "Lower other audio",
+        description: "Turn the volume down while a session listens, and put it "
+          + "back afterwards. Moves the system output, so it quiets everything"
+      ) {
+        Toggle("Lower other audio", isOn: $settings.duckOtherAudioWhileDictating)
+          .labelsHidden()
+          .toggleStyle(.switch)
+      }
+    }
+
     SettingsCard(title: "Sounds") {
       SettingsRow(
         title: "Play sounds",

--- a/TalkifyTests/AudioDuckingTests.swift
+++ b/TalkifyTests/AudioDuckingTests.swift
@@ -1,0 +1,107 @@
+import Testing
+@testable import Talkify
+
+/// When Talkify is allowed to move the system volume and when it must leave it
+/// alone. The device access is separate from these decisions, so none of this
+/// needs a sound card.
+@MainActor
+struct AudioDuckingTests {
+  @MainActor
+  private final class FakeOutput {
+    var volume: Float?
+    var writes: [Float] = []
+
+    func session() -> AudioDuckingSession {
+      AudioDuckingSession(
+        readVolume: { [self] in volume },
+        writeVolume: { [self] value in
+          volume = value
+          writes.append(value)
+          return true
+        }
+      )
+    }
+  }
+
+  @Test func duckingLowersTheOutputAndRestoringPutsItBack() {
+    let output = FakeOutput()
+    output.volume = 0.8
+    let session = output.session()
+
+    session.duck(to: 0.25)
+    #expect(output.volume == 0.2)
+    #expect(session.isDucked)
+
+    session.restore()
+    #expect(output.volume == 0.8)
+    #expect(!session.isDucked)
+  }
+
+  /// The rule the clipboard restore already follows: a value the user changed
+  /// during the session is theirs, and must not be overwritten with a stale one.
+  @Test func aVolumeChangedDuringTheSessionIsLeftAlone() {
+    let output = FakeOutput()
+    output.volume = 0.8
+    let session = output.session()
+
+    session.duck(to: 0.25)
+    output.volume = 0.5
+
+    session.restore()
+    #expect(output.volume == 0.5)
+    #expect(!session.isDucked)
+  }
+
+  /// Ducking twice would restore to an already-lowered volume, leaving the Mac
+  /// quieter after every session than before it.
+  @Test func duckingIsNotCumulative() {
+    let output = FakeOutput()
+    output.volume = 1.0
+    let session = output.session()
+
+    session.duck(to: 0.5)
+    session.duck(to: 0.5)
+    #expect(output.volume == 0.5)
+
+    session.restore()
+    #expect(output.volume == 1.0)
+  }
+
+  @Test func restoringWithoutDuckingChangesNothing() {
+    let output = FakeOutput()
+    output.volume = 0.4
+    let session = output.session()
+
+    session.restore()
+    #expect(output.writes.isEmpty)
+    #expect(output.volume == 0.4)
+  }
+
+  /// Silence needs no ducking, and ducking it would only put this in a
+  /// position to restore over a change the user makes meanwhile.
+  @Test func silenceIsNotDucked() {
+    let output = FakeOutput()
+    output.volume = 0
+    let session = output.session()
+
+    session.duck()
+    #expect(!session.isDucked)
+    #expect(output.writes.isEmpty)
+  }
+
+  /// A device with no settable volume, an aggregate or some HDMI outputs.
+  @Test func anOutputWithNoVolumeControlIsNotDucked() {
+    let session = AudioDuckingSession(readVolume: { nil }, writeVolume: { _ in false })
+    session.duck()
+    #expect(!session.isDucked)
+    session.restore()
+  }
+
+  /// A write that fails leaves nothing to restore, rather than recording a
+  /// duck that never happened and later stamping the old value back.
+  @Test func aFailedWriteDoesNotCountAsDucked() {
+    let session = AudioDuckingSession(readVolume: { 0.7 }, writeVolume: { _ in false })
+    session.duck()
+    #expect(!session.isDucked)
+  }
+}

--- a/TalkifyTests/AudioDuckingTests.swift
+++ b/TalkifyTests/AudioDuckingTests.swift
@@ -1,106 +1,159 @@
+import CoreAudio
 import Testing
 @testable import Talkify
 
-/// When Talkify is allowed to move the system volume and when it must leave it
+/// When Talkify is allowed to move an output's volume and when it must leave it
 /// alone. The device access is separate from these decisions, so none of this
 /// needs a sound card.
 @MainActor
 struct AudioDuckingTests {
+  /// A pretend set of output devices, with one of them current.
   @MainActor
-  private final class FakeOutput {
-    var volume: Float?
-    var writes: [Float] = []
+  private final class FakeAudio {
+    var volumes: [AudioDeviceID: Float] = [:]
+    var current: AudioDeviceID?
+    var writes: [(device: AudioDeviceID, value: Float)] = []
+    /// Devices that report no settable volume: aggregates, some HDMI outputs.
+    var unsettable: Set<AudioDeviceID> = []
 
     func session() -> AudioDuckingSession {
       AudioDuckingSession(
-        readVolume: { [self] in volume },
-        writeVolume: { [self] value in
-          volume = value
-          writes.append(value)
+        defaultDevice: { [self] in current },
+        readVolume: { [self] device in volumes[device] },
+        writeVolume: { [self] device, value in
+          guard !unsettable.contains(device) else { return false }
+          volumes[device] = value
+          writes.append((device, value))
           return true
         }
       )
     }
   }
 
+  private let speakers: AudioDeviceID = 1
+  private let airPods: AudioDeviceID = 2
+
   @Test func duckingLowersTheOutputAndRestoringPutsItBack() {
-    let output = FakeOutput()
-    output.volume = 0.8
-    let session = output.session()
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 0.8]
+    audio.current = speakers
+    let session = audio.session()
 
     session.duck(to: 0.25)
-    #expect(output.volume == 0.2)
+    #expect(audio.volumes[speakers] == 0.2)
     #expect(session.isDucked)
 
     session.restore()
-    #expect(output.volume == 0.8)
+    #expect(audio.volumes[speakers] == 0.8)
     #expect(!session.isDucked)
   }
 
   /// The rule the clipboard restore already follows: a value the user changed
   /// during the session is theirs, and must not be overwritten with a stale one.
   @Test func aVolumeChangedDuringTheSessionIsLeftAlone() {
-    let output = FakeOutput()
-    output.volume = 0.8
-    let session = output.session()
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 0.8]
+    audio.current = speakers
+    let session = audio.session()
 
     session.duck(to: 0.25)
-    output.volume = 0.5
+    audio.volumes[speakers] = 0.5
 
     session.restore()
-    #expect(output.volume == 0.5)
+    #expect(audio.volumes[speakers] == 0.5)
     #expect(!session.isDucked)
+  }
+
+  /// The regression: AirPods connecting mid-sentence makes them the default
+  /// output, and restoring against the new default read a volume Talkify never
+  /// set, declined to touch it, and left the speakers quiet.
+  @Test func theDeviceThatWasLoweredIsTheOneRestored() {
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 1.0, airPods: 0.5]
+    audio.current = speakers
+    let session = audio.session()
+
+    session.duck(to: 0.2)
+    #expect(audio.volumes[speakers] == 0.2)
+
+    // AirPods connect and become the default output mid-session.
+    audio.current = airPods
+
+    session.restore()
+    #expect(audio.volumes[speakers] == 1.0, "the lowered device was left quiet")
+    #expect(audio.volumes[airPods] == 0.5, "an untouched device must stay untouched")
   }
 
   /// Ducking twice would restore to an already-lowered volume, leaving the Mac
   /// quieter after every session than before it.
   @Test func duckingIsNotCumulative() {
-    let output = FakeOutput()
-    output.volume = 1.0
-    let session = output.session()
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 1.0]
+    audio.current = speakers
+    let session = audio.session()
 
     session.duck(to: 0.5)
     session.duck(to: 0.5)
-    #expect(output.volume == 0.5)
+    #expect(audio.volumes[speakers] == 0.5)
 
     session.restore()
-    #expect(output.volume == 1.0)
+    #expect(audio.volumes[speakers] == 1.0)
   }
 
   @Test func restoringWithoutDuckingChangesNothing() {
-    let output = FakeOutput()
-    output.volume = 0.4
-    let session = output.session()
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 0.4]
+    audio.current = speakers
+    let session = audio.session()
 
     session.restore()
-    #expect(output.writes.isEmpty)
-    #expect(output.volume == 0.4)
+    #expect(audio.writes.isEmpty)
+    #expect(audio.volumes[speakers] == 0.4)
   }
 
   /// Silence needs no ducking, and ducking it would only put this in a
   /// position to restore over a change the user makes meanwhile.
   @Test func silenceIsNotDucked() {
-    let output = FakeOutput()
-    output.volume = 0
-    let session = output.session()
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 0]
+    audio.current = speakers
+    let session = audio.session()
 
     session.duck()
     #expect(!session.isDucked)
-    #expect(output.writes.isEmpty)
+    #expect(audio.writes.isEmpty)
   }
 
   /// A device with no settable volume, an aggregate or some HDMI outputs.
   @Test func anOutputWithNoVolumeControlIsNotDucked() {
-    let session = AudioDuckingSession(readVolume: { nil }, writeVolume: { _ in false })
+    let audio = FakeAudio()
+    audio.current = speakers
+    let session = audio.session()
+
     session.duck()
     #expect(!session.isDucked)
     session.restore()
+    #expect(audio.writes.isEmpty)
   }
 
   /// A write that fails leaves nothing to restore, rather than recording a
   /// duck that never happened and later stamping the old value back.
   @Test func aFailedWriteDoesNotCountAsDucked() {
-    let session = AudioDuckingSession(readVolume: { 0.7 }, writeVolume: { _ in false })
+    let audio = FakeAudio()
+    audio.volumes = [speakers: 0.7]
+    audio.current = speakers
+    audio.unsettable = [speakers]
+    let session = audio.session()
+
+    session.duck()
+    #expect(!session.isDucked)
+  }
+
+  /// No output at all, which is what a Mac with every device removed reports.
+  @Test func noDefaultOutputIsNotDucked() {
+    let audio = FakeAudio()
+    let session = audio.session()
+
     session.duck()
     #expect(!session.isDucked)
   }


### PR DESCRIPTION
Adds an optional, off-by-default **Lower other audio** setting that turns the volume down while a Direct Dictation session listens and puts it back when it ends.

## Why it works this way

macOS has no per-application ducking. `kAudioSessionProperty_OtherMixableAudioShouldDuck`, which is how iOS does this, is `API_UNAVAILABLE(macos)` in the current SDK and nothing replaced it. There is no way to ask the system to quiet everyone else while leaving you alone.

What is available is the default output device's own volume, so that is what moves: `kAudioHardwarePropertyDefaultOutputDevice` to find the device, then `kAudioDevicePropertyVolumeScalar` on the output scope's main element. The unavoidable cost is that it quiets Talkify's own Begin and End sounds too, and that is why the setting's description says it moves the system output rather than pretending to be per-app. It is off by default: silently taking over a system-wide control is not something to do to someone who did not ask for it.

## Shape

`AudioDucker` is the device access, and nothing else: read the volume, write the volume, answer nil when the device has no settable one (aggregates and some HDMI outputs). `AudioDuckingSession` holds the decisions and takes both accessors as closures, which is what makes the rules testable without a sound card.

The rules it enforces:

- **Restoring is guarded.** It records both the original volume and the value it set. On restore, if the current volume is not the value it set, the user reached for the volume mid-session and their number wins. This is the same rule `TextInsertionService` already applies to the clipboard, and it is the difference between a feature and something that fights you.
- **Ducking does not stack.** A second duck before a restore would make the restore put back an already-lowered volume, so every session would leave the Mac quieter than it found it.
- **Silence is not ducked**, and neither is an output with no settable volume, and a failed write does not record a duck. Each of those would otherwise leave state that restore would later act on.

The duck rides the `notifyRecording` effect rather than the begin or end paths, because it is the one signal the machine produces on every terminal route: inserted, cancelled, escaped, failed, and the no-speech timeout. There is no path that ends a session without it, so there is no path that leaves the volume down. `stop()` restores as well, so quitting mid-session cannot either.

The choice rides the session settings snapshot (ADR-0004), so flipping the toggle mid-session cannot leave a session that ducked without one that restores.

One thing I did not solve: if Talkify is force-killed while ducked, the volume stays down, because the original is only in memory and there is no sensible value to restore at next launch. Persisting it would risk stamping a stale volume over a fresh boot.

`CONTEXT.md` gains the domain rules for all of the above.

Tested with seven cases in `AudioDuckingTests` covering the round trip, the user-moved-it guard, non-cumulative ducking, restore-without-duck, silence, an output with no volume control, and a failed write. The Core Audio calls themselves are not tested; I have not verified on a real device with music playing, so that is worth a listen before merging. Full suite passes locally.

Closes #55