### PR TITLE
[FEATURE] Let the user choose where finished dictation text goes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,10 @@ _Avoid_: Drop zone, catch area
 A finished **Drop Transcription** held in a temporary folder under its final name while the HUD offers it, before a drag or the card's timer decides where it lands.
 _Avoid_: Draft, cache, pending file
 
+**Insertion destination**:
+Where a finished **Direct Dictation** session's text goes: into the focused control, onto the clipboard, or both.
+_Avoid_: Output mode, result mode, paste mode
+
 **Settings section**:
 A navigable category of persisted application preferences with a visible user-facing purpose.
 _Avoid_: Placeholder tab, settings page
@@ -131,7 +135,7 @@ _Avoid_: Transcript history, cloud analytics
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation
 - Settings changes update the Appearance preview immediately, while an active Direct Dictation session keeps the choices captured at session start
-- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, and sound volume
+- Dictation session settings include the voice visual, waveform style, glow palette, glow center, reveal style, long-draft behavior, HUD size, sound set, sound enabled state, sound volume, and the insertion destination
 - A third voice visual, Compact, shows a small five-bar voice indicator beside the leading-aligned live draft inside the shape, after the iOS Dynamic Island caption look; the shape grows with the draft
 - Compact is the only visual that shows the live draft while listening; Waveform and Edge Glow replace the draft text entirely
 - An In the Shape live-draft placement for Waveform and Edge Glow was prototyped and removed; the draft-in-shape presentation belongs to Compact alone
@@ -196,7 +200,12 @@ _Avoid_: Transcript history, cloud analytics
 - Pressing Escape cancels active **Direct Dictation** immediately without inserting text
 - If **Direct Dictation** hears no speech in the first 15 seconds, it closes and inserts nothing
 - Once speech has arrived, the session stays open until the user ends or cancels it
-- **Direct Dictation** ends by inserting text into the previously focused control
+- **Direct Dictation** ends by inserting text into the previously focused control, unless the **Insertion destination** says otherwise
+- The **Insertion destination** is a Settings pick with three values: insert into the app (paste, then restore the previous clipboard, the default and the behaviour that shipped before the pick existed), copy to the clipboard (never paste), and insert and copy (paste and deliberately leave the text on the clipboard)
+- Copy to the clipboard returns before focus validation, because a session with nothing to paste into has no target to validate
+- Insert and copy skips the clipboard snapshot and the guarded restore, since leaving the text on the clipboard is the whole point of it
+- A copy-to-the-clipboard session is a completed session: it plays the Paste sound and records **Insights** usage like any other
+- The **Insertion destination** rides the Dictation session settings snapshot, so changing the pick mid-session cannot send that session's text somewhere it did not agree to
 - **Direct Dictation** inserts through clipboard paste after Accessibility validates the original target
 - If an app exposes no focused element, Talkify captures and later validates the frontmost application instead
 - Talkify sends the paste event globally only after the captured focus boundary passes validation

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -15,6 +15,7 @@ final class AppSettings {
   private enum Keys {
     static let soundSet = "dictationSoundSet"
     static let soundsEnabled = "dictationSoundsEnabled"
+    static let insertionDestination = "insertionDestination"
     static let soundVolume = "dictationSoundVolume"
     static let voiceVisual = "hudVoiceVisual"
     static let waveformStyle = "hudWaveformStyle"
@@ -38,6 +39,14 @@ final class AppSettings {
 
   var soundSet: DictationSoundSet {
     didSet { defaults.set(soundSet.rawValue, forKey: Keys.soundSet) }
+  }
+
+  /// Where a finished session's text goes. Defaults to the behaviour that
+  /// shipped before the pick existed.
+  var insertionDestination: InsertionDestination {
+    didSet {
+      defaults.set(insertionDestination.rawValue, forKey: Keys.insertionDestination)
+    }
   }
 
   var dictationSoundsEnabled: Bool {
@@ -175,6 +184,7 @@ final class AppSettings {
     self.defaults = defaults
     soundSet = Self.stored(in: defaults, key: Keys.soundSet) ?? .synth8
     dictationSoundsEnabled = defaults.object(forKey: Keys.soundsEnabled) as? Bool ?? true
+    insertionDestination = Self.stored(in: defaults, key: Keys.insertionDestination) ?? .insert
     let storedSoundVolume = defaults.object(forKey: Keys.soundVolume) as? Double ?? 0.5
     storedDictationSoundVolume = DictationSoundSettings.normalizedVolume(storedSoundVolume)
     transcriptDestination = Self.stored(in: defaults, key: Keys.transcriptDestination) ?? .besideSource
@@ -226,6 +236,9 @@ final class AppSettings {
 /// this value until its end and paste sounds have played.
 struct DictationSessionSettings: Equatable {
   let sounds: DictationSoundSettings
+  /// Captured with everything else, so changing the pick mid-session cannot
+  /// send the text somewhere the session did not agree to (ADR-0004).
+  let insertionDestination: InsertionDestination
   let voiceVisual: HUDVoiceVisualStyle
   let waveformStyle: HUDWaveformStyle
   let revealStyle: HUDRevealStyle
@@ -249,6 +262,7 @@ struct DictationSessionSettings: Equatable {
       isEnabled: settings.dictationSoundsEnabled,
       volume: settings.dictationSoundVolume
     )
+    insertionDestination = settings.insertionDestination
     voiceVisual = settings.voiceVisual
     waveformStyle = settings.waveformStyle
     revealStyle = settings.revealStyle

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -437,7 +437,11 @@ final class DirectDictationController {
       do {
         let text = try await speechService.finish()
         hudController.hide()
-        let outcome = await textInsertionService.insert(text, into: focusedTarget)
+        let outcome = await textInsertionService.insert(
+          text,
+          into: focusedTarget,
+          destination: currentSessionSettings?.insertionDestination ?? .insert
+        )
         switch outcome {
         case .inserted, .copiedToClipboard:
           hudController.playPasteSound()

--- a/Talkify/Dictation/InsertionDestination.swift
+++ b/Talkify/Dictation/InsertionDestination.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Where a finished Direct Dictation session's text goes.
+///
+/// Pasting and restoring the clipboard is right for most people and stays the
+/// default, but it fights two real cases: someone who wants to place the text
+/// themselves rather than have it land wherever focus happened to sit, and
+/// anyone running a clipboard-history manager, whose history never keeps a
+/// dictation because the restore puts the old clipboard back over it.
+///
+/// The raw values are persisted picks and are load-bearing (CLAUDE.md).
+enum InsertionDestination: String, CaseIterable, Sendable {
+  /// Paste into the focused control, then put the previous clipboard back.
+  case insert
+  /// Leave the text on the clipboard and paste nothing.
+  case clipboard
+  /// Paste into the focused control and deliberately leave the text on the
+  /// clipboard, so a history manager keeps it.
+  case insertAndCopy
+
+  var title: String {
+    switch self {
+    case .insert: "Insert into the app"
+    case .clipboard: "Copy to the clipboard"
+    case .insertAndCopy: "Insert and copy"
+    }
+  }
+
+  var detail: String {
+    switch self {
+    case .insert: "Paste where you were typing, then restore your clipboard"
+    case .clipboard: "Never paste. Leave the words on the clipboard for you to place"
+    case .insertAndCopy: "Paste where you were typing and keep the words on the clipboard"
+    }
+  }
+
+  /// Whether the session has a focused control to paste into. Clipboard-only
+  /// has no target, so it never validates one.
+  var pastes: Bool { self != .clipboard }
+
+  /// Whether the previous clipboard is put back afterwards. Insert-and-copy
+  /// exists precisely to leave it alone.
+  var restoresClipboard: Bool { self == .insert }
+}

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -138,8 +138,17 @@ final class TextInsertionService {
   ///   - text: The finalized text to deliver.
   ///   - target: The focus boundary captured when Direct Dictation began.
   /// - Returns: The terminal delivery outcome used by the session controller.
-  func insert(_ text: String, into target: Target?) async -> InsertionOutcome {
+  func insert(
+    _ text: String,
+    into target: Target?,
+    destination: InsertionDestination = .insert
+  ) async -> InsertionOutcome {
     guard !text.isEmpty else { return .inserted }
+
+    // Clipboard-only returns before any of the target checks: there is no
+    // control to paste into, so there is nothing to validate.
+    guard destination.pastes else { return copyToClipboard(text) }
+
     guard let target else {
       return copyToClipboard(text)
     }
@@ -151,7 +160,26 @@ final class TextInsertionService {
     guard dependencies.isTargetFocused(target) else {
       return copyToClipboard(text)
     }
+
+    guard destination.restoresClipboard else {
+      return await pasteLeavingClipboard(text, into: target)
+    }
     return await pasteAndRestoreClipboard(text, into: target)
+  }
+
+  /// Insert-and-copy: the text is put on the clipboard and left there, so the
+  /// snapshot and the guarded restore are skipped entirely. Leaving it is the
+  /// point of the pick, and it is what lets a clipboard-history manager keep
+  /// the dictation.
+  private func pasteLeavingClipboard(
+    _ text: String,
+    into target: Target
+  ) async -> InsertionOutcome {
+    guard copyToClipboard(text) == .copiedToClipboard else { return .unavailable }
+    guard dependencies.isTargetFocused(target) else { return .copiedToClipboard }
+    guard dependencies.postPasteShortcut() else { return .copiedToClipboard }
+    await dependencies.waitForPasteRead()
+    return .inserted
   }
 
   private static func focusedElement() -> AXUIElement? {

--- a/Talkify/Settings/Sections/DictationSettingsView.swift
+++ b/Talkify/Settings/Sections/DictationSettingsView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// The Dictation section: what happens to the words once a session ends.
+///
+/// Pasting and restoring the clipboard is right for most people and stays the
+/// default. The other two picks exist for people it fights: someone who wants
+/// to place the text themselves, and anyone whose clipboard-history manager
+/// never keeps a dictation because the restore puts the old clipboard back
+/// over it (CONTEXT.md).
+struct DictationSettingsView: View {
+  @Bindable var settings: AppSettings
+
+  var body: some View {
+    SettingsCard(title: "Finished text") {
+      SettingsPickerRow(
+        title: "Send it to",
+        description: settings.insertionDestination.detail,
+        options: InsertionDestination.allCases,
+        optionLabel: \.title,
+        selection: $settings.insertionDestination,
+        controlWidth: 260
+      )
+    }
+  }
+}

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -14,6 +14,7 @@ enum SettingsSectionGroup: String, CaseIterable, Identifiable {
 
 enum SettingsSection: String, CaseIterable, Identifiable {
   case appearance
+  case dictation
   case sounds
   case dropTranscription
   case readAloud
@@ -28,6 +29,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   var title: String {
     switch self {
     case .appearance: "Appearance"
+    case .dictation: "Dictation"
     case .sounds: "Sounds"
     case .dropTranscription: "Drop Transcription"
     case .readAloud: "Read Aloud"
@@ -41,6 +43,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   var subtitle: String {
     switch self {
     case .appearance: "Customize the Direct Dictation HUD"
+    case .dictation: "Choose where your finished text goes"
     case .sounds: "Choose and preview the session sounds"
     case .dropTranscription: "Transcribe audio and video files"
     case .readAloud: "Choose the voice that reads selected text"
@@ -54,6 +57,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   var icon: String {
     switch self {
     case .appearance: "sparkles"
+    case .dictation: "text.cursor"
     case .sounds: "waveform"
     case .dropTranscription: "square.and.arrow.down"
     case .readAloud: "speaker.wave.2"

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -242,6 +242,8 @@ private struct SettingsContent: View {
         switch section {
         case .appearance:
           AppearanceSettingsView(settings: settings)
+        case .dictation:
+          DictationSettingsView(settings: settings)
         case .sounds:
           SoundsSettingsView(settings: settings, sounds: sounds)
         case .dropTranscription:

--- a/TalkifyTests/InsertionDestinationTests.swift
+++ b/TalkifyTests/InsertionDestinationTests.swift
@@ -1,0 +1,155 @@
+import AppKit
+import Testing
+@testable import Talkify
+
+/// Where a finished session's text goes. The default still pastes and puts the
+/// clipboard back; the other two picks exist for people that fights.
+@MainActor
+struct InsertionDestinationTests {
+  private func pasteboard() -> NSPasteboard {
+    NSPasteboard(name: .init(rawValue: "TalkifyTests-destination-\(UUID().uuidString)"))
+  }
+
+  /// Named test pasteboards are isolated to one test, but AppKit does not
+  /// declare NSPasteboard Sendable for this background-capable API.
+  private nonisolated func reader(
+    for pasteboard: NSPasteboard
+  ) -> @Sendable () -> [TextInsertionService.ClipboardItemSnapshot]? {
+    nonisolated(unsafe) let background = pasteboard
+    return { TextInsertionService.snapshot(of: background) }
+  }
+
+  /// A flag the paste closures can set from whatever context they run on.
+  private final class Signal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: String?
+    private var fired = false
+
+    func fire(_ value: String? = nil) {
+      lock.lock()
+      fired = true
+      stored = value
+      lock.unlock()
+    }
+
+    var didFire: Bool {
+      lock.lock()
+      defer { lock.unlock() }
+      return fired
+    }
+
+    var value: String? {
+      lock.lock()
+      defer { lock.unlock() }
+      return stored
+    }
+  }
+
+  private func service(
+    _ board: NSPasteboard,
+    isTargetFocused: @escaping @Sendable (TextInsertionService.Target) -> Bool = { _ in true },
+    postPasteShortcut: @escaping @Sendable () -> Bool = { true },
+    onPaste: @escaping @Sendable () -> Void = {}
+  ) -> TextInsertionService {
+    TextInsertionService(dependencies: .init(
+      pasteboard: board,
+      readClipboardItems: reader(for: board),
+      snapshotTimeout: .milliseconds(100),
+      focusedElement: { nil },
+      frontmostApplication: { nil },
+      isProcessRunning: { _ in true },
+      isTargetFocused: isTargetFocused,
+      postPasteShortcut: postPasteShortcut,
+      waitForPasteRead: { onPaste() }
+    ))
+  }
+
+  private func target() -> TextInsertionService.Target {
+    TextInsertionService.Target(
+      element: nil,
+      processIdentifier: ProcessInfo.processInfo.processIdentifier,
+      isSecure: false,
+      displayID: nil
+    )
+  }
+
+  /// Clipboard-only never pastes, so the words stay where the user can place
+  /// them and the previous clipboard is not put back over them.
+  @Test func clipboardOnlyLeavesTheTextAndPastesNothing() async {
+    let board = pasteboard()
+    board.clearContents()
+    board.setString("previous clipboard", forType: .string)
+    let pasted = Signal()
+    let service = service(board, postPasteShortcut: { pasted.fire(); return true })
+
+    let outcome = await service.insert("dictated", into: target(), destination: .clipboard)
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(!pasted.didFire)
+    #expect(board.string(forType: .string) == "dictated")
+  }
+
+  /// It returns before any target check, because there is no control to paste
+  /// into: a dead target must not turn a clipboard-only session into a failure.
+  @Test func clipboardOnlyDoesNotNeedALiveTarget() async {
+    let board = pasteboard()
+    board.clearContents()
+    let service = service(board, isTargetFocused: { _ in false })
+
+    let outcome = await service.insert("dictated", into: nil, destination: .clipboard)
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(board.string(forType: .string) == "dictated")
+  }
+
+  /// The point of insert-and-copy: the words are still on the clipboard
+  /// afterwards, which is what lets a history manager keep them.
+  @Test func insertAndCopyPastesAndKeepsTheTextOnTheClipboard() async {
+    let board = pasteboard()
+    board.clearContents()
+    board.setString("previous clipboard", forType: .string)
+    let seen = Signal()
+    nonisolated(unsafe) let background = board
+    let service = service(board, onPaste: { seen.fire(background.string(forType: .string)) })
+
+    let outcome = await service.insert("dictated", into: target(), destination: .insertAndCopy)
+
+    #expect(outcome == .inserted)
+    #expect(seen.value == "dictated")
+    #expect(board.string(forType: .string) == "dictated")
+  }
+
+  /// The default is unchanged: paste, then put the clipboard back.
+  @Test func insertingStillRestoresThePreviousClipboard() async {
+    let board = pasteboard()
+    board.clearContents()
+    board.setString("previous clipboard", forType: .string)
+    let service = service(board)
+
+    let outcome = await service.insert("dictated", into: target(), destination: .insert)
+
+    #expect(outcome == .inserted)
+    #expect(board.string(forType: .string) == "previous clipboard")
+  }
+
+  /// Insert-and-copy with a target that went away still leaves the words on
+  /// the clipboard, which is the outcome that counts as a finished session.
+  @Test func insertAndCopyFallsBackToTheClipboardWhenThePasteFails() async {
+    let board = pasteboard()
+    board.clearContents()
+    let service = service(board, postPasteShortcut: { false })
+
+    let outcome = await service.insert("dictated", into: target(), destination: .insertAndCopy)
+
+    #expect(outcome == .copiedToClipboard)
+    #expect(board.string(forType: .string) == "dictated")
+  }
+
+  @Test func theDefaultPickIsTodaysBehaviour() {
+    #expect(InsertionDestination.insert.pastes)
+    #expect(InsertionDestination.insert.restoresClipboard)
+    #expect(!InsertionDestination.clipboard.pastes)
+    #expect(InsertionDestination.insertAndCopy.pastes)
+    #expect(!InsertionDestination.insertAndCopy.restoresClipboard)
+  }
+}

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -29,8 +29,8 @@ struct SettingsWindowTests {
 
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
     let expected: [SettingsSection] = [
-      .appearance, .sounds, .dropTranscription, .readAloud, .language, .shortcuts,
-      .updates, .insights,
+      .appearance, .dictation, .sounds, .dropTranscription, .readAloud, .language,
+      .shortcuts, .updates, .insights,
     ]
     #expect(SettingsSection.allCases == expected)
     #expect(SettingsSectionGroup.settings.sections == expected)


### PR DESCRIPTION
Adds the three-way insertion destination the issue describes: **insert into the app** (paste, then restore the previous clipboard, the default and exactly today's behaviour), **copy to the clipboard** (never paste), and **insert and copy** (paste and deliberately leave the text on the clipboard).

## How it is wired

`InsertionDestination` carries the two facts the insertion path needs, `pastes` and `restoresClipboard`, rather than having `TextInsertionService` switch on the case three times. Its raw values are persisted picks, so they are load-bearing.

`insert(_:into:destination:)` branches in two places only:

- Clipboard-only returns before the target checks. There is no control to paste into, so validating one would be inventing a failure: a dead target must not turn a clipboard-only session into "couldn't insert text".
- Insert-and-copy goes through `pasteLeavingClipboard`, which skips the snapshot and the guarded restore entirely and simply copies, pastes, and stops. Leaving the words there is the whole point, and it is what lets a clipboard-history manager keep a dictation at all. If the paste fails it still returns `.copiedToClipboard`, so the words survive.

The default path is untouched, snapshot and change-count-gated restore and all.

Both new picks return outcomes the controller already treats as completed sessions, so the Paste sound and Insights recording needed no change. That was the intent in the issue and it fell out of the existing `case .inserted, .copiedToClipboard` branch.

The pick rides the session settings snapshot per ADR-0004, so flipping it mid-session cannot send that session's text somewhere it did not agree to.

## Settings

It gets its own **Dictation** section rather than being wedged into Sounds or Appearance, since it is about what dictation does rather than how it looks or sounds. The row's description changes with the pick, so the consequence is visible without opening the menu.

`CONTEXT.md` gains the term and its rules, including that clipboard-only counts as a completed session.

Tested with six new cases in `InsertionDestinationTests` covering clipboard-only not pasting, clipboard-only not needing a live target, insert-and-copy leaving the text behind and its paste-failure fallback, and the default still restoring. `SettingsWindowTests` was updated for the new section. Full suite passes locally. I have not driven the three picks by hand against a real app, so that is worth doing before merging.

Closes #63