### PR TITLE
[FEATURE] Add Launch at Login setting

### DIFF
--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   private var usageTracker: UsageTracker?
   private let settingsRuntimeState = SettingsRuntimeState()
   private let updaterService = SparkleUpdaterService()
+  private let launchAtLoginService = LaunchAtLoginService()
 
   static func main() {
     let application = NSApplication.shared
@@ -213,7 +214,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         sounds: HUDSounds(),
         runtimeState: settingsRuntimeState,
         usageTracker: usageTracker,
-        updater: updaterService
+        updater: updaterService,
+        launchAtLogin: launchAtLoginService
       )
     }
     settingsWindowController?.show()

--- a/Talkify/App/LaunchAtLoginService.swift
+++ b/Talkify/App/LaunchAtLoginService.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Observation
+import ServiceManagement
+
+/// Registers Talkify as a login item through `SMAppService`, wrapped so the
+/// rest of the app never imports `ServiceManagement`. Disabled by default
+/// (CONTEXT.md): `SMAppService` is the source of truth for whether the login
+/// item is registered, so this holds no preference of its own.
+@MainActor
+@Observable
+final class LaunchAtLoginService {
+  private(set) var isEnabled: Bool
+
+  @ObservationIgnored
+  private let service: SMAppService
+
+  init(service: SMAppService = .mainApp) {
+    self.service = service
+    self.isEnabled = service.status == .enabled
+  }
+
+  func setEnabled(_ enabled: Bool) {
+    do {
+      if enabled {
+        try service.register()
+      } else {
+        try service.unregister()
+      }
+      isEnabled = service.status == .enabled
+    } catch {
+      isEnabled = service.status == .enabled
+    }
+  }
+}

--- a/Talkify/Settings/Sections/GeneralSettingsView.swift
+++ b/Talkify/Settings/Sections/GeneralSettingsView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// The General section: app-wide behaviour that is not tied to any one
+/// feature. Currently just Launch at Login.
+struct GeneralSettingsView: View {
+  let launchAtLogin: LaunchAtLoginService
+
+  var body: some View {
+    SettingsCard(title: "Startup") {
+      SettingsRow(
+        title: "Launch at login",
+        description: "Open Talkify automatically when you sign in"
+      ) {
+        Toggle("", isOn: launchAtLoginBinding)
+          .labelsHidden()
+          .toggleStyle(.switch)
+      }
+    }
+  }
+
+  private var launchAtLoginBinding: Binding<Bool> {
+    Binding(
+      get: { launchAtLogin.isEnabled },
+      set: { launchAtLogin.setEnabled($0) }
+    )
+  }
+}

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -13,6 +13,7 @@ enum SettingsSectionGroup: String, CaseIterable, Identifiable {
 }
 
 enum SettingsSection: String, CaseIterable, Identifiable {
+  case general
   case appearance
   case sounds
   case dictation
@@ -28,6 +29,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
   var title: String {
     switch self {
+    case .general: "General"
     case .appearance: "Appearance"
     case .sounds: "Sounds"
     case .dictation: "Dictation"
@@ -42,6 +44,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
   var subtitle: String {
     switch self {
+    case .general: "Choose how Talkify starts"
     case .appearance: "Customize the Direct Dictation HUD"
     case .sounds: "Choose and preview the session sounds"
     case .dictation: "Choose where finished dictation text goes"
@@ -56,6 +59,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
 
   var icon: String {
     switch self {
+    case .general: "gearshape"
     case .appearance: "sparkles"
     case .sounds: "waveform"
     case .dictation: "text.cursor"

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
   let runtimeState: SettingsRuntimeState
   let usageTracker: UsageTracker
   let updater: SparkleUpdaterService
+  let launchAtLogin: LaunchAtLoginService
   let onClose: () -> Void
 
   @Environment(\.colorSchemeContrast) private var contrast
@@ -38,7 +39,8 @@ struct SettingsView: View {
             sounds: sounds,
             usageTracker: usageTracker,
             runtimeState: runtimeState,
-            updater: updater
+            updater: updater,
+            launchAtLogin: launchAtLogin
           )
           .id(selectedSection)
           .transition(.opacity)
@@ -225,6 +227,7 @@ private struct SettingsContent: View {
   let usageTracker: UsageTracker
   let runtimeState: SettingsRuntimeState
   let updater: SparkleUpdaterService
+  let launchAtLogin: LaunchAtLoginService
 
   @Environment(\.colorSchemeContrast) private var contrast
 
@@ -240,6 +243,8 @@ private struct SettingsContent: View {
         }
 
         switch section {
+        case .general:
+          GeneralSettingsView(launchAtLogin: launchAtLogin)
         case .appearance:
           AppearanceSettingsView(settings: settings)
         case .sounds:
@@ -281,6 +286,7 @@ private struct SettingsContent: View {
     // Never started, so the preview shows the pane's disabled state rather
     // than reaching for the network.
     updater: SparkleUpdaterService(),
+    launchAtLogin: LaunchAtLoginService(),
     onClose: {}
   )
 }

--- a/Talkify/Settings/SettingsWindowController.swift
+++ b/Talkify/Settings/SettingsWindowController.swift
@@ -21,7 +21,8 @@ final class SettingsWindowController: NSWindowController {
     sounds: HUDSounds,
     runtimeState: SettingsRuntimeState,
     usageTracker: UsageTracker,
-    updater: SparkleUpdaterService
+    updater: SparkleUpdaterService,
+    launchAtLogin: LaunchAtLoginService
   ) {
     let window = TalkifySettingsWindow(
       contentRect: NSRect(origin: .zero, size: Self.windowSize),
@@ -36,6 +37,7 @@ final class SettingsWindowController: NSWindowController {
         runtimeState: runtimeState,
         usageTracker: usageTracker,
         updater: updater,
+        launchAtLogin: launchAtLogin,
         onClose: { [weak window] in window?.close() }
       )
     )

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -14,7 +14,8 @@ struct SettingsWindowTests {
         fileURL: FileManager.default.temporaryDirectory
           .appending(path: "TalkifySettingsWindowTests-" + UUID().uuidString + ".json")
       )),
-      updater: SparkleUpdaterService()
+      updater: SparkleUpdaterService(),
+      launchAtLogin: LaunchAtLoginService()
     )
     let window = try #require(controller.window)
     #expect(window.title == "Talkify Settings")
@@ -29,8 +30,8 @@ struct SettingsWindowTests {
 
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
     let expected: [SettingsSection] = [
-      .appearance, .sounds, .dictation, .dropTranscription, .readAloud, .language,
-      .shortcuts, .updates, .insights,
+      .general, .appearance, .sounds, .dictation, .dropTranscription, .readAloud,
+      .language, .shortcuts, .updates, .insights,
     ]
     #expect(SettingsSection.allCases == expected)
     #expect(SettingsSectionGroup.settings.sections == expected)


### PR DESCRIPTION
Adds a Launch at Login toggle so Talkify can start automatically at sign-in, matching the behaviour CONTEXT.md already documents but that was never built. It wraps SMAppService in a new LaunchAtLoginService, following the same isolation pattern SparkleUpdaterService already uses for Sparkle, since the login-item registration status is owned by the system rather than by AppSettings. The toggle lives on a new General settings pane, since none of the existing panes are app-lifecycle-scoped rather than feature-scoped, and it's off by default per CONTEXT.md.

<img width="882" height="621" alt="image" src="https://github.com/user-attachments/assets/49429b0b-a325-4c71-9730-3c3f3efb3a96" />

Closes #87