### PR TITLE
[FIX] Keep App Nap off Talkify while it is working

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -127,6 +127,8 @@ _Avoid_: Transcript history, cloud analytics
 - The wait between the last word and the recognized text is silent — no label stands in for it, and the voice visual comes to rest rather than reading the silence as a dead microphone
 - Compact opens with no text at all, because it is built around the live draft and a placeholder would be words nobody spoke
 - The HUD's shaders and the particle cloud's compute kernels are compiled at launch, so the cost never lands on the first frames of a session
+- Talkify holds a user-initiated activity assertion while a **Direct Dictation** session or a **Drop Transcription** job runs, and holds none while idle: a menu-bar-only app with no window is what App Nap targets, and a napped process draws the HUD's animation clock too slowly to watch
+- The assertion is taken before the begin guards run, because the frames a napped process draws badly are the first ones; every guard that refuses a session releases it again
 - The HUD shows a live visual that reacts to microphone audio while listening
 - Settings changes apply to the live app and persist immediately; Settings has no Save step
 - The Appearance preview uses the same preferences and HUD surface as Direct Dictation

--- a/Talkify/App/ActivityAssertion.swift
+++ b/Talkify/App/ActivityAssertion.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Keeps macOS from napping Talkify while something is actually happening.
+///
+/// Talkify is `LSUIElement` with no window on screen, which is exactly the
+/// shape App Nap targets. After a few hours idle the process is throttled, and
+/// the first thing to suffer is the HUD: every voice visual draws through
+/// `TimelineView(.animation)`, whose clock App Nap slows right down. A session
+/// then either animates wrongly or is over before its first frame lands (#77).
+///
+/// Held only for the length of a session or a file job, never while idle. An
+/// assertion that lasted all day would trade a rare glitch for a permanent
+/// battery cost, which is the wrong way round.
+@MainActor
+final class ActivityAssertion {
+  private let reason: String
+  private let begin: (ProcessInfo.ActivityOptions, String) -> NSObjectProtocol
+  private let end: (NSObjectProtocol) -> Void
+  private var token: NSObjectProtocol?
+
+  init(
+    reason: String,
+    begin: @escaping (ProcessInfo.ActivityOptions, String) -> NSObjectProtocol
+      = { ProcessInfo.processInfo.beginActivity(options: $0, reason: $1) },
+    end: @escaping (NSObjectProtocol) -> Void
+      = { ProcessInfo.processInfo.endActivity($0) }
+  ) {
+    self.reason = reason
+    self.begin = begin
+    self.end = end
+  }
+
+  var isHeld: Bool { token != nil }
+
+  /// Idempotent: a second begin would strand the first token, and a stranded
+  /// token is an assertion nothing can ever release.
+  func hold() {
+    guard token == nil else { return }
+    token = begin(.userInitiated, reason)
+  }
+
+  func release() {
+    guard let token else { return }
+    end(token)
+    self.token = nil
+  }
+
+  // No deinit release: the token is MainActor-isolated and deinit is not, and
+  // the only owners are controllers that live as long as the app. Every path
+  // that holds one also releases it.
+}

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -26,6 +26,9 @@ final class DirectDictationController {
   private var keyEventMonitor: GlobalKeyEventMonitor?
   private var machine = DictationSessionMachine()
   private let ducking = AudioDuckingSession()
+  /// Held for the length of a session. Without it, a Talkify that has sat
+  /// idle for hours is napped, and the HUD's animation clock with it (#77).
+  private let activity = ActivityAssertion(reason: "Direct Dictation session")
   private var focusedTarget: TextInsertionService.Target?
   private var noSpeechTask: Task<Void, Never>?
   private var permissionTask: Task<Void, Never>?
@@ -378,6 +381,7 @@ final class DirectDictationController {
         if currentSessionSettings?.ducksOtherAudio == true { ducking.duck() }
       } else {
         ducking.restore()
+        activity.release()
         focusedTarget = nil
         sessionStartTask = nil
         currentSessionSettings = nil
@@ -393,8 +397,15 @@ final class DirectDictationController {
   private var pendingLiveText: String?
 
   private func checkAndBegin() {
+    // Held here rather than once recording starts: the first HUD frames are
+    // what a napped process draws badly, and by then they have been drawn.
+    // Every rejection below releases it, because .beginRejected produces no
+    // effects and nothing downstream would.
+    activity.hold()
+
     guard isPrepared else {
       dependencies.showMessage(preparationFailureMessage ?? "Preparing speech…", nil)
+      activity.release()
       send(.beginRejected)
       return
     }
@@ -403,6 +414,7 @@ final class DirectDictationController {
       // One dialog that explains it, not the system prompt again on every press.
       dependencies.showAccessibilitySetupAlert()
       startPermissionWatch()
+      activity.release()
       send(.beginRejected)
       return
     }
@@ -410,6 +422,7 @@ final class DirectDictationController {
     let target = dependencies.captureFocusedTarget()
     if target?.isSecure == true {
       dependencies.showMessage("Secure field", target?.displayID)
+      activity.release()
       send(.beginRejected)
       return
     }

--- a/Talkify/DropTranscription/DropTranscriptionController.swift
+++ b/Talkify/DropTranscription/DropTranscriptionController.swift
@@ -34,6 +34,9 @@ final class DropTranscriptionController {
   private let offer: TranscriptOffer
   /// Reported while a job runs, for the status item.
   var onProgressChange: ((Double?) -> Void)?
+  /// Held while a file job runs. A transcription takes minutes with no window
+  /// on screen, which is exactly when App Nap throttles the process (#77).
+  private let activity = ActivityAssertion(reason: "Drop Transcription job")
 
   var isRunning: Bool { job != nil }
 
@@ -188,10 +191,12 @@ final class DropTranscriptionController {
     // Nothing in the shape while a job runs. The drop target retracts and the
     // menu bar ghost carries progress from there.
     onProgressChange?(0)
+    activity.hold()
 
     job = Task { [weak self] in
       defer {
         self?.job = nil
+        self?.activity.release()
         self?.onProgressChange?(nil)
       }
       do {

--- a/TalkifyTests/ActivityAssertionTests.swift
+++ b/TalkifyTests/ActivityAssertionTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import Talkify
+
+/// What keeps macOS from napping Talkify mid-session, and what makes sure it
+/// stops keeping it awake afterwards. A stranded assertion is worse than the
+/// bug it fixes: it disables App Nap for the rest of the run.
+@MainActor
+struct ActivityAssertionTests {
+  @MainActor
+  private final class Recorder {
+    var begins: [(options: ProcessInfo.ActivityOptions, reason: String)] = []
+    var ends = 0
+
+    func assertion(reason: String = "test") -> ActivityAssertion {
+      ActivityAssertion(
+        reason: reason,
+        begin: { [self] options, why in
+          begins.append((options, why))
+          return NSString(string: "token-\(begins.count)")
+        },
+        end: { [self] _ in ends += 1 }
+      )
+    }
+  }
+
+  @Test func holdingTakesOneAssertionAndReleasingGivesItBack() {
+    let recorder = Recorder()
+    let activity = recorder.assertion(reason: "Direct Dictation session")
+
+    activity.hold()
+    #expect(activity.isHeld)
+    #expect(recorder.begins.count == 1)
+    #expect(recorder.begins.first?.reason == "Direct Dictation session")
+
+    activity.release()
+    #expect(!activity.isHeld)
+    #expect(recorder.ends == 1)
+  }
+
+  /// `.userInitiated` and not `.background`, which is the whole point: a
+  /// background activity does not stop App Nap, and stopping App Nap is why
+  /// this exists.
+  ///
+  /// Asserted as equality rather than `contains`, because these are not
+  /// disjoint flags: `.userInitiated` is 0xffffff and `.background` is 0xff,
+  /// so a userInitiated assertion "contains" background bitwise and a
+  /// contains check would pass whatever was passed in.
+  @Test func theAssertionSaysAPersonIsWaiting() {
+    let recorder = Recorder()
+    recorder.assertion().hold()
+    #expect(recorder.begins.first?.options == .userInitiated)
+  }
+
+  /// A second hold would strand the first token, and a stranded token is an
+  /// assertion nothing can ever release.
+  @Test func holdingTwiceTakesOneAssertion() {
+    let recorder = Recorder()
+    let activity = recorder.assertion()
+
+    activity.hold()
+    activity.hold()
+    activity.hold()
+
+    #expect(recorder.begins.count == 1)
+    activity.release()
+    #expect(recorder.ends == 1)
+    #expect(!activity.isHeld)
+  }
+
+  /// Release is called from several terminal paths that can overlap, so a
+  /// second one must be silent rather than ending a token twice.
+  @Test func releasingTwiceEndsOneAssertion() {
+    let recorder = Recorder()
+    let activity = recorder.assertion()
+
+    activity.hold()
+    activity.release()
+    activity.release()
+
+    #expect(recorder.ends == 1)
+  }
+
+  @Test func releasingWithoutHoldingDoesNothing() {
+    let recorder = Recorder()
+    recorder.assertion().release()
+    #expect(recorder.ends == 0)
+    #expect(recorder.begins.isEmpty)
+  }
+
+  /// A second session after a first has ended takes a fresh assertion, rather
+  /// than quietly running unprotected because a flag was left set.
+  @Test func aLaterSessionTakesItsOwnAssertion() {
+    let recorder = Recorder()
+    let activity = recorder.assertion()
+
+    activity.hold()
+    activity.release()
+    activity.hold()
+
+    #expect(recorder.begins.count == 2)
+    #expect(activity.isHeld)
+  }
+}


### PR DESCRIPTION
A candidate fix for #77, the HUD that stops appearing or animates wrongly after four or five hours idle.

Because Talkify is `LSUIElement` with no window on screen, after a long idle the process gets throttled.

Potential fix:

`ActivityAssertion` holds a `.userInitiated` assertion for the length of a session, and for the length of a Drop Transcription job, and holds none while idle. An assertion that lasted all day would trade a rare glitch for a permanent battery cost, which is the wrong way round.

It is taken at the top of `checkAndBegin` rather than when recording starts, because the frames a napped process draws badly are the first ones, and by the time recording starts they have been drawn. That means every guard that refuses a session has to release it: `.beginRejected` produces no effects, so nothing downstream ever would, and a stranded assertion disables App Nap for the rest of the run. All three rejection paths release, and `release()` is idempotent because several terminal paths can reach it.

Refs #77