### PR TITLE
[FEATURE] Name the application a history entry was aimed at

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -212,6 +212,9 @@ _Avoid_: Transcript history, cloud analytics
 - Early versions persist no audio, recognized text, captions, or transcript history
 - An off-by-default **Save transcription history** setting exists; turning it on is the one explicit exception to the no-persistence line above
 - While history is on, each completed **Direct Dictation** session appends a timestamped entry to a daily plain-text file in a user-visible folder defaulting to `~/Documents/Talkify/`
+- A history entry names the application the text was aimed at, meaning the one that held focus when the session started, because a record of what was said is easier to use later when it says where it was being said
+- History is written before insertion, so an entry names where the words were headed rather than where they landed; a clipboard-only session names the clipboard, since it aimed at no application at all
+- An entry whose application cannot be named keeps the bare timestamp rather than reading "Unknown"
 - The history folder is the user's pick, and Clear History removes only the day files Talkify wrote there
 - The history choice is captured in the Dictation session settings snapshot at session start
 - A **Drop Transcription** writes a transcript file because the user asked for one; Talkify keeps no copy of it and no record that it happened

--- a/Talkify/Dictation/DictationHistoryStore.swift
+++ b/Talkify/Dictation/DictationHistoryStore.swift
@@ -35,6 +35,30 @@ actor DictationHistoryStore {
     )
   }
 
+  /// The entry's heading: the time, and where the text was going.
+  ///
+  /// The source is where the words were aimed, which is the application that
+  /// held focus when the session started. History is written before insertion
+  /// so a failed paste cannot lose the text, so where it landed is not known
+  /// yet. An unnamed source leaves the heading as the bare timestamp rather
+  /// than writing "Unknown".
+  static func heading(
+    for date: Date,
+    source: String?,
+    calendar: Calendar = .current
+  ) -> String {
+    let time = timestamp(for: date, calendar: calendar)
+    guard let source, !source.trimmingCharacters(in: .whitespaces).isEmpty else {
+      return time
+    }
+    // Newlines would forge a second entry inside this one.
+    let clean = source
+      .replacingOccurrences(of: "\n", with: " ")
+      .replacingOccurrences(of: "\r", with: " ")
+      .trimmingCharacters(in: .whitespaces)
+    return "\(time) \(clean)"
+  }
+
   private let calendar: Calendar
 
   init(calendar: Calendar = .current) {
@@ -43,7 +67,12 @@ actor DictationHistoryStore {
 
   /// Appends one session's text to its day file, creating the folder and the
   /// file as needed. Nothing is ever overwritten: a day file only grows.
-  func record(_ text: String, at date: Date = .now, in folder: URL) throws {
+  func record(
+    _ text: String,
+    from source: String? = nil,
+    at date: Date = .now,
+    in folder: URL
+  ) throws {
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
 
@@ -53,7 +82,8 @@ actor DictationHistoryStore {
     )
 
     let fileURL = folder.appending(path: Self.fileName(for: date, calendar: calendar))
-    let entry = "\(Self.timestamp(for: date, calendar: calendar))\n\(trimmed)\n\n"
+    let heading = Self.heading(for: date, source: source, calendar: calendar)
+    let entry = "\(heading)\n\(trimmed)\n\n"
     let entryData = Data(entry.utf8)
 
     if let handle = try? FileHandle(forWritingTo: fileURL) {

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -62,7 +62,11 @@ extension DirectDictationController {
     ) async -> Void
 
     // Transcription history, written only while its setting is on.
-    let recordHistory: @Sendable (_ text: String, _ folder: URL) async -> Void
+    let recordHistory: @Sendable (
+      _ text: String,
+      _ source: String?,
+      _ folder: URL
+    ) async -> Void
 
     /// Builds the production boundaries around the live services the
     /// controller previously constructed itself.
@@ -120,10 +124,10 @@ extension DirectDictationController {
         recordSession: {
           await usageTracker.recordSession(wordCount: $0, speakingDuration: $1)
         },
-        recordHistory: { text, folder in
+        recordHistory: { text, source, folder in
           // A history write must never cost the session its insertion; a
           // full disk or revoked folder loses the entry, not the words.
-          try? await historyStore.record(text, in: folder)
+          try? await historyStore.record(text, from: source, in: folder)
         }
       )
     }

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -444,6 +444,16 @@ final class DirectDictationController {
     pendingLiveText = nil
   }
 
+  /// What the history entry names as this session's destination.
+  ///
+  /// Clipboard-only never aims at an application, so naming the one that
+  /// happened to hold focus would be a lie. Everything else names where the
+  /// words were headed when they were spoken.
+  private func historySource(for destination: InsertionDestination) -> String? {
+    guard destination != .clipboardOnly else { return "Clipboard" }
+    return focusedTarget?.applicationName
+  }
+
   /// Finishes recognition and routes the insertion outcome to its terminal UI.
   ///
   /// - Parameter speakingDuration: The completed session's measured speech time.
@@ -459,7 +469,11 @@ final class DirectDictationController {
         if session.historyEnabled, !text.isEmpty {
           // Before the outcome routing: words the paste then loses are
           // exactly the words history exists to keep.
-          await dependencies.recordHistory(text, session.historyFolder)
+          await dependencies.recordHistory(
+            text,
+            historySource(for: session.insertionDestination),
+            session.historyFolder
+          )
         }
         let outcome = await dependencies.insertText(
           text, focusedTarget, session.insertionDestination

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -36,17 +36,23 @@ final class TextInsertionService {
 
     let isSecure: Bool
     let displayID: CGDirectDisplayID?
+    /// The application that held focus when the session began, for the
+    /// history entry to name. Resolved at capture time rather than at write
+    /// time, because by then the application may be gone.
+    let applicationName: String?
 
     init(
       element: AXUIElement?,
       processIdentifier: pid_t,
       isSecure: Bool,
-      displayID: CGDirectDisplayID?
+      displayID: CGDirectDisplayID?,
+      applicationName: String? = nil
     ) {
       self.element = element
       self.processIdentifier = processIdentifier
       self.isSecure = isSecure
       self.displayID = displayID
+      self.applicationName = applicationName
     }
   }
 
@@ -117,7 +123,10 @@ final class TextInsertionService {
         element: element,
         processIdentifier: processIdentifier,
         isSecure: isSecureTextField(element),
-        displayID: displayID(for: element)
+        displayID: displayID(for: element),
+        applicationName: NSRunningApplication(
+          processIdentifier: processIdentifier
+        )?.localizedName
       )
     }
 
@@ -128,7 +137,8 @@ final class TextInsertionService {
       element: nil,
       processIdentifier: application.processIdentifier,
       isSecure: false,
-      displayID: nil
+      displayID: nil,
+      applicationName: application.localizedName
     )
   }
 

--- a/TalkifyTests/DictationHistoryStoreTests.swift
+++ b/TalkifyTests/DictationHistoryStoreTests.swift
@@ -150,6 +150,54 @@ struct DictationHistoryStoreTests {
   }
 
   /// A fresh per-test folder under the system temporary directory.
+  /// The point of naming the source: a day file that says only what you said
+  /// is harder to use later than one that says where you were saying it.
+  @Test func anEntryNamesTheApplicationItWasAimedAt() async throws {
+    let folder = temporaryFolder()
+    defer { try? FileManager.default.removeItem(at: folder) }
+    let store = DictationHistoryStore(calendar: testCalendar())
+    let noon = Date(timeIntervalSince1970: 1_755_000_000)
+
+    try await store.record("hello there", from: "Ghostty", at: noon, in: folder)
+
+    let file = folder.appending(path: DictationHistoryStore.fileName(
+      for: noon,
+      calendar: testCalendar()
+    ))
+    let contents = try String(contentsOf: file, encoding: .utf8)
+    let heading = DictationHistoryStore.timestamp(for: noon, calendar: testCalendar())
+    #expect(contents.hasPrefix("\(heading) Ghostty\n"))
+    #expect(contents.contains("hello there"))
+  }
+
+  /// An unnamed source leaves the heading exactly as it was before sources
+  /// existed, so entries written by an older build still read the same.
+  @Test func anUnnamedSourceLeavesTheBareTimestamp() {
+    let noon = Date(timeIntervalSince1970: 1_755_000_000)
+    let calendar = testCalendar()
+    let bare = DictationHistoryStore.timestamp(for: noon, calendar: calendar)
+
+    #expect(DictationHistoryStore.heading(for: noon, source: nil, calendar: calendar) == bare)
+    #expect(DictationHistoryStore.heading(for: noon, source: "", calendar: calendar) == bare)
+    #expect(DictationHistoryStore.heading(for: noon, source: "   ", calendar: calendar) == bare)
+  }
+
+  /// An application name is not something Talkify chose, so a name carrying a
+  /// newline must not be able to forge a second entry inside this one.
+  @Test func aSourceCannotForgeASecondEntry() {
+    let noon = Date(timeIntervalSince1970: 1_755_000_000)
+    let calendar = testCalendar()
+
+    let heading = DictationHistoryStore.heading(
+      for: noon,
+      source: "Evil\n[00:00:00] injected",
+      calendar: calendar
+    )
+
+    #expect(!heading.contains("\n"))
+    #expect(heading.hasSuffix("Evil [00:00:00] injected"))
+  }
+
   private func temporaryFolder() -> URL {
     FileManager.default.temporaryDirectory
       .appending(path: UUID().uuidString, directoryHint: .isDirectory)

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -36,12 +36,16 @@ struct DirectDictationControllerTests {
     return defaults
   }
 
-  private static func makeTarget(isSecure: Bool = false) -> TextInsertionService.Target {
+  private static func makeTarget(
+    isSecure: Bool = false,
+    applicationName: String? = nil
+  ) -> TextInsertionService.Target {
     TextInsertionService.Target(
       element: nil,
       processIdentifier: 1,
       isSecure: isSecure,
-      displayID: nil
+      displayID: nil,
+      applicationName: applicationName
     )
   }
 
@@ -59,7 +63,7 @@ struct DirectDictationControllerTests {
     startRecognitionBody: (@Sendable (Locale) async throws -> Void)? = nil,
     finishRecognition: @escaping @Sendable () async throws -> String = { "" },
     shutDownRecognition: @escaping @Sendable () async -> Void = {},
-    historyEntries: OSAllocatedUnfairLock<[(text: String, folder: URL)]>
+    historyEntries: OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>
       = .init(initialState: []),
     insertOutcome: TextInsertionService.InsertionOutcome = .inserted
   ) -> DirectDictationController.Dependencies {
@@ -112,8 +116,8 @@ struct DirectDictationControllerTests {
         recorder.events.append("recordSession")
         recorder.recordedSessions.append((wordCount, speakingDuration))
       },
-      recordHistory: { text, folder in
-        historyEntries.withLock { $0.append((text, folder)) }
+      recordHistory: { text, source, folder in
+        historyEntries.withLock { $0.append((text, source, folder)) }
       }
     )
   }
@@ -503,7 +507,7 @@ struct DirectDictationControllerTests {
   @Test func finishWritesNoHistoryWhileTheSettingIsOff() async {
     let recorder = Recorder()
     let prewarmed = OSAllocatedUnfairLock(initialState: false)
-    let historyEntries = OSAllocatedUnfairLock<[(text: String, folder: URL)]>(
+    let historyEntries = OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>(
       initialState: []
     )
     let controller = makeController(
@@ -532,7 +536,7 @@ struct DirectDictationControllerTests {
   @Test func finishWritesHistoryToTheCapturedFolderWhileOn() async {
     let recorder = Recorder()
     let prewarmed = OSAllocatedUnfairLock(initialState: false)
-    let historyEntries = OSAllocatedUnfairLock<[(text: String, folder: URL)]>(
+    let historyEntries = OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>(
       initialState: []
     )
     let folder = URL(filePath: "/tmp/TalkifyTests-history-\(UUID().uuidString)")
@@ -561,6 +565,75 @@ struct DirectDictationControllerTests {
     let entries = historyEntries.withLock { $0 }
     #expect(entries.map(\.text) == ["spoken words"])
     #expect(entries.map(\.folder) == [folder])
+    controller.stop()
+  }
+
+  /// A day file that says only what you said is harder to use later than one
+  /// that says where you were saying it, so the entry names the application
+  /// that held focus when the session started.
+  @Test func historyNamesTheApplicationTheTextWasAimedAt() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let historyEntries = OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>(
+      initialState: []
+    )
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.dictationHistoryEnabled = true
+    let controller = makeController(
+      settings: settings,
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        captureFocusedTarget: { Self.makeTarget(applicationName: "Ghostty") },
+        finishRecognition: { "spoken words" },
+        historyEntries: historyEntries
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    controller.toggleFromMenu()
+    await waitUntil("Finish never delivered") { !recorder.insertedTexts.isEmpty }
+
+    #expect(historyEntries.withLock { $0 }.map(\.source) == ["Ghostty"])
+    controller.stop()
+  }
+
+  /// Clipboard-only never aims at an application, so naming whichever one
+  /// happened to hold focus would put a lie in the file.
+  @Test func clipboardOnlyHistoryNamesTheClipboardRatherThanAnApplication() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let historyEntries = OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>(
+      initialState: []
+    )
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.dictationHistoryEnabled = true
+    settings.insertionDestination = .clipboardOnly
+    let controller = makeController(
+      settings: settings,
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        captureFocusedTarget: { Self.makeTarget(applicationName: "Ghostty") },
+        finishRecognition: { "spoken words" },
+        historyEntries: historyEntries,
+        insertOutcome: .copiedToClipboard
+      )
+    )
+    await prepare(controller, prewarmed: prewarmed)
+
+    controller.toggleFromMenu()
+    await waitUntil("Session never reached recording") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    controller.toggleFromMenu()
+    await waitUntil("Finish never delivered") { !recorder.insertedTexts.isEmpty }
+
+    #expect(historyEntries.withLock { $0 }.map(\.source) == ["Clipboard"])
     controller.stop()
   }
 }


### PR DESCRIPTION
Follows #67, now that it has landed. Each history entry's heading gains the application the text was aimed at, so a day file says where the words were going and not only what they were:

```
[16:52:03] Ghostty
can we also save which app the transcription went to

[16:54:11] Clipboard
this one was clipboard-only
```

The name is where the text was aimed rather than where it landed. History is written before insertion so a failed paste cannot lose the words, which means the destination is not known yet, so the heading names the application that held focus when the session began. Clipboard-only names the clipboard, because it aims at no application and naming whichever one had focus would be false. An application that cannot be named keeps the bare timestamp rather than "Unknown", so entries written before this change still read the same. An application name is not a string Talkify chose, so newlines are flattened; otherwise a name could forge a second `[00:00:00]` entry inside a real one.

Tested with five new cases: three in `DictationHistoryStoreTests` for the heading, the unnamed fallback and the newline flattening, and two in `DirectDictationControllerTests` for the name reaching the entry and clipboard-only naming the clipboard. Full suite green locally, 260 passing.

Closes #79