### PR TITLE
[DOCS] Say how a tapped session ends

### DIFF
--- a/Talkify/Settings/Sections/LanguageSettingsView.swift
+++ b/Talkify/Settings/Sections/LanguageSettingsView.swift
@@ -141,7 +141,7 @@ struct LanguageSettingsView: View {
 
   private var secondaryTriggerDescription: String {
     let binding = settings.secondaryTriggerBinding
-    var description = "Hold it to dictate in \(secondaryName)"
+    var description = "Hold it to dictate in \(secondaryName), or tap it to start and tap again to finish"
     if binding.isMouseButton {
       description += ". This button keeps its usual action unless that exact "
         + "combination is pressed"

--- a/Talkify/Settings/Sections/ShortcutsSettingsView.swift
+++ b/Talkify/Settings/Sections/ShortcutsSettingsView.swift
@@ -80,7 +80,7 @@ struct ShortcutsSettingsView: View {
         .dictation,
         allowsBareModifier: true,
         allowsMouseButton: true,
-        sentence: "Hold %@ to talk, or tap it to keep listening hands-free."
+        sentence: "Hold %@ to talk, or tap it to start and tap again to finish."
       )
 
       if settings.isSecondLanguageEnabled {
@@ -88,7 +88,7 @@ struct ShortcutsSettingsView: View {
           .secondLanguage,
           allowsBareModifier: true,
           allowsMouseButton: true,
-          sentence: "Hold %@ to dictate in your other language."
+          sentence: "Hold %@ to dictate in your other language, or tap it the same way."
         )
       }
 


### PR DESCRIPTION
The Shortcuts row said "Hold fn to talk, or tap it to keep listening hands-free." Two problems, and only one is tone.

"Keep listening" describes continuing something already running, so it reads as *while holding, tap to keep it going*, which is not the gesture. And it never said how a tapped session ends. Tap, speak, then what? The sentence stopped there.

Read Aloud one row below already says "again to stop", and the README already says "Quick-tap fn, speak, tap again to finish". Settings was the only place telling half the story.

Now: "Hold fn to talk, or tap it to start and tap again to finish." Finish rather than stop, deliberately, because tapping again inserts the text while Escape throws it away, and stop blurs those two. The second language rows in both Shortcuts and Language had the same gap and say it now too.

Escape is left out on purpose. The row is at its length limit and cancel is a third gesture; it belongs in a HUD hint shown to someone who is actually mid-session.

Tested by build. Copy only, no behaviour change.

Refs #85