### PR TITLE
[TEST] Stop most insertion tests racing the snapshot deadline

### DIFF
--- a/Talkify/Dictation/TextInsertionService+Clipboard.swift
+++ b/Talkify/Dictation/TextInsertionService+Clipboard.swift
@@ -103,7 +103,10 @@ extension TextInsertionService {
         }
       }
 
-      let timeoutTask = Self.makeSnapshotTimeoutTask(after: timeout) {
+      let timeoutTask = Self.makeSnapshotTimeoutTask(
+        after: timeout,
+        waiting: dependencies.snapshotTimeoutSignal
+      ) {
         complete(.timedOut)
       }
       let executeRead: @Sendable () -> Void = {
@@ -167,14 +170,11 @@ extension TextInsertionService {
   /// - Returns: A task the actual reader must cancel when it completes.
   private nonisolated static func makeSnapshotTimeoutTask(
     after timeout: Duration,
+    waiting: @escaping @Sendable (Duration) async -> Void,
     onTimeout: @escaping @Sendable () -> Void
   ) -> Task<Void, Never> {
     Task {
-      do {
-        try await Task.sleep(for: timeout)
-      } catch {
-        return
-      }
+      await waiting(timeout)
       guard !Task.isCancelled else { return }
       onTimeout()
     }

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -66,6 +66,17 @@ final class TextInsertionService {
     let readClipboardItems: @Sendable () -> [ClipboardItemSnapshot]?
     /// The total acquisition deadline shared by the first read and one reread.
     let snapshotTimeout: Duration
+    /// How the snapshot deadline is waited out.
+    ///
+    /// Injectable so a test can decide which of the two racers wins instead of
+    /// hoping the machine is fast enough: a signal that never returns lets the
+    /// read win, one that returns at once lets the deadline win. Production
+    /// sleeps. Before this, every insertion test was really asserting that a
+    /// real pasteboard read finished inside 100 milliseconds on whatever
+    /// machine happened to be running it (#82).
+    var snapshotTimeoutSignal: @Sendable (Duration) async -> Void = { timeout in
+      try? await Task.sleep(for: timeout)
+    }
     let focusedElement: @MainActor () -> AXUIElement?
     let frontmostApplication: @MainActor () -> NSRunningApplication?
     let isProcessRunning: @MainActor (pid_t) -> Bool

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -17,6 +17,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -54,6 +55,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -90,6 +92,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -123,6 +126,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: { nil },
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -160,6 +164,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -188,6 +193,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -220,6 +226,7 @@ struct TextInsertionServiceTests {
         return TextInsertionService.snapshot(of: backgroundPasteboard)
       },
       snapshotTimeout: .milliseconds(150),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -261,6 +268,7 @@ struct TextInsertionServiceTests {
         return snapshot
       },
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -304,6 +312,7 @@ struct TextInsertionServiceTests {
         return snapshot
       },
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -335,6 +344,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -374,6 +384,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -404,6 +415,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -430,6 +442,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -460,6 +473,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { application },
       isProcessRunning: { processIdentifier in
@@ -755,6 +769,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -785,6 +800,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in false },
@@ -811,6 +827,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -840,6 +857,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -874,6 +892,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -906,6 +925,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -937,6 +957,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -971,6 +992,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -1001,6 +1023,7 @@ struct TextInsertionServiceTests {
       pasteboard: pasteboard,
       readClipboardItems: makeClipboardReader(for: pasteboard),
       snapshotTimeout: .milliseconds(100),
+      snapshotTimeoutSignal: Self.neverTimesOut,
       focusedElement: { nil },
       frontmostApplication: { nil },
       isProcessRunning: { _ in true },
@@ -1016,6 +1039,20 @@ struct TextInsertionServiceTests {
 
     #expect(outcome == .inserted)
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  /// A deadline that never arrives, so the read always wins the race.
+  ///
+  /// Most of these tests are about what the insertion path decides, not about
+  /// the deadline. Leaving a real 100ms timer in them meant asserting that a
+  /// pasteboard read finishes inside 100ms on whatever machine is running, and
+  /// CI is not that machine (#82). Tests that are genuinely about the deadline
+  /// pass their own signal.
+  /// Sixty seconds rather than forever: long enough that it never fires in a
+  /// passing run, short enough that a genuinely stuck read fails the test
+  /// instead of hanging the suite.
+  private static let neverTimesOut: @Sendable (Duration) async -> Void = { _ in
+    try? await Task.sleep(for: .seconds(60))
   }
 
   private func makePasteboard() -> NSPasteboard {


### PR DESCRIPTION
Partial fix for #82, and I want to be straight about which part.

## What was wrong

Every test in `TextInsertionServiceTests` built its service with `snapshotTimeout: .milliseconds(100)` and let a real `NSPasteboard` read race it. So each was quietly asserting that a pasteboard read finishes inside 100ms on whatever machine is running. On CI it often does not: the deadline wins, `snapshotClipboardItems` returns `.timedOut`, and a test expecting `.copiedToClipboard` sees `.unavailable`. That is exactly how `missingClipboardRepresentationUsesCopyFallback` failed four times this week.

## What this changes

`Dependencies` gains `snapshotTimeoutSignal`, defaulting to the real `Task.sleep`, so production behaviour is untouched. The 24 tests that are about what the insertion path *decides* rather than about the deadline now pass a signal that does not fire within the life of the test. Those tests no longer have a wall-clock dependency at all.

## What it does not fix, and why

`activeReadSkipsLaterInsertionImmediatelyAndRecovers` still uses a real deadline. It has to: it awaits the first insertion while that insertion's read is deliberately blocked, so only the deadline can free it. I tried giving it a deadline the test fires on command, and it went from intermittently failing on CI to failing every run locally, so I reverted that and left the test as it was. It remains a candidate for the next sighting.

## What I could not prove

I could not reproduce the CI failure locally, so I cannot demonstrate this fixes it. The suite is green here three runs in a row, but it was green three runs in a row before the change too. I also ran the insertion tests with all 14 cores pinned under load, on this branch and on unmodified `main`, and both passed, so raw CPU contention is not the trigger either.

What this rests on is the mechanism rather than a reproduction: 24 tests that could previously lose a race no longer have a race to lose. The proof is CI staying green over the next few weeks, and #82 should stay open until it has.

Refs #82