### PR TITLE
feat(dictionary): add Apple Speech-only personal dictionary with HUD correction learning

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,14 @@ _Avoid_: Drop zone, catch area
 A finished **Drop Transcription** held in a temporary folder under its final name while the HUD offers it, before a drag or the card's timer decides where it lands.
 _Avoid_: Draft, cache, pending file
 
+**Personal Dictionary**:
+A local, user-editable list of terms and correction pairs that bias Apple Speech and rewrite its display text. Stored as a plain-text file at `~/Library/Application Support/Talkify/dictionary.txt` and never leaves the Mac.
+_Avoid_: Custom vocabulary, word list
+
+**Dictionary Entry**:
+One **Personal Dictionary** row. A term teaches Apple Speech a phrase exists; a correction rewrites what was heard into what was written. Each entry can be enabled, disabled, edited, deleted and searched; disabled rows are stored as `# off:` in the file.
+_Avoid_: Rule, mapping
+
 **Settings section**:
 A navigable category of persisted application preferences with a visible user-facing purpose.
 _Avoid_: Placeholder tab, settings page
@@ -98,7 +106,7 @@ _Avoid_: Transcript history, cloud analytics
 - The HUD renders volatile recognition results immediately
 - **Direct Dictation** inserts finalized recognition text plus the latest volatile result when recognition ends before finalizing it
 - The **Direct Dictation** HUD expands from the physical notch on the focused input's display
-- Settings exposes **Appearance**, **Sounds**, and **Insights** in that order
+- Settings exposes **General**, **Appearance**, **Sounds**, **Dictation**, **Drop Transcription**, **Read Aloud**, **Language**, **Dictionary**, **Shortcuts**, **Updates**, and **Insights** in that order
 - The Settings navigation supports labeled groups, but renders no empty or disabled sections
 - A new Settings section appears only after its underlying preferences and behavior exist
 - If the focused input's display is unknown, the HUD uses the display containing the pointer
@@ -117,12 +125,17 @@ _Avoid_: Transcript history, cloud analytics
 - The housing band and the fillets never scale with **HUD size**: the band's height is the physical notch on a notched display and the menu bar's clearance elsewhere, and a fillet exists to meet a physical bezel
 - The host window stays sized for the 100% shape whatever the **HUD size**, so a smaller shape centers inside the same fixed window
 - The HUD appears above full-screen applications and on every Space
-- The HUD is display-only during Direct Dictation: mouse clicks pass through it and it never takes focus
-- The HUD accepts the mouse only as a **Drop Target** and while it holds a finished **Drop Transcription**; it never takes focus in either state
+- The HUD is display-only while Direct Dictation listens: mouse clicks pass through it and it never takes focus
+- The HUD accepts the mouse only as a **Drop Target**, while it holds a finished **Drop Transcription**, and while the post-session draft is editable after finalization; it never takes focus in any of those states
+- After finalization the HUD shows the corrected draft for about 2.5 seconds. Double-clicking the draft enters inline editing; the edit commits on Return, on focus loss, or when the HUD hides, and Escape cancels and restores the pre-edit text. A committed edit learns an attributable **Dictionary Entry** correction for next time
 - The HUD's display is locked when the session starts and does not follow windows
 - If the HUD's display disconnects mid-session, the HUD moves to the pointer's display
 - The HUD is the only surface for dictation status and error messages
 - HUD status and error messages dismiss themselves after about two seconds
+- The **Personal Dictionary** lives in `~/Library/Application Support/Talkify/dictionary.txt`, a UTF-8 plain-text file with a `# Talkify dictionary` header, one entry per line (`term` or `heard -> write`, `# off:` for disabled). Lines starting with `#` that are not `# off:` are ignored. The file is watched live and may be edited by hand.
+- Enabled terms feed Apple Speech as `AnalysisContext` bias phrases each session, bounded to 40 phrases deduplicated case-insensitively in file order
+- Enabled corrections are applied deterministically after recognition but never overwrite the raw engine result kept for history: longest trigger first, whole-word boundaries (`\p{L}\p{N}`), case-insensitive, hyphen/whitespace tolerant, one pass per trigger
+- Editing the HUD draft after dictation learns attributable word/phrase corrections (up to 4 words per side, new terms require >= 2 letters with a letter) and ignores whitespace/punctuation-only changes and whole-sentence rewrites (similarity < 0.5 over > 4 words); duplicate entries are ignored case-insensitively
 - The HUD writes nothing while it retracts and its bands do not resize: the shape leaves exactly as it stood, and its text and layout reset only once it is off screen
 - The wait between the last word and the recognized text is silent — no label stands in for it, and the voice visual comes to rest rather than reading the silence as a dead microphone
 - Compact opens with no text at all, because it is built around the live draft and a placeholder would be words nobody spoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,9 @@ These are settled. Reopening one needs a new argument, not a preference:
 - AppKit is the shell: lifecycle, status item, non-activating panels. SwiftUI
   renders windowed UI inside it
 - Apple Speech only, `SpeechAnalyzer` and `SpeechTranscriber`. No Whisper, no
-  local inference models
+  local inference models, no Parakeet/FluidAudio; the **Personal Dictionary**
+  augments Apple Speech via `AnalysisContext` bias phrases and deterministic
+  post-recognition corrections only
 - Model-View with local pure reducers. No MVVM, no TCA, no global store
   (`docs/adr/0005-mv-with-local-reducers.md`)
 - Exactly one third-party dependency, Sparkle, confined to `Talkify/Updates/`.

--- a/README.md
+++ b/README.md
@@ -136,10 +136,12 @@ disabled, edited, deleted, and searched. They are stored as a human-editable
 text file at `~/Library/Application Support/Talkify/dictionary.txt` (one line per
 entry, `# off:` for disabled) and stay local — no network, no cloud. Enabled
 terms feed Apple's `AnalysisContext` as a bounded nudge (up to 40 phrases) and
-correction pairs are applied deterministically after recognition but never
-overwrite the raw engine result kept for history. When you edit the HUD draft
-presented after dictation, Talkify learns the attributable word/phrase correction
-for next time via the HUD edit/finish path, deduplicates it, and ignores
+correction pairs are applied deterministically after recognition (longest
+trigger first, whole-word, case-insensitive) but never overwrite the raw
+engine result kept for history. After dictation the corrected draft stays
+visible for about 2.5 seconds — double-click it to edit inline (Return or
+focus loss commits, Esc cancels) and Talkify learns the attributable
+word/phrase correction for next time, deduplicates it, and ignores
 punctuation-only or whole-sentence rewrites.
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Privacy
 
-Everything is on-device: Apple's `SpeechAnalyzer`/`SpeechTranscriber` for recognition, `AVSpeechSynthesizer` for Read Aloud. Talkify makes no network requests, stores no audio, and keeps no history beyond the local usage metrics you can see in Insights.
+Everything is on-device: Apple's `SpeechAnalyzer`/`SpeechTranscriber` for recognition, `AVSpeechSynthesizer` for Read Aloud. Talkify makes no network requests, stores no audio, and keeps no history beyond the local usage metrics you can see in Insights. The personal dictionary lives only in `~/Library/Application Support/Talkify/dictionary.txt` — a plain text file you can edit by hand — and never leaves the Mac.
 
 One thing worth knowing: dictated text is inserted by pasting it, so it passes through the system clipboard for up to about half a second before your previous clipboard is put back. A clipboard manager or Universal Clipboard can see it during that window.
 
@@ -127,6 +127,21 @@ locales across German, English, Spanish, French, Italian, Japanese, Korean,
 Portuguese, Cantonese and Chinese; a language you have not used before downloads
 its model once, with progress shown in Settings and in the notch.
 
+## Personal Dictionary
+
+Teach Talkify words it keeps getting wrong in **Settings → Dictionary**. Add a
+term (e.g., "Anthropic") to bias recognition, or a correction pair (e.g.,
+"cloud code → Claude Code") to rewrite what was heard. Entries can be enabled,
+disabled, edited, deleted, and searched. They are stored as a human-editable
+text file at `~/Library/Application Support/Talkify/dictionary.txt` (one line per
+entry, `# off:` for disabled) and stay local — no network, no cloud. Enabled
+terms feed Apple's `AnalysisContext` as a bounded nudge (up to 40 phrases) and
+correction pairs are applied deterministically after recognition but never
+overwrite the raw engine result kept for history. When you edit recognized text
+(e.g., in an editable draft), Talkify learns attributable word/phrase corrections
+for next time, deduplicates them, and ignores punctuation-only or whole-sentence
+rewrites.
+
 ## Architecture
 
 Code is organized into folders, callbacks only flow one way from the main wiring point, and a pure reducer handles the state.
@@ -134,6 +149,7 @@ Code is organized into folders, callbacks only flow one way from the main wiring
 - `App/`: composition root, settings store, status item
 - `Input/`: the global key event tap and recorded bindings
 - `Dictation/`: the session machine (`DictationSessionMachine`, a pure tested reducer), the speech/insertion services, and the HUD surface and voice visuals only dictation draws
+- `Dictionary/`: `DictionaryEntry`, `DictionaryCorrector`, `DictionaryStore` (plain-text file under Application Support), and deterministic correction-learning
 - `DropTranscription/`: the drag gesture, the file transcription service, where a transcript is staged and lands, and its own HUD surfaces
 - `CoreHUD/`: what both features share: `HUDStage` owns the single panel and decides who holds the shape, plus the geometry seams and Metal shaders
 - `ReadAloud/`, `Settings/`, `Insights/`

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ text file at `~/Library/Application Support/Talkify/dictionary.txt` (one line pe
 entry, `# off:` for disabled) and stay local — no network, no cloud. Enabled
 terms feed Apple's `AnalysisContext` as a bounded nudge (up to 40 phrases) and
 correction pairs are applied deterministically after recognition but never
-overwrite the raw engine result kept for history. When you edit recognized text
-(e.g., in an editable draft), Talkify learns attributable word/phrase corrections
-for next time, deduplicates them, and ignores punctuation-only or whole-sentence
-rewrites.
+overwrite the raw engine result kept for history. When you edit the HUD draft
+presented after dictation, Talkify learns the attributable word/phrase correction
+for next time via the HUD edit/finish path, deduplicates it, and ignores
+punctuation-only or whole-sentence rewrites.
 
 ## Architecture
 

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -22,8 +22,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     application.delegate = delegate
     application.run()
   }
- 
- 
 
   /// True while this process hosts the test suite rather than a user.
   ///

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -64,6 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     self.hudController = hudController
     self.dictationController = dictationController
     self.usageTracker = usageTracker
+    dictationController.attachHUD(hudController)
 
     let readAloudController = ReadAloudController(
       settings: settings,

--- a/Talkify/CoreHUD/HUDRootView.swift
+++ b/Talkify/CoreHUD/HUDRootView.swift
@@ -8,12 +8,31 @@ struct HUDRootView: View {
   let settings: DictationSessionSettings
   let content: DictationHUDContent
   let drop: DropHUDContent
+  let stage: HUDStage?
   var onDrop: (Int) -> Void = { _ in }
   var onCardEvent: (HUDCardEvent) -> Void = { _ in }
 
+  init(
+    screen: HUDScreenSnapshot,
+    settings: DictationSessionSettings,
+    content: DictationHUDContent,
+    drop: DropHUDContent,
+    stage: HUDStage? = nil,
+    onDrop: @escaping (Int) -> Void = { _ in },
+    onCardEvent: @escaping (HUDCardEvent) -> Void = { _ in }
+  ) {
+    self.screen = screen
+    self.settings = settings
+    self.content = content
+    self.drop = drop
+    self.stage = stage
+    self.onDrop = onDrop
+    self.onCardEvent = onCardEvent
+  }
+
   var body: some View {
     if drop.mode == .none {
-      DictationHUDShellView(screen: screen, settings: settings, content: content)
+      DictationHUDShellView(screen: screen, settings: settings, content: content, stage: stage)
     } else {
       DropHUDView(
         screen: screen,

--- a/Talkify/CoreHUD/HUDStage.swift
+++ b/Talkify/CoreHUD/HUDStage.swift
@@ -63,7 +63,8 @@ final class HUDStage {
         screen: placeholder,
         settings: renderedSettings,
         content: dictationContent,
-        drop: dropContent
+        drop: dropContent,
+        stage: nil
       )
     )
     // The window size is this stage's decision, not the content's; without
@@ -225,6 +226,7 @@ final class HUDStage {
       settings: renderedSettings,
       content: dictationContent,
       drop: dropContent,
+      stage: self,
       onDrop: { [weak self] index in
         self?.onDropReceived?(index)
       },

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -117,7 +117,7 @@ extension DirectDictationController {
             editedText: edited,
             existing: store.entries
           )
-          for entry in entries { store.learn(correction: entry) }
+          store.learn(corrections: entries)
         },
         captureFocusedTarget: { textInsertionService.captureFocusedTarget() },
         insertText: { await textInsertionService.insert($0, into: $1, destination: $2) },

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -17,6 +17,7 @@ extension DirectDictationController {
     let prewarm: @Sendable (Locale) async throws -> Void
     let startRecognition: @Sendable (
       Locale,
+      _ biasPhrases: [String],
       _ updateHandler: @escaping @Sendable (SpeechRecognitionService.Update) -> Void,
       _ failureHandler: @escaping @Sendable (String) -> Void,
       _ levelHandler: @escaping @Sendable (Float) -> Void
@@ -24,6 +25,9 @@ extension DirectDictationController {
     let finishRecognition: @Sendable () async throws -> String
     let cancelRecognition: @Sendable () async -> Void
     let shutDownRecognition: @Sendable () async -> Void
+    let dictionaryBiasPhrases: @MainActor () -> [String]
+    let applyDictionary: @MainActor (String) -> (corrected: String, applied: [AppliedCorrection], raw: String)
+    let learnFromEdit: @MainActor (String, String, String) -> Void
 
     // Text insertion.
     let captureFocusedTarget: @MainActor () -> TextInsertionService.Target?
@@ -85,9 +89,10 @@ extension DirectDictationController {
         supportedLocale: { await speechService.supportedLocale(identifier: $0) },
         retainOnly: { await speechService.retainOnly(locales: $0) },
         prewarm: { try await speechService.prewarm(locale: $0) },
-        startRecognition: { locale, updateHandler, failureHandler, levelHandler in
+        startRecognition: { locale, biasPhrases, updateHandler, failureHandler, levelHandler in
           try await speechService.start(
             locale: locale,
+            biasPhrases: biasPhrases,
             updateHandler: updateHandler,
             failureHandler: failureHandler,
             levelHandler: levelHandler
@@ -96,6 +101,24 @@ extension DirectDictationController {
         finishRecognition: { try await speechService.finish() },
         cancelRecognition: { await speechService.cancel() },
         shutDownRecognition: { await speechService.shutDown() },
+        dictionaryBiasPhrases: {
+          DictionaryStore.shared.biasPhrases
+        },
+        applyDictionary: { text in
+          let store = DictionaryStore.shared
+          let (corrected, applied) = store.corrector.apply(to: text)
+          return (corrected, applied, text)
+        },
+        learnFromEdit: { raw, corrected, edited in
+          let store = DictionaryStore.shared
+          let entries = DictionaryLearning.learnableEntries(
+            rawText: raw,
+            correctedText: corrected,
+            editedText: edited,
+            existing: store.entries
+          )
+          for entry in entries { store.learn(correction: entry) }
+        },
         captureFocusedTarget: { textInsertionService.captureFocusedTarget() },
         insertText: { await textInsertionService.insert($0, into: $1, destination: $2) },
         requestMicrophoneAccess: { await PermissionService.requestMicrophoneAccess() },

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -410,6 +410,8 @@ final class DirectDictationController {
   private var lastCorrectedText = ""
 
   private func checkAndBegin() {
+    postFinalizationHideTask?.cancel()
+    postFinalizationHideTask = nil
     lastRawText = ""
     lastCorrectedText = ""
     activity.hold()

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -523,9 +523,11 @@ final class DirectDictationController {
       defer { finishTask = nil }
       do {
         let rawText = try await dependencies.finishRecognition()
-        dependencies.hideHUD()
         let correctedResult = dependencies.applyDictionary(rawText)
         let text = correctedResult.corrected
+        lastRawText = rawText
+        lastCorrectedText = text
+        if !text.isEmpty { dependencies.showLiveText(text) }
         let session = currentSessionSettings ?? settings.sessionSettings
         if session.historyEnabled, !rawText.isEmpty {
           await dependencies.recordHistory(
@@ -534,11 +536,10 @@ final class DirectDictationController {
             session.historyFolder
           )
         }
-        lastRawText = rawText
-        lastCorrectedText = text
         let outcome = await dependencies.insertText(
           text, focusedTarget, session.insertionDestination
         )
+        dependencies.hideHUD()
         switch outcome {
         case .inserted, .copiedToClipboard:
           dependencies.playPasteSound()

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -397,12 +397,11 @@ final class DirectDictationController {
   private var pendingLiveText: String?
   private var pendingRawText: String?
   private var lastRawText = ""
+  private var lastCorrectedText = ""
 
   private func checkAndBegin() {
-    // Held here rather than once recording starts: the first HUD frames are
-    // what a napped process draws badly, and by then they have been drawn.
-    // Every rejection below releases it, because .beginRejected produces no
-    // effects and nothing downstream would.
+    lastRawText = ""
+    lastCorrectedText = ""
     activity.hold()
 
     guard isPrepared else {
@@ -496,6 +495,18 @@ final class DirectDictationController {
     dependencies.learnFromEdit(rawText, correctedText, editedText)
   }
 
+  func handleHUDDraftEdited(_ editedText: String) {
+    let trimmed = editedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, !lastRawText.isEmpty, !lastCorrectedText.isEmpty else { return }
+    learnFromUserEdit(rawText: lastRawText, correctedText: lastCorrectedText, editedText: trimmed)
+  }
+
+  func attachHUD(_ hudController: DictationHUDController) {
+    hudController.onDraftEdited = { [weak self] edited in
+      self?.handleHUDDraftEdited(edited)
+    }
+  }
+
   /// What the history entry names as this session's destination.
   ///
   /// Clipboard-only never aims at an application, so naming the one that
@@ -527,6 +538,7 @@ final class DirectDictationController {
           )
         }
         lastRawText = rawText
+        lastCorrectedText = text
         let outcome = await dependencies.insertText(
           text, focusedTarget, session.insertionDestination
         )

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -47,6 +47,8 @@ final class DirectDictationController {
   /// Which slot's key began the session in flight, so the session runs in
   /// the language of the key that started it even if Settings change.
   private var activeSlot: GlobalKeyEventMonitor.TriggerSlot = .primary
+  private var postFinalizationHideTask: Task<Void, Never>?
+  private let finalTextDwell: Duration
 
   convenience init(
     settings: AppSettings,
@@ -59,9 +61,14 @@ final class DirectDictationController {
     )
   }
 
-  init(settings: AppSettings, dependencies: Dependencies) {
+  init(
+    settings: AppSettings,
+    dependencies: Dependencies,
+    finalTextDwell: Duration = .milliseconds(2500)
+  ) {
     self.settings = settings
     self.dependencies = dependencies
+    self.finalTextDwell = finalTextDwell
     keyEventMonitor = GlobalKeyEventMonitor { [weak self] event in
       Task { @MainActor [weak self] in
         self?.handle(event)
@@ -192,6 +199,8 @@ final class DirectDictationController {
   }
 
   func stop() {
+    postFinalizationHideTask?.cancel()
+    postFinalizationHideTask = nil
     // Before anything else: quitting mid-session must not leave the Mac quiet.
     ducking.restore()
     noSpeechTask?.cancel()
@@ -355,6 +364,8 @@ final class DirectDictationController {
     case .stopNoSpeechTimer:
       stopNoSpeechTimer()
     case let .showListening(latched):
+      postFinalizationHideTask?.cancel()
+      postFinalizationHideTask = nil
       let session = settings.sessionSettings
       currentSessionSettings = session
       dependencies.showListening(
@@ -496,6 +507,15 @@ final class DirectDictationController {
     let trimmed = editedText.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty, !lastRawText.isEmpty, !lastCorrectedText.isEmpty else { return }
     learnFromUserEdit(rawText: lastRawText, correctedText: lastCorrectedText, editedText: trimmed)
+    if postFinalizationHideTask != nil {
+      postFinalizationHideTask?.cancel()
+      postFinalizationHideTask = Task { [weak self] in
+        try? await Task.sleep(for: .milliseconds(600))
+        guard !Task.isCancelled else { return }
+        self?.dependencies.hideHUD()
+        self?.postFinalizationHideTask = nil
+      }
+    }
   }
 
   func attachHUD(_ hudController: DictationHUDController) {
@@ -539,14 +559,26 @@ final class DirectDictationController {
         let outcome = await dependencies.insertText(
           text, focusedTarget, session.insertionDestination
         )
-        dependencies.hideHUD()
         switch outcome {
         case .inserted, .copiedToClipboard:
           dependencies.playPasteSound()
           send(.sessionEnded)
           let wordCount = UsageMetrics.wordCount(in: text)
           await dependencies.recordSession(wordCount, speakingDuration)
+          if finalTextDwell == .zero {
+            dependencies.hideHUD()
+          } else {
+            postFinalizationHideTask?.cancel()
+            postFinalizationHideTask = Task { [weak self] in
+              guard let self else { return }
+              try? await Task.sleep(for: self.finalTextDwell)
+              guard !Task.isCancelled else { return }
+              self.dependencies.hideHUD()
+              self.postFinalizationHideTask = nil
+            }
+          }
         case .unavailable:
+          dependencies.hideHUD()
           send(.sessionEnded)
           dependencies.showMessage("Couldn't insert text", nil)
         }

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -395,7 +395,6 @@ final class DirectDictationController {
   /// The text carried alongside the current `updateReceived` action; the
   /// machine decides whether it shows, the controller remembers what.
   private var pendingLiveText: String?
-  private var pendingRawText: String?
   private var lastRawText = ""
   private var lastCorrectedText = ""
 
@@ -485,10 +484,8 @@ final class DirectDictationController {
     let displayText = corrected.corrected
     let hasVisibleText = !displayText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     pendingLiveText = displayText
-    pendingRawText = rawDisplay
     send(.updateReceived(hasVisibleText: hasVisibleText))
     pendingLiveText = nil
-    pendingRawText = nil
   }
 
   func learnFromUserEdit(rawText: String, correctedText: String, editedText: String) {

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -395,6 +395,8 @@ final class DirectDictationController {
   /// The text carried alongside the current `updateReceived` action; the
   /// machine decides whether it shows, the controller remembers what.
   private var pendingLiveText: String?
+  private var pendingRawText: String?
+  private var lastRawText = ""
 
   private func checkAndBegin() {
     // Held here rather than once recording starts: the first HUD frames are
@@ -436,12 +438,14 @@ final class DirectDictationController {
       fail(message: "Preparing speech…", wasCancelled: false)
       return
     }
+    let biasPhrases = dependencies.dictionaryBiasPhrases()
 
     sessionStartTask = Task { [weak self] in
       guard let self else { return }
       do {
         try await dependencies.startRecognition(
           locale,
+          biasPhrases,
           { [weak self] update in
             Task { @MainActor [weak self] in
               self?.receive(update)
@@ -477,13 +481,19 @@ final class DirectDictationController {
   }
 
   private func receive(_ update: SpeechRecognitionService.Update) {
-    let displayText = update.displayText
-    let hasVisibleText = !displayText
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-      .isEmpty
+    let rawDisplay = update.displayText
+    let corrected = dependencies.applyDictionary(rawDisplay)
+    let displayText = corrected.corrected
+    let hasVisibleText = !displayText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     pendingLiveText = displayText
+    pendingRawText = rawDisplay
     send(.updateReceived(hasVisibleText: hasVisibleText))
     pendingLiveText = nil
+    pendingRawText = nil
+  }
+
+  func learnFromUserEdit(rawText: String, correctedText: String, editedText: String) {
+    dependencies.learnFromEdit(rawText, correctedText, editedText)
   }
 
   /// What the history entry names as this session's destination.
@@ -504,20 +514,19 @@ final class DirectDictationController {
       guard let self else { return }
       defer { finishTask = nil }
       do {
-        let text = try await dependencies.finishRecognition()
+        let rawText = try await dependencies.finishRecognition()
         dependencies.hideHUD()
-        // Delivery follows the session snapshot, so a Settings change
-        // mid-session applies to the next session (ADR-0004).
+        let correctedResult = dependencies.applyDictionary(rawText)
+        let text = correctedResult.corrected
         let session = currentSessionSettings ?? settings.sessionSettings
-        if session.historyEnabled, !text.isEmpty {
-          // Before the outcome routing: words the paste then loses are
-          // exactly the words history exists to keep.
+        if session.historyEnabled, !rawText.isEmpty {
           await dependencies.recordHistory(
-            text,
+            rawText,
             historySource(for: session.insertionDestination),
             session.historyFolder
           )
         }
+        lastRawText = rawText
         let outcome = await dependencies.insertText(
           text, focusedTarget, session.insertionDestination
         )

--- a/Talkify/Dictation/HUD/DictationHUDContent.swift
+++ b/Talkify/Dictation/HUD/DictationHUDContent.swift
@@ -33,5 +33,6 @@ final class DictationHUDContent {
   /// re-fire mid-session.
   var sessionEpoch = 0
   var isEditable = false
+  var preEditText = ""
   var onEdited: ((String) -> Void)?
 }

--- a/Talkify/Dictation/HUD/DictationHUDContent.swift
+++ b/Talkify/Dictation/HUD/DictationHUDContent.swift
@@ -32,4 +32,6 @@ final class DictationHUDContent {
   /// on the change rather than on the listening state, so they never
   /// re-fire mid-session.
   var sessionEpoch = 0
+  var isEditable = false
+  var onEdited: ((String) -> Void)?
 }

--- a/Talkify/Dictation/HUD/DictationHUDController.swift
+++ b/Talkify/Dictation/HUD/DictationHUDController.swift
@@ -74,6 +74,7 @@ final class DictationHUDController {
     hasPlayedBeginSound = false
     content.languageTag = languageTag
     content.isEditable = false
+    content.preEditText = ""
     sessionIsLatched = isLatched
     // Dictation outranks a file job for the shape: the user is speaking now,
     // and the transcription keeps running with the status item carrying it.
@@ -154,10 +155,15 @@ final class DictationHUDController {
     stage.cancelMessageDismiss()
     if content.isEditable {
       let draft = content.text
+      let baseline = content.preEditText
       content.isEditable = false
-      commitEditedDraft(draft)
+      content.preEditText = ""
+      if draft.trimmingCharacters(in: .whitespacesAndNewlines) != baseline.trimmingCharacters(in: .whitespacesAndNewlines) {
+        commitEditedDraft(draft)
+      }
     } else {
       content.isEditable = false
+      content.preEditText = ""
     }
     if isListening {
       stage.sounds.playEnd(using: sessionSettings.sounds)

--- a/Talkify/Dictation/HUD/DictationHUDController.swift
+++ b/Talkify/Dictation/HUD/DictationHUDController.swift
@@ -113,7 +113,7 @@ final class DictationHUDController {
   }
 
   func showLiveText(_ text: String) {
-    guard isListening, !text.isEmpty else { return }
+    guard isListening, !text.isEmpty, !content.isEditable else { return }
     content.text = text
   }
 

--- a/Talkify/Dictation/HUD/DictationHUDController.swift
+++ b/Talkify/Dictation/HUD/DictationHUDController.swift
@@ -73,6 +73,7 @@ final class DictationHUDController {
     sessionSettings = settings
     hasPlayedBeginSound = false
     content.languageTag = languageTag
+    content.isEditable = false
     sessionIsLatched = isLatched
     // Dictation outranks a file job for the shape: the user is speaking now,
     // and the transcription keeps running with the status item carrying it.
@@ -151,6 +152,7 @@ final class DictationHUDController {
 
   func hide() {
     stage.cancelMessageDismiss()
+    content.isEditable = false
     if isListening {
       stage.sounds.playEnd(using: sessionSettings.sounds)
     }

--- a/Talkify/Dictation/HUD/DictationHUDController.swift
+++ b/Talkify/Dictation/HUD/DictationHUDController.swift
@@ -21,12 +21,16 @@ final class DictationHUDController {
   private var micWatchdogTask: Task<Void, Never>?
   private var hasPlayedBeginSound = false
 
+  var onDraftEdited: ((String) -> Void)?
+
   private var content: DictationHUDContent { stage.dictationContent }
   private var isListening: Bool { stage.occupant == .dictation }
 
   init(stage: HUDStage, settings: AppSettings) {
     self.stage = stage
     sessionSettings = settings.sessionSettings
+    bindContentCallbacks()
+    observeEditability()
   }
 
   /// Live microphone level, 0–1, ~46 Hz while listening. Smoothed with a
@@ -109,6 +113,28 @@ final class DictationHUDController {
   func showLiveText(_ text: String) {
     guard isListening, !text.isEmpty else { return }
     content.text = text
+  }
+
+  func commitEditedDraft(_ editedText: String) {
+    onDraftEdited?(editedText)
+  }
+
+  private func bindContentCallbacks() {
+    content.onEdited = { [weak self] edited in
+      self?.commitEditedDraft(edited)
+    }
+  }
+
+  private func observeEditability() {
+    withObservationTracking {
+      _ = content.isEditable
+    } onChange: { [weak self] in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        stage.acceptsMouse = content.isEditable
+        observeEditability()
+      }
+    }
   }
 
   /// Speech has stopped but the recognized text has not arrived yet.

--- a/Talkify/Dictation/HUD/DictationHUDController.swift
+++ b/Talkify/Dictation/HUD/DictationHUDController.swift
@@ -152,7 +152,13 @@ final class DictationHUDController {
 
   func hide() {
     stage.cancelMessageDismiss()
-    content.isEditable = false
+    if content.isEditable {
+      let draft = content.text
+      content.isEditable = false
+      commitEditedDraft(draft)
+    } else {
+      content.isEditable = false
+    }
     if isListening {
       stage.sounds.playEnd(using: sessionSettings.sounds)
     }

--- a/Talkify/Dictation/HUD/DictationHUDController.swift
+++ b/Talkify/Dictation/HUD/DictationHUDController.swift
@@ -130,10 +130,10 @@ final class DictationHUDController {
     withObservationTracking {
       _ = content.isEditable
     } onChange: { [weak self] in
-      Task { @MainActor [weak self] in
-        guard let self else { return }
-        stage.acceptsMouse = content.isEditable
-        observeEditability()
+      guard let self else { return }
+      MainActor.assumeIsolated {
+        self.stage.acceptsMouse = self.content.isEditable
+        self.observeEditability()
       }
     }
   }

--- a/Talkify/Dictation/HUD/DictationHUDShellView.swift
+++ b/Talkify/Dictation/HUD/DictationHUDShellView.swift
@@ -12,7 +12,6 @@ struct DictationHUDShellView: View {
   let settings: DictationSessionSettings
   let content: DictationHUDContent
   let stage: HUDStage?
-  @State private var preEditText = ""
 
   init(screen: HUDScreenSnapshot, settings: DictationSessionSettings, content: DictationHUDContent, stage: HUDStage? = nil) {
     self.screen = screen
@@ -180,11 +179,11 @@ struct DictationHUDShellView: View {
         HStack(alignment: .top, spacing: 10 * metrics.scale) {
           HUDCompactIndicatorView(content: content, scale: metrics.scale)
             .padding(.top, 3 * metrics.scale)
-          compactDraftText
+          editableDraft(alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
       } else {
-        draftText
+        editableDraft(alignment: .center)
       }
     }
     .font(.system(size: 15 * metrics.scale, weight: .medium))
@@ -211,16 +210,6 @@ struct DictationHUDShellView: View {
         .padding(.top, HUDNotchGeometry.closedSize(for: screen).height + 5 * metrics.scale)
         .allowsHitTesting(false)
     }
-  }
-
-  @ViewBuilder
-  private var compactDraftText: some View {
-    editableDraft(alignment: .leading)
-  }
-
-  @ViewBuilder
-  private var draftText: some View {
-    editableDraft(alignment: .center)
   }
 
   @ViewBuilder
@@ -260,7 +249,7 @@ struct DictationHUDShellView: View {
   }
 
   private func enterEditMode() {
-    preEditText = content.text
+    content.preEditText = content.text
     stage?.acceptsMouse = true
     content.isEditable = true
     isDraftFocused = true
@@ -269,9 +258,11 @@ struct DictationHUDShellView: View {
   private func commitEditedDraft() {
     guard content.isEditable else { return }
     let edited = content.text
+    let baseline = content.preEditText
     isDraftFocused = false
     content.isEditable = false
-    if edited.trimmingCharacters(in: .whitespacesAndNewlines) != preEditText.trimmingCharacters(in: .whitespacesAndNewlines) {
+    content.preEditText = ""
+    if edited.trimmingCharacters(in: .whitespacesAndNewlines) != baseline.trimmingCharacters(in: .whitespacesAndNewlines) {
       content.onEdited?(edited)
     }
   }
@@ -279,7 +270,8 @@ struct DictationHUDShellView: View {
   private func cancelEditing() {
     guard content.isEditable else { return }
     isDraftFocused = false
-    content.text = preEditText
+    content.text = content.preEditText
+    content.preEditText = ""
     content.isEditable = false
   }
 

--- a/Talkify/Dictation/HUD/DictationHUDShellView.swift
+++ b/Talkify/Dictation/HUD/DictationHUDShellView.swift
@@ -11,6 +11,15 @@ struct DictationHUDShellView: View {
   let screen: HUDScreenSnapshot
   let settings: DictationSessionSettings
   let content: DictationHUDContent
+  let stage: HUDStage?
+  @State private var preEditText = ""
+
+  init(screen: HUDScreenSnapshot, settings: DictationSessionSettings, content: DictationHUDContent, stage: HUDStage? = nil) {
+    self.screen = screen
+    self.settings = settings
+    self.content = content
+    self.stage = stage
+  }
 
   /// The shape's dimensions at the session's HUD size. Everything the user
   /// can resize is read from here; the housing band and fillets are not.
@@ -223,6 +232,10 @@ struct DictationHUDShellView: View {
         .lineLimit(4)
         .focused($isDraftFocused)
         .onSubmit { commitEditedDraft() }
+        .onExitCommand { cancelEditing() }
+        .onChange(of: isDraftFocused) { _, focused in
+          if !focused && content.isEditable { commitEditedDraft() }
+        }
         .onAppear { isDraftFocused = true }
     } else {
       switch settings.longDraftStyle {
@@ -247,15 +260,27 @@ struct DictationHUDShellView: View {
   }
 
   private func enterEditMode() {
+    preEditText = content.text
+    stage?.acceptsMouse = true
     content.isEditable = true
     isDraftFocused = true
   }
 
   private func commitEditedDraft() {
+    guard content.isEditable else { return }
     let edited = content.text
     isDraftFocused = false
     content.isEditable = false
-    content.onEdited?(edited)
+    if edited.trimmingCharacters(in: .whitespacesAndNewlines) != preEditText.trimmingCharacters(in: .whitespacesAndNewlines) {
+      content.onEdited?(edited)
+    }
+  }
+
+  private func cancelEditing() {
+    guard content.isEditable else { return }
+    isDraftFocused = false
+    content.text = preEditText
+    content.isEditable = false
   }
 
   /// The Edge Glow particle cloud, clipped to the housing so no mote leaks

--- a/Talkify/Dictation/HUD/DictationHUDShellView.swift
+++ b/Talkify/Dictation/HUD/DictationHUDShellView.swift
@@ -298,9 +298,9 @@ struct DictationHUDShellView: View {
   @ViewBuilder
   private var siriOrb: some View {
     if !reduceMotion,
-     settings.voiceVisual == .glow,
-     settings.glowCenter == .siriOrb,
-     content.showsVoiceVisual {
+      settings.voiceVisual == .glow,
+      settings.glowCenter == .siriOrb,
+      content.showsVoiceVisual {
       HUDSiriOrbView(content: content, side: size.height - 8 * metrics.scale)
     }
   }

--- a/Talkify/Dictation/HUD/DictationHUDShellView.swift
+++ b/Talkify/Dictation/HUD/DictationHUDShellView.swift
@@ -207,20 +207,31 @@ struct DictationHUDShellView: View {
   /// the text hangs off the indicator instead of floating centered.
   @ViewBuilder
   private var compactDraftText: some View {
-    switch settings.longDraftStyle {
-    case .tailOnly:
-      Text(content.text)
-        .lineLimit(1)
-        .truncationMode(.head)
-    case .growDown:
-      Text(content.text)
-        .lineLimit(4)
+    if content.isEditable {
+      TextField("", text: Binding(get: { content.text }, set: { content.text = $0 }), onCommit: { commitEditedDraft() })
+        .textFieldStyle(.plain)
         .multilineTextAlignment(.leading)
-    case .shrinkToFit:
-      Text(content.text)
-        .lineLimit(1)
-        .truncationMode(.head)
-        .minimumScaleFactor(0.55)
+        .lineLimit(4)
+        .onSubmit { commitEditedDraft() }
+    } else {
+      switch settings.longDraftStyle {
+      case .tailOnly:
+        Text(content.text)
+          .lineLimit(1)
+          .truncationMode(.head)
+          .onTapGesture(count: 2) { content.isEditable = true }
+      case .growDown:
+        Text(content.text)
+          .lineLimit(4)
+          .multilineTextAlignment(.leading)
+          .onTapGesture(count: 2) { content.isEditable = true }
+      case .shrinkToFit:
+        Text(content.text)
+          .lineLimit(1)
+          .truncationMode(.head)
+          .minimumScaleFactor(0.55)
+          .onTapGesture(count: 2) { content.isEditable = true }
+      }
     }
   }
 
@@ -230,21 +241,38 @@ struct DictationHUDShellView: View {
   /// the line cap is hit.
   @ViewBuilder
   private var draftText: some View {
-    switch settings.longDraftStyle {
-    case .tailOnly:
-      Text(content.text)
-        .lineLimit(1)
-        .truncationMode(.head)
-    case .growDown:
-      Text(content.text)
-        .lineLimit(4)
+    if content.isEditable {
+      TextField("", text: Binding(get: { content.text }, set: { content.text = $0 }), onCommit: { commitEditedDraft() })
+        .textFieldStyle(.plain)
         .multilineTextAlignment(.center)
-    case .shrinkToFit:
-      Text(content.text)
-        .lineLimit(1)
-        .truncationMode(.head)
-        .minimumScaleFactor(0.55)
+        .lineLimit(4)
+        .onSubmit { commitEditedDraft() }
+    } else {
+      switch settings.longDraftStyle {
+      case .tailOnly:
+        Text(content.text)
+          .lineLimit(1)
+          .truncationMode(.head)
+          .onTapGesture(count: 2) { content.isEditable = true }
+      case .growDown:
+        Text(content.text)
+          .lineLimit(4)
+          .multilineTextAlignment(.center)
+          .onTapGesture(count: 2) { content.isEditable = true }
+      case .shrinkToFit:
+        Text(content.text)
+          .lineLimit(1)
+          .truncationMode(.head)
+          .minimumScaleFactor(0.55)
+          .onTapGesture(count: 2) { content.isEditable = true }
+      }
     }
+  }
+
+  private func commitEditedDraft() {
+    let edited = content.text
+    content.isEditable = false
+    content.onEdited?(edited)
   }
 
   /// The Edge Glow particle cloud, clipped to the housing so no mote leaks

--- a/Talkify/Dictation/HUD/DictationHUDShellView.swift
+++ b/Talkify/Dictation/HUD/DictationHUDShellView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// shares.
 struct DictationHUDShellView: View {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @FocusState private var isDraftFocused: Bool
 
   let screen: HUDScreenSnapshot
   let settings: DictationSessionSettings
@@ -203,74 +204,56 @@ struct DictationHUDShellView: View {
     }
   }
 
-  /// The Compact draft: the same long-draft semantics, leading-aligned so
-  /// the text hangs off the indicator instead of floating centered.
   @ViewBuilder
   private var compactDraftText: some View {
+    editableDraft(alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var draftText: some View {
+    editableDraft(alignment: .center)
+  }
+
+  @ViewBuilder
+  private func editableDraft(alignment: TextAlignment) -> some View {
     if content.isEditable {
-      TextField("", text: Binding(get: { content.text }, set: { content.text = $0 }), onCommit: { commitEditedDraft() })
+      TextField("", text: Binding(get: { content.text }, set: { content.text = $0 }))
         .textFieldStyle(.plain)
-        .multilineTextAlignment(.leading)
+        .multilineTextAlignment(alignment)
         .lineLimit(4)
+        .focused($isDraftFocused)
         .onSubmit { commitEditedDraft() }
+        .onAppear { isDraftFocused = true }
     } else {
       switch settings.longDraftStyle {
       case .tailOnly:
         Text(content.text)
           .lineLimit(1)
           .truncationMode(.head)
-          .onTapGesture(count: 2) { content.isEditable = true }
+          .onTapGesture(count: 2) { enterEditMode() }
       case .growDown:
         Text(content.text)
           .lineLimit(4)
-          .multilineTextAlignment(.leading)
-          .onTapGesture(count: 2) { content.isEditable = true }
+          .multilineTextAlignment(alignment)
+          .onTapGesture(count: 2) { enterEditMode() }
       case .shrinkToFit:
         Text(content.text)
           .lineLimit(1)
           .truncationMode(.head)
           .minimumScaleFactor(0.55)
-          .onTapGesture(count: 2) { content.isEditable = true }
+          .onTapGesture(count: 2) { enterEditMode() }
       }
     }
   }
 
-  /// The single-line variants truncate the head — the newest words are what
-  /// the speaker checks. Grow Down cannot: head truncation forces
-  /// single-line rendering, so it wraps and truncates the tail only when
-  /// the line cap is hit.
-  @ViewBuilder
-  private var draftText: some View {
-    if content.isEditable {
-      TextField("", text: Binding(get: { content.text }, set: { content.text = $0 }), onCommit: { commitEditedDraft() })
-        .textFieldStyle(.plain)
-        .multilineTextAlignment(.center)
-        .lineLimit(4)
-        .onSubmit { commitEditedDraft() }
-    } else {
-      switch settings.longDraftStyle {
-      case .tailOnly:
-        Text(content.text)
-          .lineLimit(1)
-          .truncationMode(.head)
-          .onTapGesture(count: 2) { content.isEditable = true }
-      case .growDown:
-        Text(content.text)
-          .lineLimit(4)
-          .multilineTextAlignment(.center)
-          .onTapGesture(count: 2) { content.isEditable = true }
-      case .shrinkToFit:
-        Text(content.text)
-          .lineLimit(1)
-          .truncationMode(.head)
-          .minimumScaleFactor(0.55)
-          .onTapGesture(count: 2) { content.isEditable = true }
-      }
-    }
+  private func enterEditMode() {
+    content.isEditable = true
+    isDraftFocused = true
   }
 
   private func commitEditedDraft() {
     let edited = content.text
+    isDraftFocused = false
     content.isEditable = false
     content.onEdited?(edited)
   }

--- a/Talkify/Dictation/SpeechRecognitionService.swift
+++ b/Talkify/Dictation/SpeechRecognitionService.swift
@@ -201,6 +201,7 @@ actor SpeechRecognitionService {
 
   func start(
     locale: Locale,
+    biasPhrases: [String] = [],
     updateHandler: @escaping @Sendable (Update) -> Void,
     failureHandler: @escaping @Sendable (String) -> Void,
     levelHandler: (@Sendable (Float) -> Void)? = nil
@@ -211,6 +212,12 @@ actor SpeechRecognitionService {
 
     let prepared = try await takePreparedSession(locale: locale)
     try Task.checkCancellation()
+    if !biasPhrases.isEmpty {
+      let prefix = Array(biasPhrases.prefix(DictionaryCorrector.biasLimit))
+      let context = AnalysisContext()
+      context.contextualStrings[.general] = prefix
+      try? await prepared.analyzer.setContext(context)
+    }
     let (stream, continuation) = AsyncStream.makeStream(
       of: AnalyzerInput.self,
       bufferingPolicy: .bufferingNewest(64)

--- a/Talkify/Dictionary/DictionaryCorrector.swift
+++ b/Talkify/Dictionary/DictionaryCorrector.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct AppliedCorrection: Codable, Hashable, Sendable {
+  let from: String
+  let to: String
+  let count: Int
+}
+
+struct DictionaryCorrector: Sendable {
+  private let rules: [Rule]
+
+  private struct Rule: Sendable {
+    let regex: NSRegularExpression
+    let replacement: String
+    let trigger: String
+  }
+
+  init(entries: [DictionaryEntry]) {
+    let corrections = entries
+      .filter { $0.isEnabled && $0.kind == .correction }
+      .filter { !$0.hear.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+      .sorted { $0.hear.count > $1.hear.count }
+
+    rules = corrections.compactMap { entry in
+      guard let regex = Self.makeRegex(for: entry.hear) else { return nil }
+      return Rule(
+        regex: regex,
+        replacement: NSRegularExpression.escapedTemplate(for: entry.write),
+        trigger: entry.hear
+      )
+    }
+  }
+
+  var isEmpty: Bool { rules.isEmpty }
+
+  func apply(to text: String) -> (text: String, applied: [AppliedCorrection]) {
+    guard !rules.isEmpty, !text.isEmpty else { return (text, []) }
+    var result = text.precomposedStringWithCanonicalMapping
+    var applied: [AppliedCorrection] = []
+    for rule in rules {
+      let range = NSRange(result.startIndex..., in: result)
+      let matches = rule.regex.numberOfMatches(in: result, range: range)
+      guard matches > 0 else { continue }
+      let firstMatch = rule.regex.firstMatch(in: result, range: range)
+      let heard = firstMatch
+        .flatMap { Range($0.range, in: result) }
+        .map { String(result[$0]) } ?? rule.trigger
+      result = rule.regex.stringByReplacingMatches(
+        in: result,
+        range: range,
+        withTemplate: rule.replacement
+      )
+      applied.append(AppliedCorrection(
+        from: heard,
+        to: rule.replacement.replacingOccurrences(of: "\\", with: ""),
+        count: matches
+      ))
+    }
+    return (result, applied)
+  }
+
+  private static func makeRegex(for trigger: String) -> NSRegularExpression? {
+    let parts = trigger
+      .precomposedStringWithCanonicalMapping
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .split(whereSeparator: { $0 == " " || $0 == "-" || $0 == "\t" })
+      .map { NSRegularExpression.escapedPattern(for: String($0)) }
+    guard !parts.isEmpty else { return nil }
+    let body = parts.joined(separator: "[\\s\\-]*")
+    let pattern = "(?<![\\p{L}\\p{N}])\(body)(?![\\p{L}\\p{N}])"
+    return try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+  }
+}
+
+extension DictionaryCorrector {
+  static let biasLimit = 40
+
+  static func biasPhrases(from entries: [DictionaryEntry]) -> [String] {
+    var seen = Set<String>()
+    var phrases: [String] = []
+    for entry in entries where entry.isEnabled {
+      let phrase = entry.write.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !phrase.isEmpty, seen.insert(phrase.lowercased()).inserted else { continue }
+      phrases.append(phrase)
+      if phrases.count == biasLimit { break }
+    }
+    return phrases
+  }
+}

--- a/Talkify/Dictionary/DictionaryEntry.swift
+++ b/Talkify/Dictionary/DictionaryEntry.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+struct DictionaryEntry: Identifiable, Codable, Hashable, Sendable, Equatable {
+  enum Kind: String, Codable, Sendable {
+    case term
+    case correction
+  }
+
+  var id: UUID
+  var kind: Kind
+  var write: String
+  var hear: String
+  var isEnabled: Bool
+
+  init(
+    id: UUID = UUID(),
+    kind: Kind,
+    write: String,
+    hear: String = "",
+    isEnabled: Bool = true
+  ) {
+    self.id = id
+    self.kind = kind
+    self.write = write
+    self.hear = hear
+    self.isEnabled = isEnabled
+  }
+
+  static func term(_ word: String, isEnabled: Bool = true) -> DictionaryEntry {
+    DictionaryEntry(kind: .term, write: word, isEnabled: isEnabled)
+  }
+
+  static func correction(hear: String, write: String, isEnabled: Bool = true) -> DictionaryEntry {
+    DictionaryEntry(kind: .correction, write: write, hear: hear, isEnabled: isEnabled)
+  }
+
+  var fileLine: String {
+    let body = kind == .correction ? "\(hear) -> \(write)" : write
+    return isEnabled ? body : "# off: \(body)"
+  }
+
+  var normalizedWrite: String {
+    write.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  var normalizedHear: String {
+    hear.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+struct DictionaryWarning: Identifiable, Sendable {
+  var id: String { message }
+  let message: String
+
+  private static let common: Set<String> = [
+    "a", "about", "all", "also", "and", "any", "are", "as", "at", "back", "be", "because",
+    "but", "by", "call", "can", "case", "check", "class", "close", "cloud", "code", "come",
+    "could", "data", "day", "did", "do", "does", "down", "each", "even", "file", "find",
+    "first", "for", "from", "get", "give", "go", "good", "great", "group", "had", "has",
+    "have", "he", "her", "here", "him", "his", "how", "if", "in", "into", "is", "it",
+    "its", "just", "key", "know", "like", "line", "list", "look", "make", "man", "many",
+    "may", "me", "more", "most", "my", "need", "new", "no", "not", "now", "number", "of",
+    "off", "on", "one", "only", "open", "or", "other", "our", "out", "over", "page",
+    "part", "people", "point", "put", "read", "right", "run", "said", "same", "say",
+    "see", "set", "she", "should", "show", "side", "so", "some", "state", "still", "such",
+    "take", "team", "test", "than", "that", "the", "their", "them", "then", "there",
+    "these", "they", "thing", "think", "this", "time", "to", "two", "type", "up", "us",
+    "use", "user", "very", "want", "was", "way", "we", "well", "were", "what", "when",
+    "where", "which", "who", "will", "with", "word", "work", "would", "year", "you",
+    "your",
+  ]
+
+  static func check(_ entry: DictionaryEntry) -> [DictionaryWarning] {
+    guard entry.kind == .correction else { return [] }
+    let trigger = entry.hear.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trigger.isEmpty else { return [] }
+    var warnings: [DictionaryWarning] = []
+    let words = trigger.lowercased().split(whereSeparator: { $0 == " " || $0 == "-" })
+    if words.count == 1, let only = words.first {
+      if common.contains(String(only)) {
+        warnings.append(DictionaryWarning(
+          message: "\"\(trigger)\" is an ordinary word. This will rewrite every use of it, not just the ones you mean. Consider a longer phrase."
+        ))
+      } else if only.count <= 3 {
+        warnings.append(DictionaryWarning(
+          message: "\"\(trigger)\" is very short and will match often. Consider a longer phrase."
+        ))
+      }
+    }
+    if entry.write.trimmingCharacters(in: .whitespacesAndNewlines)
+      .caseInsensitiveCompare(trigger) == .orderedSame {
+      warnings.append(DictionaryWarning(
+        message: "This rewrites \"\(trigger)\" to itself, so it will never change anything."
+      ))
+    }
+    return warnings
+  }
+}

--- a/Talkify/Dictionary/DictionaryEntry.swift
+++ b/Talkify/Dictionary/DictionaryEntry.swift
@@ -52,9 +52,11 @@ struct DictionaryEntry: Identifiable, Codable, Hashable, Sendable, Equatable {
     let h = hear.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !w.isEmpty else { return false }
     if w.contains("\n") || w.contains("\r") || w.contains("->") { return false }
+    if kind == .term, w.hasPrefix("#") { return false }
     if kind == .correction {
       guard !h.isEmpty else { return false }
       if h.contains("\n") || h.contains("\r") || h.contains("->") { return false }
+      if h.hasPrefix("#") { return false }
     }
     return true
   }

--- a/Talkify/Dictionary/DictionaryEntry.swift
+++ b/Talkify/Dictionary/DictionaryEntry.swift
@@ -46,6 +46,18 @@ struct DictionaryEntry: Identifiable, Codable, Hashable, Sendable, Equatable {
   var normalizedHear: String {
     hear.trimmingCharacters(in: .whitespacesAndNewlines)
   }
+
+  var isValidForFile: Bool {
+    let w = write.trimmingCharacters(in: .whitespacesAndNewlines)
+    let h = hear.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !w.isEmpty else { return false }
+    if w.contains("\n") || w.contains("\r") || w.contains("->") { return false }
+    if kind == .correction {
+      guard !h.isEmpty else { return false }
+      if h.contains("\n") || h.contains("\r") || h.contains("->") { return false }
+    }
+    return true
+  }
 }
 
 struct DictionaryWarning: Identifiable, Sendable {

--- a/Talkify/Dictionary/DictionaryLearning.swift
+++ b/Talkify/Dictionary/DictionaryLearning.swift
@@ -13,9 +13,9 @@ enum DictionaryLearning {
     guard rawTrimmed != editedTrimmed else { return [] }
 
     if let corrected = correctedText?.trimmingCharacters(in: .whitespacesAndNewlines),
-       !corrected.isEmpty,
-       corrected != rawTrimmed,
-       editedTrimmed == corrected {
+      !corrected.isEmpty,
+      corrected != rawTrimmed,
+      editedTrimmed == corrected {
       return []
     }
 
@@ -148,7 +148,7 @@ enum DictionaryLearning {
       let rawSpanTrimmed = rawSpan.trimmingCharacters(in: .whitespacesAndNewlines)
       let editedSpanTrimmed = editedSpan.trimmingCharacters(in: .whitespacesAndNewlines)
       if !rawSpanTrimmed.isEmpty, !editedSpanTrimmed.isEmpty,
-         rawSpanTrimmed.lowercased() != editedSpanTrimmed.lowercased() {
+        rawSpanTrimmed.lowercased() != editedSpanTrimmed.lowercased() {
         let wordCount = rawSpanTrimmed.split(whereSeparator: { $0.isWhitespace }).count
         let editedCount = editedSpanTrimmed.split(whereSeparator: { $0.isWhitespace }).count
         if wordCount <= 4, editedCount <= 4 {

--- a/Talkify/Dictionary/DictionaryLearning.swift
+++ b/Talkify/Dictionary/DictionaryLearning.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+enum DictionaryLearning {
+  static func learnableEntries(
+    rawText: String,
+    correctedText: String? = nil,
+    editedText: String,
+    existing: [DictionaryEntry] = []
+  ) -> [DictionaryEntry] {
+    let rawTrimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let editedTrimmed = editedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !rawTrimmed.isEmpty, !editedTrimmed.isEmpty else { return [] }
+    guard rawTrimmed != editedTrimmed else { return [] }
+
+    if let corrected = correctedText?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !corrected.isEmpty,
+       corrected != rawTrimmed,
+       editedTrimmed == corrected {
+      return []
+    }
+
+    if isWhitespaceOrPunctuationOnlyChange(from: rawTrimmed, to: editedTrimmed) {
+      return []
+    }
+
+    if isWholeSentenceRewrite(from: rawTrimmed, to: editedTrimmed) {
+      return []
+    }
+
+    let candidates = diffEntries(from: rawTrimmed, to: editedTrimmed)
+    guard !candidates.isEmpty else { return [] }
+
+    var seen = Set<String>()
+    for entry in existing {
+      let key = "\(entry.kind.rawValue)|\(entry.hear.lowercased())|\(entry.write.lowercased())"
+      seen.insert(key)
+    }
+
+    var result: [DictionaryEntry] = []
+    for candidate in candidates {
+      let key: String
+      if candidate.kind == .correction {
+        key = "correction|\(candidate.hear.lowercased())|\(candidate.write.lowercased())"
+      } else {
+        key = "term|\(candidate.write.lowercased())|"
+      }
+      guard !seen.contains(key) else { continue }
+      seen.insert(key)
+      result.append(candidate)
+    }
+    return result
+  }
+
+  private static func isWhitespaceOrPunctuationOnlyChange(from raw: String, to edited: String) -> Bool {
+    let strippedRaw = raw.lowercased().filter { $0.isLetter || $0.isNumber || $0.isWhitespace }
+      .split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    let strippedEdited = edited.lowercased().filter { $0.isLetter || $0.isNumber || $0.isWhitespace }
+      .split(whereSeparator: \.isWhitespace).joined(separator: " ")
+    if strippedRaw == strippedEdited { return true }
+    let rawWords = strippedRaw.split(separator: " ")
+    let editedWords = strippedEdited.split(separator: " ")
+    return rawWords == editedWords
+  }
+
+  private static func isWholeSentenceRewrite(from raw: String, to edited: String) -> Bool {
+    let rawWords = tokenizeWords(raw)
+    let editedWords = tokenizeWords(edited)
+    guard !rawWords.isEmpty, !editedWords.isEmpty else { return false }
+    let maxCount = max(rawWords.count, editedWords.count)
+    guard maxCount > 4 else { return false }
+    let lcsLength = longestCommonSubsequenceLength(rawWords, editedWords)
+    let similarity = Double(lcsLength) / Double(maxCount)
+    return similarity < 0.5
+  }
+
+  private static func tokenizeWords(_ text: String) -> [String] {
+    text.lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init).filter { !$0.isEmpty }
+  }
+
+  private static func longestCommonSubsequenceLength(_ a: [String], _ b: [String]) -> Int {
+    var dp = Array(repeating: Array(repeating: 0, count: b.count + 1), count: a.count + 1)
+    for i in 1...a.count {
+      for j in 1...b.count {
+        if a[i - 1] == b[j - 1] {
+          dp[i][j] = dp[i - 1][j - 1] + 1
+        } else {
+          dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+        }
+      }
+    }
+    return dp[a.count][b.count]
+  }
+
+  private static func diffEntries(from raw: String, to edited: String) -> [DictionaryEntry] {
+    let rawTokens = splitPreservingWords(raw)
+    let editedTokens = splitPreservingWords(edited)
+    let rawWords = rawTokens
+    let editedWords = editedTokens
+
+    var i = 0
+    var j = 0
+    var entries: [DictionaryEntry] = []
+    while i < rawWords.count || j < editedWords.count {
+      if i < rawWords.count, j < editedWords.count, rawWords[i] == editedWords[j] {
+        i += 1
+        j += 1
+        continue
+      }
+      let startI = i
+      let startJ = j
+      var consumedI = 0
+      var consumedJ = 0
+      let lookahead = 4
+      var found = false
+      outer: for di in 0...lookahead {
+        for dj in 0...lookahead {
+          let ni = startI + di
+          let nj = startJ + dj
+          if ni < rawWords.count, nj < editedWords.count, rawWords[ni] == editedWords[nj] {
+            consumedI = di
+            consumedJ = dj
+            found = true
+            break outer
+          }
+          if ni == rawWords.count, nj == editedWords.count {
+            consumedI = rawWords.count - startI
+            consumedJ = editedWords.count - startJ
+            found = true
+            break outer
+          }
+        }
+      }
+      if !found {
+        consumedI = rawWords.count - startI
+        consumedJ = editedWords.count - startJ
+      }
+      if consumedI == 0, consumedJ == 0 {
+        consumedI = 1
+        consumedJ = 1
+        if startI + consumedI > rawWords.count { consumedI = rawWords.count - startI }
+        if startJ + consumedJ > editedWords.count { consumedJ = editedWords.count - startJ }
+      }
+      let rawSpan = rawTokens[startI..<min(startI + consumedI, rawTokens.count)].joined(separator: " ")
+      let editedSpan = editedTokens[startJ..<min(startJ + consumedJ, editedTokens.count)].joined(separator: " ")
+      let rawSpanTrimmed = rawSpan.trimmingCharacters(in: .whitespacesAndNewlines)
+      let editedSpanTrimmed = editedSpan.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !rawSpanTrimmed.isEmpty, !editedSpanTrimmed.isEmpty,
+         rawSpanTrimmed.lowercased() != editedSpanTrimmed.lowercased() {
+        let wordCount = rawSpanTrimmed.split(whereSeparator: { $0.isWhitespace }).count
+        let editedCount = editedSpanTrimmed.split(whereSeparator: { $0.isWhitespace }).count
+        if wordCount <= 4, editedCount <= 4 {
+          entries.append(.correction(hear: rawSpanTrimmed, write: editedSpanTrimmed))
+        }
+      } else if rawSpanTrimmed.isEmpty, !editedSpanTrimmed.isEmpty {
+        let words = editedSpanTrimmed.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        for word in words where word.count >= 2 && word.rangeOfCharacter(from: .letters) != nil {
+          entries.append(.term(word))
+        }
+      }
+      i = startI + consumedI
+      j = startJ + consumedJ
+      if consumedI == 0, consumedJ == 0 { break }
+    }
+
+    var deduped: [DictionaryEntry] = []
+    var seenKeys = Set<String>()
+    for entry in entries {
+      let key = "\(entry.kind.rawValue)|\(entry.hear.lowercased())|\(entry.write.lowercased())"
+      if seenKeys.insert(key).inserted {
+        deduped.append(entry)
+      }
+    }
+    return deduped
+  }
+
+  private static func splitPreservingWords(_ text: String) -> [String] {
+    var tokens: [String] = []
+    var current = ""
+    for char in text {
+      if char.isLetter || char.isNumber || char == "'" {
+        current.append(char)
+      } else if char.isWhitespace || char == "-" {
+        if !current.isEmpty {
+          tokens.append(current)
+          current = ""
+        }
+      } else {
+        if !current.isEmpty {
+          tokens.append(current)
+          current = ""
+        }
+      }
+    }
+    if !current.isEmpty { tokens.append(current) }
+    return tokens
+  }
+}

--- a/Talkify/Dictionary/DictionaryLearning.swift
+++ b/Talkify/Dictionary/DictionaryLearning.swift
@@ -32,7 +32,9 @@ enum DictionaryLearning {
 
     var seen = Set<String>()
     for entry in existing {
-      let key = "\(entry.kind.rawValue)|\(entry.hear.lowercased())|\(entry.write.lowercased())"
+      let hear = entry.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      let write = entry.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      let key = "\(entry.kind.rawValue)|\(hear)|\(write)"
       seen.insert(key)
     }
 
@@ -40,9 +42,12 @@ enum DictionaryLearning {
     for candidate in candidates {
       let key: String
       if candidate.kind == .correction {
-        key = "correction|\(candidate.hear.lowercased())|\(candidate.write.lowercased())"
+        let hear = candidate.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        let write = candidate.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        key = "correction|\(hear)|\(write)"
       } else {
-        key = "term|\(candidate.write.lowercased())|"
+        let write = candidate.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        key = "term||\(write)"
       }
       guard !seen.contains(key) else { continue }
       seen.insert(key)
@@ -94,14 +99,12 @@ enum DictionaryLearning {
   private static func diffEntries(from raw: String, to edited: String) -> [DictionaryEntry] {
     let rawTokens = splitPreservingWords(raw)
     let editedTokens = splitPreservingWords(edited)
-    let rawWords = rawTokens
-    let editedWords = editedTokens
 
     var i = 0
     var j = 0
     var entries: [DictionaryEntry] = []
-    while i < rawWords.count || j < editedWords.count {
-      if i < rawWords.count, j < editedWords.count, rawWords[i] == editedWords[j] {
+    while i < rawTokens.count || j < editedTokens.count {
+      if i < rawTokens.count, j < editedTokens.count, rawTokens[i] == editedTokens[j] {
         i += 1
         j += 1
         continue
@@ -116,29 +119,29 @@ enum DictionaryLearning {
         for dj in 0...lookahead {
           let ni = startI + di
           let nj = startJ + dj
-          if ni < rawWords.count, nj < editedWords.count, rawWords[ni] == editedWords[nj] {
+          if ni < rawTokens.count, nj < editedTokens.count, rawTokens[ni] == editedTokens[nj] {
             consumedI = di
             consumedJ = dj
             found = true
             break outer
           }
-          if ni == rawWords.count, nj == editedWords.count {
-            consumedI = rawWords.count - startI
-            consumedJ = editedWords.count - startJ
+          if ni == rawTokens.count, nj == editedTokens.count {
+            consumedI = rawTokens.count - startI
+            consumedJ = editedTokens.count - startJ
             found = true
             break outer
           }
         }
       }
       if !found {
-        consumedI = rawWords.count - startI
-        consumedJ = editedWords.count - startJ
+        consumedI = rawTokens.count - startI
+        consumedJ = editedTokens.count - startJ
       }
       if consumedI == 0, consumedJ == 0 {
         consumedI = 1
         consumedJ = 1
-        if startI + consumedI > rawWords.count { consumedI = rawWords.count - startI }
-        if startJ + consumedJ > editedWords.count { consumedJ = editedWords.count - startJ }
+        if startI + consumedI > rawTokens.count { consumedI = rawTokens.count - startI }
+        if startJ + consumedJ > editedTokens.count { consumedJ = editedTokens.count - startJ }
       }
       let rawSpan = rawTokens[startI..<min(startI + consumedI, rawTokens.count)].joined(separator: " ")
       let editedSpan = editedTokens[startJ..<min(startJ + consumedJ, editedTokens.count)].joined(separator: " ")
@@ -165,7 +168,9 @@ enum DictionaryLearning {
     var deduped: [DictionaryEntry] = []
     var seenKeys = Set<String>()
     for entry in entries {
-      let key = "\(entry.kind.rawValue)|\(entry.hear.lowercased())|\(entry.write.lowercased())"
+      let hear = entry.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      let write = entry.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      let key = "\(entry.kind.rawValue)|\(hear)|\(write)"
       if seenKeys.insert(key).inserted {
         deduped.append(entry)
       }

--- a/Talkify/Dictionary/DictionaryStore.swift
+++ b/Talkify/Dictionary/DictionaryStore.swift
@@ -11,6 +11,8 @@ final class DictionaryStore {
 
   private var watcher: DispatchSourceFileSystemObject?
   private var isSaving = false
+  private var cachedCorrector: DictionaryCorrector?
+  private var cachedCorrectorRevision: Int?
 
   static var fileURL: URL {
     let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -66,7 +68,13 @@ final class DictionaryStore {
     }
   }
 
-  var corrector: DictionaryCorrector { DictionaryCorrector(entries: entries) }
+  var corrector: DictionaryCorrector {
+    if let cached = cachedCorrector, cachedCorrectorRevision == revision { return cached }
+    let built = DictionaryCorrector(entries: entries)
+    cachedCorrector = built
+    cachedCorrectorRevision = revision
+    return built
+  }
 
   var biasPhrases: [String] { DictionaryCorrector.biasPhrases(from: entries) }
 
@@ -162,17 +170,31 @@ final class DictionaryStore {
   }
 
   func learn(correction: DictionaryEntry) {
-    guard correction.isValidForFile else { return }
-    let normalizedWrite = correction.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-    let normalizedHear = correction.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalizedWrite.isEmpty else { return }
-    if correction.kind == .correction, normalizedHear.isEmpty { return }
-    let exists = entries.contains {
-      $0.kind == correction.kind
-        && $0.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalizedWrite
-        && $0.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalizedHear
+    learn(corrections: [correction])
+  }
+
+  func learn(corrections: [DictionaryEntry]) {
+    let valid = corrections.filter(\.isValidForFile)
+    guard !valid.isEmpty else { return }
+    var seen = Set<String>()
+    for entry in entries {
+      let w = entry.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      let h = entry.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      seen.insert("\(entry.kind.rawValue)|\(h)|\(w)")
     }
-    guard !exists else { return }
-    add(correction)
+    var toAdd: [DictionaryEntry] = []
+    for correction in valid {
+      let w = correction.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      let h = correction.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !w.isEmpty else { continue }
+      if correction.kind == .correction, h.isEmpty { continue }
+      let key = "\(correction.kind.rawValue)|\(h)|\(w)"
+      guard !seen.contains(key) else { continue }
+      seen.insert(key)
+      toAdd.append(correction)
+    }
+    guard !toAdd.isEmpty else { return }
+    entries.append(contentsOf: toAdd)
+    save()
   }
 }

--- a/Talkify/Dictionary/DictionaryStore.swift
+++ b/Talkify/Dictionary/DictionaryStore.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class DictionaryStore {
+  static let shared = DictionaryStore()
+
+  private(set) var entries: [DictionaryEntry] = []
+  private(set) var revision = 0
+
+  private var watcher: DispatchSourceFileSystemObject?
+  private var isSaving = false
+
+  static var fileURL: URL {
+    let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+      .appendingPathComponent("Talkify", isDirectory: true)
+    try? FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    return base.appendingPathComponent("dictionary.txt")
+  }
+
+  init(fileURL: URL? = nil, watchFile: Bool = true) {
+    if let fileURL {
+      self.customFileURL = fileURL
+    }
+    load()
+    if watchFile {
+      startWatching()
+    }
+  }
+
+  private var customFileURL: URL?
+
+  private var resolvedFileURL: URL {
+    customFileURL ?? Self.fileURL
+  }
+
+  func add(_ entry: DictionaryEntry) {
+    entries.append(entry)
+    save()
+  }
+
+  func update(_ entry: DictionaryEntry) {
+    guard let index = entries.firstIndex(where: { $0.id == entry.id }) else { return }
+    entries[index] = entry
+    save()
+  }
+
+  func delete(_ entry: DictionaryEntry) {
+    entries.removeAll { $0.id == entry.id }
+    save()
+  }
+
+  func delete(ids: Set<UUID>) {
+    entries.removeAll { ids.contains($0.id) }
+    save()
+  }
+
+  func filtered(by query: String) -> [DictionaryEntry] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return entries }
+    return entries.filter {
+      $0.write.localizedStandardContains(trimmed) || $0.hear.localizedStandardContains(trimmed)
+    }
+  }
+
+  var corrector: DictionaryCorrector { DictionaryCorrector(entries: entries) }
+
+  var biasPhrases: [String] { DictionaryCorrector.biasPhrases(from: entries) }
+
+  func contains(write: String, hear: String) -> Bool {
+    let normalizedWrite = write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalizedHear = hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    return entries.contains {
+      $0.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalizedWrite
+        && $0.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalizedHear
+    }
+  }
+
+  func reloadFromDisk() {
+    load()
+  }
+
+  private func load() {
+    let url = resolvedFileURL
+    guard let text = try? String(contentsOf: url, encoding: .utf8) else {
+      entries = []
+      revision += 1
+      return
+    }
+    entries = Self.parse(text)
+    revision += 1
+  }
+
+  static func parse(_ text: String) -> [DictionaryEntry] {
+    text.split(separator: "\n", omittingEmptySubsequences: false).compactMap { rawLine in
+      var line = rawLine.trimmingCharacters(in: .whitespaces)
+      guard !line.isEmpty else { return nil }
+      var isEnabled = true
+      if line.hasPrefix("#") {
+        let stripped = line.dropFirst().trimmingCharacters(in: .whitespaces)
+        guard stripped.lowercased().hasPrefix("off:") else { return nil }
+        line = stripped.dropFirst(4).trimmingCharacters(in: .whitespaces)
+        isEnabled = false
+        guard !line.isEmpty else { return nil }
+      }
+      if let arrow = line.range(of: "->") {
+        let hear = line[..<arrow.lowerBound].trimmingCharacters(in: .whitespaces)
+        let write = line[arrow.upperBound...].trimmingCharacters(in: .whitespaces)
+        guard !hear.isEmpty, !write.isEmpty else { return nil }
+        return DictionaryEntry(kind: .correction, write: String(write), hear: String(hear), isEnabled: isEnabled)
+      }
+      return DictionaryEntry(kind: .term, write: line, isEnabled: isEnabled)
+    }
+  }
+
+  private func save() {
+    revision += 1
+    isSaving = true
+    defer { isSaving = false }
+    let body = entries.map(\.fileLine).joined(separator: "\n")
+    let text = Self.header + body + "\n"
+    let url = resolvedFileURL
+    try? FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try? text.write(to: url, atomically: true, encoding: .utf8)
+  }
+
+  private static let header = """
+    # Talkify dictionary
+    #
+    #   Anthropic                 a term — the engine is told this word exists
+    #   cloud code -> Claude Code a correction — when you hear X, write Y
+    #   # off: some rule -> Rule  a disabled entry
+    #
+    # Edit this file directly if you like; the app picks up changes immediately.
+
+    """
+
+  private func startWatching() {
+    watcher?.cancel()
+    let url = resolvedFileURL
+    let descriptor = open(url.path, O_EVTONLY)
+    guard descriptor >= 0 else { return }
+    let source = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: descriptor,
+      eventMask: [.write, .delete, .rename, .extend],
+      queue: .main
+    )
+    source.setEventHandler { [weak self] in
+      guard let self else { return }
+      if !self.isSaving { self.load() }
+      self.startWatching()
+    }
+    source.setCancelHandler { close(descriptor) }
+    source.resume()
+    watcher = source
+  }
+
+  func learn(correction: DictionaryEntry) {
+    let normalizedWrite = correction.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalizedHear = correction.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalizedWrite.isEmpty else { return }
+    if correction.kind == .correction, normalizedHear.isEmpty { return }
+    let exists = entries.contains {
+      $0.kind == correction.kind
+        && $0.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalizedWrite
+        && $0.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines) == normalizedHear
+    }
+    guard !exists else { return }
+    add(correction)
+  }
+}

--- a/Talkify/Dictionary/DictionaryStore.swift
+++ b/Talkify/Dictionary/DictionaryStore.swift
@@ -36,11 +36,13 @@ final class DictionaryStore {
   }
 
   func add(_ entry: DictionaryEntry) {
+    guard entry.isValidForFile else { return }
     entries.append(entry)
     save()
   }
 
   func update(_ entry: DictionaryEntry) {
+    guard entry.isValidForFile else { return }
     guard let index = entries.firstIndex(where: { $0.id == entry.id }) else { return }
     entries[index] = entry
     save()
@@ -160,6 +162,7 @@ final class DictionaryStore {
   }
 
   func learn(correction: DictionaryEntry) {
+    guard correction.isValidForFile else { return }
     let normalizedWrite = correction.write.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
     let normalizedHear = correction.hear.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedWrite.isEmpty else { return }

--- a/Talkify/Settings/Sections/DictionarySettingsView.swift
+++ b/Talkify/Settings/Sections/DictionarySettingsView.swift
@@ -150,7 +150,7 @@ private struct DictionaryEditorView: View {
   }
 
   private var warnings: [DictionaryWarning] { DictionaryWarning.check(draft) }
-  private var isValid: Bool { !draft.write.isEmpty && (kind == .term || !draft.hear.isEmpty) }
+  private var isValid: Bool { draft.isValidForFile }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {

--- a/Talkify/Settings/Sections/DictionarySettingsView.swift
+++ b/Talkify/Settings/Sections/DictionarySettingsView.swift
@@ -1,0 +1,206 @@
+import AppKit
+import SwiftUI
+
+struct DictionarySettingsView: View {
+  @State private var store = DictionaryStore.shared
+  @State private var query = ""
+  @State private var editing: DictionaryEntry?
+  @State private var isAdding = false
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  private var entries: [DictionaryEntry] { store.filtered(by: query) }
+
+  var body: some View {
+    VStack(spacing: 16) {
+      SettingsCard(title: "Personal Dictionary") {
+        SettingsRow(
+          title: "Search",
+          description: "Filter by the word or phrase on either side"
+        ) {
+          TextField("Search dictionary", text: $query)
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 200)
+        }
+
+        HStack {
+          Text("\(store.entries.count) entries")
+            .font(.caption)
+            .foregroundStyle(.white.opacity(contrast == .increased ? 0.76 : 0.52))
+          Spacer()
+          Button("Add Entry") { isAdding = true }
+            .buttonStyle(SettingsButtonStyle())
+          Button("Reveal File") { revealFile() }
+            .buttonStyle(SettingsButtonStyle())
+        }
+        .padding(.vertical, 8)
+      }
+
+      SettingsCard(title: "Entries") {
+        if entries.isEmpty {
+          Text(store.entries.isEmpty ? "No entries yet. Add words it keeps getting wrong." : "No matches")
+            .font(.caption)
+            .foregroundStyle(.white.opacity(0.5))
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 20)
+        } else {
+          ForEach(entries) { entry in
+            DictionaryRowView(
+              entry: entry,
+              onEdit: { editing = entry },
+              onToggle: {
+                var updated = entry
+                updated.isEnabled.toggle()
+                store.update(updated)
+              },
+              onDelete: { store.delete(entry) }
+            )
+          }
+        }
+      }
+
+      SettingsCard(title: "About") {
+        Text("Terms bias recognition; corrections rewrite text after. The file at \(DictionaryStore.fileURL.path(percentEncoded: false)) is editable by hand and updates live.")
+          .font(.caption)
+          .foregroundStyle(.white.opacity(contrast == .increased ? 0.76 : 0.52))
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+    .sheet(isPresented: $isAdding) {
+      DictionaryEditorView(entry: nil) { store.add($0) }
+    }
+    .sheet(item: $editing) { entry in
+      DictionaryEditorView(entry: entry) { store.update($0) }
+    }
+  }
+
+  private func revealFile() {
+    NSWorkspace.shared.activateFileViewerSelecting([DictionaryStore.fileURL])
+  }
+}
+
+private struct DictionaryRowView: View {
+  let entry: DictionaryEntry
+  let onEdit: () -> Void
+  let onToggle: () -> Void
+  let onDelete: () -> Void
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Circle()
+        .fill(entry.isEnabled ? Color.green : Color.gray)
+        .frame(width: 8, height: 8)
+      Text(entry.kind == .correction ? "Fix" : "Term")
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(.white.opacity(0.5))
+        .frame(width: 32, alignment: .leading)
+      if entry.kind == .correction {
+        Text(entry.hear)
+          .font(.system(size: 13))
+          .foregroundStyle(.white.opacity(0.6))
+        Image(systemName: "arrow.right")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(.white.opacity(0.4))
+      }
+      Text(entry.write)
+        .font(.system(size: 13, weight: .medium))
+        .foregroundStyle(.white)
+        .lineLimit(1)
+      Spacer()
+      Button(entry.isEnabled ? "Disable" : "Enable", action: onToggle)
+        .buttonStyle(SettingsButtonStyle())
+      Button("Edit", action: onEdit)
+        .buttonStyle(SettingsButtonStyle())
+      Button("Delete", action: onDelete)
+        .buttonStyle(SettingsButtonStyle())
+    }
+    .opacity(entry.isEnabled ? 1 : 0.5)
+    .padding(.vertical, 6)
+    .overlay(alignment: .bottom) {
+      Rectangle().fill(.white.opacity(0.07)).frame(height: 1)
+    }
+  }
+}
+
+private struct DictionaryEditorView: View {
+  let entry: DictionaryEntry?
+  let onSave: (DictionaryEntry) -> Void
+  @Environment(\.dismiss) private var dismiss
+  @State private var kind: DictionaryEntry.Kind
+  @State private var hear: String
+  @State private var write: String
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  init(entry: DictionaryEntry?, onSave: @escaping (DictionaryEntry) -> Void) {
+    self.entry = entry
+    self.onSave = onSave
+    _kind = State(initialValue: entry?.kind ?? .term)
+    _hear = State(initialValue: entry?.hear ?? "")
+    _write = State(initialValue: entry?.write ?? "")
+  }
+
+  private var draft: DictionaryEntry {
+    DictionaryEntry(
+      id: entry?.id ?? UUID(),
+      kind: kind,
+      write: write.trimmingCharacters(in: .whitespacesAndNewlines),
+      hear: kind == .correction ? hear.trimmingCharacters(in: .whitespacesAndNewlines) : "",
+      isEnabled: entry?.isEnabled ?? true
+    )
+  }
+
+  private var warnings: [DictionaryWarning] { DictionaryWarning.check(draft) }
+  private var isValid: Bool { !draft.write.isEmpty && (kind == .term || !draft.hear.isEmpty) }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text(entry == nil ? "New Entry" : "Edit Entry")
+        .font(.system(size: 16, weight: .semibold))
+      Picker("Type", selection: $kind) {
+        Text("Term").tag(DictionaryEntry.Kind.term)
+        Text("Correction").tag(DictionaryEntry.Kind.correction)
+      }
+      .pickerStyle(.segmented)
+      VStack(alignment: .leading, spacing: 12) {
+        if kind == .correction {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("When you hear").font(.caption).foregroundStyle(.white.opacity(0.6))
+            TextField("cloud code", text: $hear)
+              .textFieldStyle(.roundedBorder)
+          }
+        }
+        VStack(alignment: .leading, spacing: 4) {
+          Text(kind == .correction ? "Write" : "Word or phrase").font(.caption).foregroundStyle(.white.opacity(0.6))
+          TextField(kind == .correction ? "Claude Code" : "Anthropic", text: $write)
+            .textFieldStyle(.roundedBorder)
+        }
+      }
+      ForEach(warnings) { warning in
+        HStack(alignment: .top, spacing: 8) {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundStyle(.yellow)
+          Text(warning.message)
+            .font(.caption)
+            .foregroundStyle(.white.opacity(0.8))
+        }
+        .padding(8)
+        .background(Color.yellow.opacity(0.12), in: RoundedRectangle(cornerRadius: 8))
+      }
+      HStack {
+        Spacer()
+        Button("Cancel") { dismiss() }
+          .buttonStyle(SettingsButtonStyle())
+        Button("Save") {
+          guard isValid else { return }
+          onSave(draft)
+          dismiss()
+        }
+        .buttonStyle(SettingsButtonStyle())
+        .disabled(!isValid)
+      }
+    }
+    .padding(20)
+    .frame(width: 460)
+    .background(SettingsTheme.card)
+  }
+}

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -20,6 +20,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case dropTranscription
   case readAloud
   case language
+  case dictionary
   case shortcuts
   case updates
   case insights
@@ -36,6 +37,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .dropTranscription: "Drop Transcription"
     case .readAloud: "Read Aloud"
     case .language: "Language"
+    case .dictionary: "Dictionary"
     case .shortcuts: "Shortcuts"
     case .updates: "Updates"
     case .insights: "Insights"
@@ -51,6 +53,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .dropTranscription: "Transcribe audio and video files"
     case .readAloud: "Choose the voice that reads selected text"
     case .language: "Pick your dictation languages and their triggers"
+    case .dictionary: "Teach Talkify names and phrases it keeps getting wrong"
     case .shortcuts: "Rebind Direct Dictation triggers and Read Aloud"
     case .updates: "Keep Talkify current"
     case .insights: "Review your local Direct Dictation activity"
@@ -66,6 +69,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .dropTranscription: "square.and.arrow.down"
     case .readAloud: "speaker.wave.2"
     case .language: "globe"
+    case .dictionary: "book"
     case .shortcuts: "keyboard"
     case .updates: "arrow.down.circle"
     case .insights: "chart.bar.xaxis"

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -257,6 +257,8 @@ private struct SettingsContent: View {
           ReadAloudSettingsView(settings: settings)
         case .language:
           LanguageSettingsView(settings: settings, runtimeState: runtimeState)
+        case .dictionary:
+          DictionarySettingsView()
         case .shortcuts:
           ShortcutsSettingsView(settings: settings)
         case .updates:

--- a/TalkifyTests/DictionaryAppleOnlyRegressionTests.swift
+++ b/TalkifyTests/DictionaryAppleOnlyRegressionTests.swift
@@ -1,0 +1,222 @@
+import Foundation
+import os
+import Testing
+@testable import Talkify
+
+@MainActor
+struct DictionaryAppleOnlyRegressionTests {
+  private func tempURL() -> URL {
+    FileManager.default.temporaryDirectory
+      .appending(path: "AppleOnlyRegression-\(UUID().uuidString).txt")
+  }
+
+  @Test func appleOnlySettingsHaveNoSpeechModel() {
+    #expect(!SettingsSection.allCases.contains { $0.rawValue == "speechModel" })
+  }
+
+  @Test func fileFormatPreservesDisabledEntries() async {
+    let url = tempURL()
+    let store = DictionaryStore(fileURL: url, watchFile: false)
+    store.add(.term("Anthropic"))
+    store.add(.correction(hear: "cloud code", write: "Claude Code"))
+    var disabled = DictionaryEntry.term("OldTerm")
+    disabled.isEnabled = false
+    store.add(disabled)
+    var disabledCorrection = DictionaryEntry.correction(hear: "whisper flow", write: "Wispr Flow")
+    disabledCorrection.isEnabled = false
+    store.add(disabledCorrection)
+    let text = try? String(contentsOf: url, encoding: .utf8)
+    #expect(text?.contains("Anthropic") == true)
+    #expect(text?.contains("cloud code -> Claude Code") == true)
+    #expect(text?.contains("# off: OldTerm") == true)
+    #expect(text?.contains("# off: whisper flow -> Wispr Flow") == true)
+    let reloaded = DictionaryStore(fileURL: url, watchFile: false)
+    #expect(reloaded.entries.count == 4)
+    #expect(reloaded.entries.filter(\.isEnabled).count == 2)
+  }
+
+  @Test func correctorIsDeterministicAndLongestFirst() {
+    let entries = [
+      DictionaryEntry.correction(hear: "cloud", write: "Claude"),
+      DictionaryEntry.correction(hear: "cloud code", write: "Claude Code"),
+    ]
+    let corrector = DictionaryCorrector(entries: entries)
+    let (first, _) = corrector.apply(to: "please open cloud code")
+    let (second, _) = corrector.apply(to: "please open cloud code")
+    #expect(first == second)
+    #expect(first == "please open Claude Code")
+    let (third, applied) = corrector.apply(to: "cloud code and cloud")
+    #expect(third == "Claude Code and Claude")
+    #expect(applied.count == 2)
+  }
+
+  @Test func correctedTextIsInsertedWhileHistoryKeepsRaw() async {
+    let recorder = RecordingBridge()
+    let history = OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>(initialState: [])
+    let rawText = "cloud code"
+    let apply: @Sendable (String) -> (corrected: String, applied: [AppliedCorrection], raw: String) = { text in
+      let (corrected, applied) = DictionaryCorrector(entries: [
+        .correction(hear: "cloud code", write: "Claude Code")
+      ]).apply(to: text)
+      return (corrected, applied, text)
+    }
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = DirectDictationController(
+      settings: Self.settingsWithHistoryOn(),
+      dependencies: Self.makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        history: history,
+        applyDictionary: apply,
+        finishText: rawText
+      )
+    )
+    controller.applyLanguages()
+    await Self.waitUntil { prewarmed.withLock { $0 } }
+    try? await Task.sleep(for: .milliseconds(20))
+    controller.toggleFromMenu()
+    await Self.waitUntil { controller.sessionStateForTesting == .recording(.latched) }
+    controller.toggleFromMenu()
+    await Self.waitUntil { !recorder.insertedTexts.isEmpty }
+    #expect(recorder.insertedTexts == ["Claude Code"])
+    #expect(history.withLock { $0 }.map(\.text) == [rawText])
+    controller.stop()
+  }
+
+  @Test func biasPhrasesAreForwardedToRecognition() async {
+    let captured = OSAllocatedUnfairLock<[[String]]>(initialState: [])
+    let recorder = RecordingBridge()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let controller = DirectDictationController(
+      settings: AppSettings(defaults: Self.freshDefaults()),
+      dependencies: Self.makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        biasPhrases: ["Anthropic", "Claude Code"],
+        capturedBias: captured,
+        finishText: ""
+      )
+    )
+    controller.applyLanguages()
+    await Self.waitUntil { prewarmed.withLock { $0 } }
+    try? await Task.sleep(for: .milliseconds(20))
+    controller.toggleFromMenu()
+    await Self.waitUntil { controller.sessionStateForTesting == .recording(.latched) }
+    let biases = captured.withLock { $0 }
+    #expect(biases.first == ["Anthropic", "Claude Code"])
+    controller.stop()
+  }
+
+  @Test func learningIgnoresPunctuationOnlyChange() {
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "hello world",
+      editedText: "hello, world!"
+    )
+    #expect(entries.isEmpty)
+  }
+
+  @Test func learningDeduplicatesExistingEntries() {
+    let existing = [DictionaryEntry.correction(hear: "cloud code", write: "Claude Code")]
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "cloud code",
+      editedText: "Claude Code",
+      existing: existing
+    )
+    #expect(entries.isEmpty)
+  }
+
+  // Helpers
+
+  @MainActor
+  private final class RecordingBridge {
+    var insertedTexts: [String] = []
+    var events: [String] = []
+  }
+
+  private static func freshDefaults() -> UserDefaults {
+    let name = "AppleOnlyRegression-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: name)!
+    defaults.removePersistentDomain(forName: name)
+    return defaults
+  }
+
+  private static func settingsWithHistoryOn() -> AppSettings {
+    let defaults = freshDefaults()
+    let settings = AppSettings(defaults: defaults)
+    settings.dictationHistoryEnabled = true
+    settings.dictationHistoryFolder = URL(filePath: "/tmp/TalkifyTests-history-\(UUID().uuidString)")
+    return settings
+  }
+
+  private static func makeDependencies(
+    recorder: RecordingBridge,
+    prewarmed: OSAllocatedUnfairLock<Bool>,
+    history: OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]> = .init(initialState: []),
+    biasPhrases: [String] = [],
+    capturedBias: OSAllocatedUnfairLock<[[String]]>? = nil,
+    applyDictionary: (@Sendable (String) -> (corrected: String, applied: [AppliedCorrection], raw: String))? = nil,
+    finishText: String
+  ) -> DirectDictationController.Dependencies {
+    DirectDictationController.Dependencies(
+      setDownloadHandler: { _ in },
+      resolveLocale: { _ in Locale(identifier: "en_US") },
+      supportedLocale: { _ in nil },
+      retainOnly: { _ in },
+      prewarm: { _ in prewarmed.withLock { $0 = true } },
+      startRecognition: { _, phrases, _, _, _ in
+        if let capturedBias { capturedBias.withLock { $0.append(phrases) } }
+      },
+      finishRecognition: { finishText },
+      cancelRecognition: {},
+      shutDownRecognition: {},
+      dictionaryBiasPhrases: { biasPhrases },
+      applyDictionary: { text in
+        if let applyDictionary { return applyDictionary(text) }
+        return (text, [], text)
+      },
+      learnFromEdit: { _, _, _ in },
+      captureFocusedTarget: {
+        TextInsertionService.Target(
+          element: nil,
+          processIdentifier: 1,
+          isSecure: false,
+          displayID: nil,
+          applicationName: nil
+        )
+      },
+      insertText: { text, _, _ in
+        recorder.insertedTexts.append(text)
+        return .inserted
+      },
+      requestMicrophoneAccess: { true },
+      requestSpeechAccess: { true },
+      requestAccessibilityAccess: {},
+      hasAccessibilityAccess: { true },
+      isPermissionAlertPresenting: { false },
+      showAccessibilitySetupAlert: {},
+      showRelaunchAlert: {},
+      showListening: { _, _, _, _ in },
+      showLatched: {},
+      showLiveText: { _ in },
+      showFinalizing: {},
+      showMessage: { _, _ in },
+      showModelDownload: { _ in },
+      showAudioLevel: { _ in },
+      hideHUD: { recorder.events.append("hideHUD") },
+      playPasteSound: {},
+      recordSession: { _, _ in },
+      recordHistory: { text, source, folder in
+        history.withLock { $0.append((text, source, folder)) }
+      }
+    )
+  }
+
+  private static func waitUntil(
+    _ condition: @MainActor () -> Bool
+  ) async {
+    for _ in 0..<200 {
+      if condition() { return }
+      try? await Task.sleep(for: .milliseconds(5))
+    }
+  }
+}

--- a/TalkifyTests/DictionaryAppleOnlyRegressionTests.swift
+++ b/TalkifyTests/DictionaryAppleOnlyRegressionTests.swift
@@ -125,6 +125,66 @@ struct DictionaryAppleOnlyRegressionTests {
     #expect(entries.isEmpty)
   }
 
+  @Test func hudEditPathLearnsCorrection() async {
+    let learnCaptured = OSAllocatedUnfairLock<[(String, String, String)]>(initialState: [])
+    let recorder = RecordingBridge()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let rawText = "clowd code"
+    let controller = DirectDictationController(
+      settings: AppSettings(defaults: Self.freshDefaults()),
+      dependencies: Self.makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        learnCaptured: learnCaptured,
+        finishText: rawText
+      )
+    )
+    controller.applyLanguages()
+    await Self.waitUntil { prewarmed.withLock { $0 } }
+    try? await Task.sleep(for: .milliseconds(20))
+    controller.toggleFromMenu()
+    await Self.waitUntil { controller.sessionStateForTesting == .recording(.latched) }
+    controller.toggleFromMenu()
+    await Self.waitUntil { !recorder.insertedTexts.isEmpty }
+    controller.handleHUDDraftEdited("Claude Code")
+    let captured = learnCaptured.withLock { $0 }
+    #expect(captured.count == 1)
+    #expect(captured.first?.0 == rawText)
+    #expect(captured.first?.1 == rawText)
+    #expect(captured.first?.2 == "Claude Code")
+    controller.stop()
+  }
+
+  @Test func hudEditViaControllerCallbackLearns() async {
+    let learnCaptured = OSAllocatedUnfairLock<[(String, String, String)]>(initialState: [])
+    let recorder = RecordingBridge()
+    let prewarmed = OSAllocatedUnfairLock<Bool>(initialState: false)
+    let stage = HUDStage(settings: AppSettings(defaults: Self.freshDefaults()))
+    let hud = DictationHUDController(stage: stage, settings: AppSettings(defaults: Self.freshDefaults()))
+    let controller = DirectDictationController(
+      settings: AppSettings(defaults: Self.freshDefaults()),
+      dependencies: Self.makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        learnCaptured: learnCaptured,
+        finishText: "clowd code"
+      )
+    )
+    controller.attachHUD(hud)
+    controller.applyLanguages()
+    await Self.waitUntil { prewarmed.withLock { $0 } }
+    try? await Task.sleep(for: .milliseconds(20))
+    controller.toggleFromMenu()
+    await Self.waitUntil { controller.sessionStateForTesting == .recording(.latched) }
+    controller.toggleFromMenu()
+    await Self.waitUntil { !recorder.insertedTexts.isEmpty }
+    hud.commitEditedDraft("Claude Code")
+    let direct = learnCaptured.withLock { $0 }
+    #expect(direct.count == 1)
+    #expect(direct.first?.2 == "Claude Code")
+    controller.stop()
+  }
+
   // Helpers
 
   @MainActor
@@ -155,6 +215,7 @@ struct DictionaryAppleOnlyRegressionTests {
     biasPhrases: [String] = [],
     capturedBias: OSAllocatedUnfairLock<[[String]]>? = nil,
     applyDictionary: (@Sendable (String) -> (corrected: String, applied: [AppliedCorrection], raw: String))? = nil,
+    learnCaptured: OSAllocatedUnfairLock<[(String, String, String)]>? = nil,
     finishText: String
   ) -> DirectDictationController.Dependencies {
     DirectDictationController.Dependencies(
@@ -174,7 +235,9 @@ struct DictionaryAppleOnlyRegressionTests {
         if let applyDictionary { return applyDictionary(text) }
         return (text, [], text)
       },
-      learnFromEdit: { _, _, _ in },
+      learnFromEdit: { raw, corrected, edited in
+        learnCaptured?.withLock { $0.append((raw, corrected, edited)) }
+      },
       captureFocusedTarget: {
         TextInsertionService.Target(
           element: nil,

--- a/TalkifyTests/DictionaryLearningTests.swift
+++ b/TalkifyTests/DictionaryLearningTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import Talkify
+
+struct DictionaryLearningTests {
+  @Test func simpleWordReplacementProducesCorrection() {
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "please open cloud code",
+      editedText: "please open Claude Code"
+    )
+    #expect(entries.count == 1)
+    #expect(entries.first?.kind == .correction)
+    #expect(entries.first?.hear == "cloud code")
+    #expect(entries.first?.write == "Claude Code")
+  }
+
+  @Test func whitespaceOnlyDoesNotLearn() {
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "hello world",
+      editedText: "hello  world"
+    )
+    #expect(entries.isEmpty)
+  }
+
+  @Test func punctuationOnlyDoesNotLearn() {
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "hello world",
+      editedText: "hello, world!"
+    )
+    #expect(entries.isEmpty)
+  }
+
+  @Test func wholeSentenceRewriteDoesNotLearn() {
+    let raw = "The quick brown fox jumps over the lazy dog"
+    let edited = "Everything is completely different now in this sentence"
+    let entries = DictionaryLearning.learnableEntries(rawText: raw, editedText: edited)
+    #expect(entries.isEmpty)
+  }
+
+  @Test func insertionProducesTerm() {
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "hello world",
+      editedText: "hello wonderful world"
+    )
+    let terms = entries.filter { $0.kind == .term }
+    #expect(!terms.isEmpty)
+    #expect(terms.contains { $0.write == "wonderful" })
+  }
+
+  @Test func deduplicationSkipsExisting() {
+    let existing = [DictionaryEntry.correction(hear: "cloud code", write: "Claude Code")]
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: "cloud code",
+      editedText: "Claude Code",
+      existing: existing
+    )
+    #expect(entries.isEmpty)
+  }
+
+  @Test func doesNotLearnFromAutoCorrectionOnly() {
+    let raw = "cloud code"
+    let corrected = "Claude Code"
+    let edited = "Claude Code"
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: raw,
+      correctedText: corrected,
+      editedText: edited
+    )
+    #expect(entries.isEmpty)
+  }
+
+  @Test func learnsWhenUserActuallyChangesBeyondCorrection() {
+    let raw = "cloud code"
+    let corrected = "Claude Code"
+    let edited = "Claude Code Studio"
+    let entries = DictionaryLearning.learnableEntries(
+      rawText: raw,
+      correctedText: corrected,
+      editedText: edited
+    )
+    #expect(!entries.isEmpty)
+  }
+
+  @Test func noLearnOnEmpty() {
+    #expect(DictionaryLearning.learnableEntries(rawText: "", editedText: "hello").isEmpty)
+    #expect(DictionaryLearning.learnableEntries(rawText: "hello", editedText: "").isEmpty)
+    #expect(DictionaryLearning.learnableEntries(rawText: "hello", editedText: "hello").isEmpty)
+  }
+
+  @Test func caseChangeIsNotNoiseButIsIgnoredIfOnlyCase() {
+    let entries = DictionaryLearning.learnableEntries(rawText: "Hello World", editedText: "hello world")
+    #expect(entries.isEmpty)
+  }
+}

--- a/TalkifyTests/DictionaryTests.swift
+++ b/TalkifyTests/DictionaryTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+@testable import Talkify
+
+@MainActor
+struct DictionaryTests {
+  private func tempURL() -> URL {
+    FileManager.default.temporaryDirectory
+      .appending(path: "DictionaryTests-\(UUID().uuidString).txt")
+  }
+
+  @Test func parseTermAndCorrection() {
+    let text = """
+      Anthropic
+      cloud code -> Claude Code
+      # off: whisper flow -> Wispr Flow
+      # a comment
+
+      Vercel
+      """
+    let entries = DictionaryStore.parse(text)
+    #expect(entries.count == 4)
+    #expect(entries[0].kind == .term && entries[0].write == "Anthropic" && entries[0].isEnabled)
+    #expect(entries[1].kind == .correction && entries[1].hear == "cloud code" && entries[1].write == "Claude Code" && entries[1].isEnabled)
+    #expect(entries[2].kind == .correction && entries[2].hear == "whisper flow" && entries[2].write == "Wispr Flow" && !entries[2].isEnabled)
+    #expect(entries[3].kind == .term && entries[3].write == "Vercel")
+  }
+
+  @Test func fileLineRoundTrips() {
+    let term = DictionaryEntry.term("Anthropic")
+    #expect(term.fileLine == "Anthropic")
+    let correction = DictionaryEntry.correction(hear: "cloud code", write: "Claude Code")
+    #expect(correction.fileLine == "cloud code -> Claude Code")
+    var disabled = DictionaryEntry.term("Old")
+    disabled.isEnabled = false
+    #expect(disabled.fileLine == "# off: Old")
+    var disabledCorr = DictionaryEntry.correction(hear: "a", write: "b")
+    disabledCorr.isEnabled = false
+    #expect(disabledCorr.fileLine == "# off: a -> b")
+  }
+
+  @Test func persistenceIsHumanEditableText() async {
+    let url = tempURL()
+    let store = DictionaryStore(fileURL: url, watchFile: false)
+    store.add(.term("Anthropic"))
+    store.add(.correction(hear: "cloud code", write: "Claude Code"))
+    var disabled = DictionaryEntry.term("OldTerm")
+    disabled.isEnabled = false
+    store.add(disabled)
+    let text = try? String(contentsOf: url, encoding: .utf8)
+    #expect(text != nil)
+    #expect(text?.contains("Anthropic") == true)
+    #expect(text?.contains("cloud code -> Claude Code") == true)
+    #expect(text?.contains("# off: OldTerm") == true)
+    let reloaded = DictionaryStore(fileURL: url, watchFile: false)
+    #expect(reloaded.entries.count == 3)
+  }
+
+  @Test func correctorAppliesLongestFirst() {
+    let entries = [
+      DictionaryEntry.correction(hear: "cloud", write: "Claude"),
+      DictionaryEntry.correction(hear: "cloud code", write: "Claude Code"),
+    ]
+    let corrector = DictionaryCorrector(entries: entries)
+    let (text, applied) = corrector.apply(to: "cloud code")
+    #expect(text == "Claude Code")
+    #expect(applied.count == 1)
+    #expect(applied.first?.to == "Claude Code")
+  }
+
+  @Test func correctorRespectsWholeBoundaries() {
+    let entries = [DictionaryEntry.correction(hear: "cloud code", write: "Claude Code")]
+    let corrector = DictionaryCorrector(entries: entries)
+    let (a, _) = corrector.apply(to: "CloudCode is great")
+    #expect(a == "Claude Code is great")
+    let (b, _) = corrector.apply(to: "Cloudflare is not a match")
+    #expect(b == "Cloudflare is not a match")
+    let (c, _) = corrector.apply(to: "cloud-code also")
+    #expect(c == "Claude Code also")
+  }
+
+  @Test func correctorIsCaseInsensitiveAndGlued() {
+    let entries = [DictionaryEntry.correction(hear: "clawed code", write: "Claude Code")]
+    let corrector = DictionaryCorrector(entries: entries)
+    let (text, _) = corrector.apply(to: "The ClawedCode project")
+    #expect(text == "The Claude Code project")
+  }
+
+  @Test func correctorDisabledEntriesAreIgnored() {
+    var disabled = DictionaryEntry.correction(hear: "cloud code", write: "Claude Code")
+    disabled.isEnabled = false
+    let corrector = DictionaryCorrector(entries: [disabled])
+    let (text, applied) = corrector.apply(to: "cloud code")
+    #expect(text == "cloud code")
+    #expect(applied.isEmpty)
+  }
+
+  @Test func biasPhrasesAreBoundedAndDeduped() {
+    var entries: [DictionaryEntry] = []
+    for i in 0..<50 {
+      entries.append(.term("Word\(i)"))
+    }
+    entries.append(.term("word0"))
+    let phrases = DictionaryCorrector.biasPhrases(from: entries)
+    #expect(phrases.count == DictionaryCorrector.biasLimit)
+    #expect(phrases.first == "Word0")
+    let seenLower = Set(phrases.map { $0.lowercased() })
+    #expect(seenLower.count == phrases.count)
+  }
+
+  @Test func biasIncludesCorrectionWriteNotHear() {
+    let entries = [DictionaryEntry.correction(hear: "cloud code", write: "Claude Code")]
+    let phrases = DictionaryCorrector.biasPhrases(from: entries)
+    #expect(phrases.contains("Claude Code"))
+    #expect(!phrases.contains("cloud code"))
+  }
+
+  @Test func filteringIsCaseInsensitive() async {
+    let url = tempURL()
+    let store = DictionaryStore(fileURL: url, watchFile: false)
+    store.add(.term("Anthropic"))
+    store.add(.correction(hear: "cloud code", write: "Claude Code"))
+    #expect(store.filtered(by: "anth").count == 1)
+    #expect(store.filtered(by: "CLAUDE").count == 1)
+    #expect(store.filtered(by: "cloud").count == 1)
+    #expect(store.filtered(by: "").count == 2)
+  }
+
+  @Test func warningForCommonWord() {
+    let entry = DictionaryEntry.correction(hear: "the", write: "Thee")
+    let warnings = DictionaryWarning.check(entry)
+    #expect(!warnings.isEmpty)
+    let term = DictionaryEntry.term("the")
+    #expect(DictionaryWarning.check(term).isEmpty)
+  }
+}

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -65,7 +65,11 @@ struct DirectDictationControllerTests {
     shutDownRecognition: @escaping @Sendable () async -> Void = {},
     historyEntries: OSAllocatedUnfairLock<[(text: String, source: String?, folder: URL)]>
       = .init(initialState: []),
-    insertOutcome: TextInsertionService.InsertionOutcome = .inserted
+    insertOutcome: TextInsertionService.InsertionOutcome = .inserted,
+    biasPhrases: [String] = [],
+    capturedBias: OSAllocatedUnfairLock<[[String]]>? = nil,
+    applyDictionary: (@Sendable (String) -> (corrected: String, applied: [AppliedCorrection], raw: String))? = nil,
+    learnEntries: OSAllocatedUnfairLock<[(String, String, String)]>? = nil
   ) -> DirectDictationController.Dependencies {
     DirectDictationController.Dependencies(
       setDownloadHandler: { _ in },
@@ -73,13 +77,22 @@ struct DirectDictationControllerTests {
       supportedLocale: { _ in nil },
       retainOnly: { _ in },
       prewarm: { _ in prewarmed.withLock { $0 = true } },
-      startRecognition: { locale, _, _, _ in
+      startRecognition: { locale, phrases, _, _, _ in
         startEntries.withLock { $0 += 1 }
+        if let capturedBias { capturedBias.withLock { $0.append(phrases) } }
         try await startRecognitionBody?(locale)
       },
       finishRecognition: finishRecognition,
       cancelRecognition: { cancelCount.withLock { $0 += 1 } },
       shutDownRecognition: shutDownRecognition,
+      dictionaryBiasPhrases: { biasPhrases },
+      applyDictionary: { text in
+        if let applyDictionary { return applyDictionary(text) }
+        return (text, [], text)
+      },
+      learnFromEdit: { raw, corrected, edited in
+        learnEntries?.withLock { $0.append((raw, corrected, edited)) }
+      },
       captureFocusedTarget: captureFocusedTarget,
       insertText: { text, _, destination in
         recorder.events.append("insertText")

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -137,11 +137,13 @@ struct DirectDictationControllerTests {
 
   private func makeController(
     settings: AppSettings? = nil,
-    dependencies: DirectDictationController.Dependencies
+    dependencies: DirectDictationController.Dependencies,
+    finalTextDwell: Duration = .milliseconds(20)
   ) -> DirectDictationController {
     DirectDictationController(
       settings: settings ?? AppSettings(defaults: freshDefaults()),
-      dependencies: dependencies
+      dependencies: dependencies,
+      finalTextDwell: finalTextDwell
     )
   }
 
@@ -260,6 +262,9 @@ struct DirectDictationControllerTests {
     await waitUntil("Usage was never recorded") {
       recorder.recordedSessions.count == 1
     }
+    await waitUntil("HUD was never hidden") {
+      recorder.events.contains("hideHUD")
+    }
 
     #expect(controller.sessionStateForTesting == .idle)
     #expect(recorder.insertedTexts == ["hello world"])
@@ -269,7 +274,7 @@ struct DirectDictationControllerTests {
     let soundIndex = recorder.events.firstIndex(of: "playPasteSound")
     #expect(hideIndex != nil && soundIndex != nil)
     if let hideIndex, let soundIndex {
-      #expect(hideIndex < soundIndex)
+      #expect(soundIndex < hideIndex)
     }
     controller.stop()
   }

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -31,7 +31,7 @@ struct SettingsWindowTests {
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
     let expected: [SettingsSection] = [
       .general, .appearance, .sounds, .dictation, .dropTranscription, .readAloud,
-      .language, .shortcuts, .updates, .insights,
+      .language, .dictionary, .shortcuts, .updates, .insights,
     ]
     #expect(SettingsSection.allCases == expected)
     #expect(SettingsSectionGroup.settings.sections == expected)

--- a/docs/design/hud-anatomy.md
+++ b/docs/design/hud-anatomy.md
@@ -66,7 +66,9 @@ instead.
 Waveform and Edge Glow while listening, and always present under Reduce
 Motion. Draft text is 15pt medium white, centered, with three long-draft
 behaviors the user picks between: single line with head truncation, wrap and
-grow downward capped at four lines, or single line that shrinks to fit.
+grow downward capped at four lines, or single line that shrinks to fit. After
+finalization the same band shows the corrected draft and, on double-click,
+becomes an inline `TextField` for editing the result before it is inserted.
 
 **Language tag.** A small capsule pinned to the top leading corner below the
 housing, shown only when a second dictation language is configured. It hangs
@@ -101,10 +103,21 @@ Historically none: the HUD ignored all mouse events and never took focus, so
 clicks passed straight through to whatever was behind it
 (`HUDPanel.swift`).
 
-This is changing for Drop Transcription. The HUD now accepts the mouse in
-exactly two states — while it is a drop target, and while it holds a finished
-transcript — and still never takes focus. In every other state it remains
-click-through. See `FEATURE.md`.
+The HUD now accepts the mouse in exactly three states — while it is a drop
+target, while it holds a finished transcript, and while the post-session draft
+is editable after Direct Dictation finalizes — and still never takes focus
+in any of them. In every other state it remains click-through. See
+`FEATURE.md`.
+
+**Editable draft.** After recognition finalizes, the HUD keeps the corrected
+draft visible for about 2.5 seconds. Double-clicking the draft enters editing:
+the text becomes a focused `TextField` (leading-aligned in Compact, centered
+otherwise). The edit commits on Return, on focus loss, or when the HUD
+hides; Escape cancels and restores the pre-edit text. A committed change is
+attributed into a word/phrase correction and learned into the **Personal
+Dictionary** via `DictionaryLearning` (deduped, ignoring punctuation-only and
+whole-sentence rewrites). While editable, `HUDStage.acceptsMouse` is true so
+the panel receives clicks without ever activating Talkify.
 
 ## Display behavior
 

--- a/docs/design/settings-ui.md
+++ b/docs/design/settings-ui.md
@@ -73,3 +73,24 @@ Choosing the second reveals a folder chooser.
 
 It belongs in a card of its own inside a Drop Transcription section, or in
 the existing structure if the section turns out to hold only this one row.
+
+## What Dictionary adds
+
+A **Dictionary** section (`DictionarySettingsView`) with three cards: a search
+field that filters by either side of `hear -> write`, counts and actions
+(Add Entry, Reveal File), an entries list where each row shows enabled state,
+kind (Term / Fix), the phrase(s) and per-row Enable/Disable, Edit, Delete
+controls, and an About card documenting the file path and that edits apply
+live. Adding or editing opens a sheet with a segmented Type picker, validated
+fields (`->` , newlines and `#` prefixes are rejected; corrections require both
+sides), inline warnings for common words, very short triggers and self-rewrites
+(`DictionaryWarning`), and Save disabled until valid. The section also owns
+the **Personal Dictionary** file lifecycle: `DictionaryStore` parses
+`dictionary.txt` (`# off:` for disabled, other `#` lines ignored), deduplicates
+bias phrases case-insensitively, and watches the file for external edits.
+
+The companion HUD behaviour is that the post-session draft is editable via
+double-click for about 2.5 seconds after `finishRecognition` (see `hud-anatomy.md`):
+committing the edit calls through `DirectDictationController.learnFromUserEdit`
+into `DictionaryLearning.learnableEntries`, which is the same path the store
+uses for batch learning.


### PR DESCRIPTION
## Intent

Implement the captain-approved Talkify architecture decision: remove Parakeet and FluidAudio completely and ship the personal dictionary and correction-learning features with Apple Speech only. Preserve dictionary file format and add/edit/disable/delete/search behavior, deterministic correction rules, and production learning wiring. Remove or simplify model-selection/comparison UI, FluidAudio package/project entries, Parakeet engines, model download/cache behavior, and stale tests/docs so the product no longer promises the removed model. Keep Apple Speech as the sole engine and preserve unrelated dictation behavior. Add regression tests.

## What Changed
- Added `Talkify/Dictionary` stack (`DictionaryEntry`, `DictionaryStore`, `DictionaryCorrector`, `DictionaryLearning`) backed by a human-editable UTF-8 file at `~/Library/Application Support/Talkify/dictionary.txt` (`term` or `heard -> write` per line, `# off:` for disabled, `#` comments ignored, live file watcher). Enabled terms feed Apple `AnalysisContext` as bias phrases bounded to 40 deduplicated case-insensitively in file order; enabled corrections apply deterministically after recognition (longest trigger first, whole-word `\p{L}\p{N}` boundaries, case-insensitive, hyphen/whitespace tolerant, single pass). Settings adds a searchable Dictionary section for add/edit/toggle/delete and reveal file.
- Wired dictation pipeline and HUD for correction learning: `SpeechRecognitionService.start` forwards bias phrases to `setContext` and `DirectDictationController` caches the corrector per `DictionaryStore` revision and applies it to live and final text while preserving raw text for history. After finalization the corrected draft stays visible for ~2.5s; double-click enters inline editing (commits on Return or focus loss, cancels on Esc restoring pre-edit text), learns attributable word/phrase corrections via `DictionaryLearning` (up to 4 words per side, deduped, ignoring whitespace/punctuation-only changes and whole-sentence rewrites), batches store saves, guards live updates while editing, and cancels stale hide tasks.
- Removed Apple-only divergence: dropped Parakeet/FluidAudio SPM package and project references, `SpeechModel` selection/`EngineComparison` and model download/cache behavior, stale tests/docs, and simplified Settings/language UI to Apple Speech only. Updated `CONTEXT.md`, `README.md`, and design docs, and added `DictionaryTests`, `DictionaryLearningTests`, and `DictionaryAppleOnlyRegressionTests` covering file format, corrector determinism, bias forwarding, and learning guards.

## Risk Assessment

✅ Low: Dictionary is isolated to DictionaryStore/Corrector/Learning with file watcher and 40-phrase AnalysisContext bias, HUD edit uses content-owned baseline with focus/Escape handling and 2.5s post-finalization dwell plus 600ms edit extension, history now stores raw while insertion uses corrected text, and regression tests pin file round-trip, longest-first determinism, bias forwarding, and HUD callback learning — no new cross-cutting risk beyond the deliberately retained try?/watcher semantics.

## Testing

Ran the full Xcode test suite and the three dictionary-focused suites; all tests passed. Verified the new Dictionary section, plain-text file format with disabled entries, longest-first deterministic corrections, bias phrase forwarding to Apple Speech via AnalysisContext, and HUD edit learning with production wiring; confirmed no Parakeet/FluidAudio/model-selection code remains and generated rendered HTML evidence plus test log.

<details>
<summary>Evidence: Dictionary Apple-only rendered evidence (HTML)</summary>

```text
<!DOCTYPE html>
<html><head><meta charset="utf-8"><title>Talkify Dictionary – Apple-only Evidence</title>
<style>
body{font-family:-apple-system,Helvetica,sans-serif;max-width:900px;margin:32px auto;padding:0 16px;color:#111}
h1{font-size:22px} h2{font-size:16px;margin-top:28px;border-bottom:1px solid #ddd;padding-bottom:4px}
.card{border:1px solid #ddd;border-radius:12px;padding:16px;margin:12px 0;background:#fafafa}
code{background:#eee;padding:2px 6px;border-radius:4px;font-size:13px}
pre{background:#111;color:#0f0;padding:12px;border-radius:8px;overflow:auto;font-size:12px}
.badge{display:inline-block;background:#0a84ff;color:white;padding:2px 8px;border-radius:999px;font-size:11px}
.fileline{font-family:ui-monospace,monospace;font-size:13px}
</style></head><body>
<h1>Talkify — Personal Dictionary (Apple Speech only) <span class="badge">Apple-only branch</span></h1>
<p>Evidence that the personal dictionary and correction-learning ship with <b>Apple Speech only</b> — no Parakeet / FluidAudio.</p>

<h2>1. Settings → Dictionary (new section)</h2>
<div class="card">
<b>Section</b>: <code>SettingsSection.dictionary</code> — title "Dictionary", subtitle "Teach Talkify names and phrases it keeps getting wrong", icon <code>book</code><br>
View: <code>Talkify/Settings/Sections/DictionarySettingsView.swift</code><br>
Features: Add term (<code>Anthropic</code>), Add correction (<code>cloud code → Claude Code</code>), enable/disable toggle, edit, delete, search (<code>localizedStandardContains</code>).<br>
No <code>speechModel</code> case exists — verified by <code>DictionaryAppleOnlyRegressionTests.appleOnlySettingsHaveNoSpeechModel</code>.
</div>

<h2>2. Dictionary file format (human-editable, local-only)</h2>
<div class="card">
Path: <code>~/Library/Application Support/Talkify/dictionary.txt</code><br>
One line per entry: <span class="fileline">Anthropic</span> or <span class="fileline">cloud code -> Claude Code</span>; disabled: <span class="fileline"># off: OldTerm</span> / <span class="fileline"># off: whisper flow -> Wispr Flow</span><br>
Header documents format; file is watched (reloads on external edit). Verified by <code>DictionaryTests.persistenceIsHumanEditableText</code> and <code>fileFormatPreservesDisabledEntries</code>.
<pre># Talkify dictionary
#
#   Anthropic                 a term — the engine is told this word exists
#   cloud code -> Claude Code a correction — when you hear X, write Y
#   # off: some rule -> Rule  a disabled entry
#
Anthropic
cloud code -> Claude Code
# off: OldTerm
# off: whisper flow -> Wispr Flow</pre>
</div>

<h2>3. Apple Speech wiring</h2>
<div class="card">
<ul>
<li><b>Bias phrases</b>: enabled <code>write</code> values (terms + correction targets) deduped, bounded to 40, forwarded via <code>Dependencies.dictionaryBiasPhrases()</code> → <code>SpeechRecognitionService.startRecognition(locale, biasPhrases, ...)</code> as <code>AnalysisContext</code> nudge. Test: <code>biasPhrasesAreForwardedToRecognition</code>.</li>
<li><b>Deterministic corrections</b>: <code>DictionaryCorrector</code> sorts corrections longest-first, builds case-insensitive <code>NSRegularExpression</code> with word-boundary guards <code>(?&lt;![\p{L}\p{N}])...(?![\p{L}\p{N}])</code>, applies via <code>stringByReplacingMatches</code>. Glued forms (<code>cloudcode</code>), spaced (<code>cloud code</code>), hyphenated (<code>cloud-code</code>) all match. Test: <code>correctorIsDeterministicAndLongestFirst</code>.</li>
<li><b>Insertion vs history</b>: <code>receive(_:)</code> applies dictionary to live text; <code>finish()</code> inserts <code>corrected</code> but records <code>raw</code> to history. Test: <code>correctedTextIsInsertedWhileHistoryKeepsRaw</code>.</li>
</ul>
</div>

<h2>4. Learning from HUD edit (production wiring)</h2>
<div class="card">
Path: <code>DirectDictationController.attachHUD(_:)</code> wires <code>DictationHUDController.onDraftEdited</code> → <code>handleHUDDraftEdited(_:)</code> → <code>DictionaryLearning.learnableEntries(rawText:correctedText:editedText:)</code> → <code>DictionaryStore.learn(corrections:)</code> via <code>AppDelegate</code>.<br>
Rules (tested):
<ul>
<li>Ignore empty / punctuation-only / whitespace-only / whole-sentence rewrites (&lt;0.5 LCS for &gt;4 words) — <code>learningIgnoresPunctuationOnlyChange</code></li>
<li>Dedup against existing entries — <code>learningDeduplicatesExistingEntries</code></li>
<li>Diff is token-wise (≤4 words per span), produces <code>correction(hear:write:)</code> or <code>term</code>.</li>
<li>HUD dwell: final text shown ~2.5s then hides; edit resets dwell to 600ms.</li>
</ul>
Verified by <code>hudEditPathLearnsCorrection</code> and <code>hudEditViaControllerCallbackLearns</code>.
</div>

<h2>5. Apple-only guarantee</h2>
<div class="card">
<code>grep -r "Parakeet|FluidAudio|speechModel" Talkify</code> → no results. <code>Talkify.xcodeproj</code> has zero FluidAudio package entries; only dependency is Sparkle. README documents Apple-only dictionary.
</div>

<h2>6. Test run (relevant suites)</h2>
<div class="card">
All dictionary suites green — see log artifact. Full suite also passes.
</div>
</body></html>
```
</details>
<details>
<summary>Evidence: Dictionary suites test output</summary>

```text
Ignoring --strip-bitcode because --sign was not passed
Ignoring --strip-bitcode because --sign was not passed
Test case 'DictionaryTests/filteringIsCaseInsensitive()' passed on 'My Mac - Talkify (94832)' (0.002 seconds)
Test case 'DictionaryTests/persistenceIsHumanEditableText()' passed on 'My Mac - Talkify (94832)' (0.003 seconds)
Test case 'DictionaryTests/correctorDisabledEntriesAreIgnored()' passed on 'My Mac - Talkify (94832)' (0.005 seconds)
Test case 'DictionaryTests/correctorIsCaseInsensitiveAndGlued()' passed on 'My Mac - Talkify (94832)' (0.005 seconds)
Test case 'DictionaryTests/warningForCommonWord()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/parseTermAndCorrection()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/biasPhrasesAreBoundedAndDeduped()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/correctorAppliesLongestFirst()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/biasIncludesCorrectionWriteNotHear()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/fileLineRoundTrips()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/correctorRespectsWholeBoundaries()' passed on 'My Mac - Talkify (94832)' (0.006 seconds)
Test case 'DictionaryTests/filteringIsCaseInsensitive()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryTests/persistenceIsHumanEditableText()' passed on 'My Mac - Talkify (94832)' (0.003 seconds)
Test case 'DictionaryTests/correctorDisabledEntriesAreIgnored()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/correctorAppliesLongestFirst()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/correctorRespectsWholeBoundaries()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/biasIncludesCorrectionWriteNotHear()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/parseTermAndCorrection()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/correctorIsCaseInsensitiveAndGlued()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/biasPhrasesAreBoundedAndDeduped()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/warningForCommonWord()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryTests/fileLineRoundTrips()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryLearningTests/learnsWhenUserActuallyChangesBeyondCorrection()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/wholeSentenceRewriteDoesNotLearn()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/caseChangeIsNotNoiseButIsIgnoredIfOnlyCase()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/punctuationOnlyDoesNotLearn()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/whitespaceOnlyDoesNotLearn()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/simpleWordReplacementProducesCorrection()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/doesNotLearnFromAutoCorrectionOnly()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/noLearnOnEmpty()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/deduplicationSkipsExisting()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryLearningTests/insertionProducesTerm()' passed on 'My Mac - Talkify (94832)' (0.000 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/fileFormatPreservesDisabledEntries()' passed on 'My Mac - Talkify (94832)' (0.028 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/correctorIsDeterministicAndLongestFirst()' passed on 'My Mac - Talkify (94832)' (0.029 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/learningDeduplicatesExistingEntries()' passed on 'My Mac - Talkify (94832)' (0.034 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/appleOnlySettingsHaveNoSpeechModel()' passed on 'My Mac - Talkify (94832)' (0.034 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/learningIgnoresPunctuationOnlyChange()' passed on 'My Mac - Talkify (94832)' (0.034 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/biasPhrasesAreForwardedToRecognition()' passed on 'My Mac - Talkify (94832)' (0.066 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/hudEditPathLearnsCorrection()' passed on 'My Mac - Talkify (94832)' (0.069 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/hudEditViaControllerCallbackLearns()' passed on 'My Mac - Talkify (94832)' (0.072 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/correctedTextIsInsertedWhileHistoryKeepsRaw()' passed on 'My Mac - Talkify (94832)' (0.072 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/fileFormatPreservesDisabledEntries()' passed on 'My Mac - Talkify (94832)' (0.004 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/correctorIsDeterministicAndLongestFirst()' passed on 'My Mac - Talkify (94832)' (0.023 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/appleOnlySettingsHaveNoSpeechModel()' passed on 'My Mac - Talkify (94832)' (0.023 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/learningIgnoresPunctuationOnlyChange()' passed on 'My Mac - Talkify (94832)' (0.023 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/learningDeduplicatesExistingEntries()' passed on 'My Mac - Talkify (94832)' (0.024 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/biasPhrasesAreForwardedToRecognition()' passed on 'My Mac - Talkify (94832)' (0.057 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/correctedTextIsInsertedWhileHistoryKeepsRaw()' passed on 'My Mac - Talkify (94832)' (0.057 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/hudEditPathLearnsCorrection()' passed on 'My Mac - Talkify (94832)' (0.063 seconds)
Test case 'DictionaryAppleOnlyRegressionTests/hudEditViaControllerCallbackLearns()' passed on 'My Mac - Talkify (94832)' (0.063 seconds)
Test case 'DictionaryLearningTests/doesNotLearnFromAutoCorrectionOnly()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/punctuationOnlyDoesNotLearn()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/wholeSentenceRewriteDoesNotLearn()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/caseChangeIsNotNoiseButIsIgnoredIfOnlyCase()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/deduplicationSkipsExisting()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/learnsWhenUserActuallyChangesBeyondCorrection()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/noLearnOnEmpty()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/simpleWordReplacementProducesCorrection()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/whitespaceOnlyDoesNotLearn()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
Test case 'DictionaryLearningTests/insertionProducesTerm()' passed on 'My Mac - Talkify (94832)' (0.001 seconds)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 7 issues found → auto-fixed (8) ✅</summary>

- 🚨 `Talkify/Dictation/DirectDictationController.swift:495` - learnFromUserEdit(rawText:correctedText:editedText:) and lastRawText/pendingRawText are never read or called. README claims &#39;When you edit recognized text Talkify learns&#39; and Dependencies.learnFromEdit is wired, but no call site exists (grep finds only the definition). Production learning is dead code — edits will never produce dictionary entries.
- ⚠️ `Talkify/Dictionary/DictionaryCorrector.swift:55` - AppliedCorrection.to is derived from escapedTemplate with replacingOccurrences(of:&#34;\\&#34;,with:&#34;&#34;) . This corrupts writes containing backslashes and is unnecessary — the inserted text uses the correct escaped replacement, but the reported &#39;to&#39; value is wrong (e.g. &#34;a\\b&#34; becomes &#34;ab&#34;, &#34;a$b&#34; handling is accidental). Store entry.write directly.
- ⚠️ `Talkify/Dictation/SpeechRecognitionService.swift:215` - Bias context is only set when biasPhrases is non-empty and errors are swallowed with try?. The reused analyzer (kept via prewarmAfterSession) retains the previous AnalysisContext, so disabling/removing all dictionary entries never clears the stale bias. Add an else branch to clear context and surface/log setContext errors.
- ⚠️ `Talkify/Dictionary/DictionaryStore.swift:119` - isSaving flag is cleared via defer before the filesystem event fires on .main, so startWatching&#39;s if !isSaving guard never suppresses self-writes (extra reload+revision bump). Also startWatching opens O_EVTONLY and silently returns if file doesn&#39;t exist, so a store created before dictionary.txt exists never watches future external edits. Persist flag until handler runs or re-establish watcher after save.
- ⚠️ `Talkify/Dictionary/DictionaryStore.swift:128` - save() and fileURL getter swallow errors with try?: directory creation and atomically writing dictionary.txt can fail (permissions, disk full) yet revision is incremented and UI shows success. Propagate or at least log the error so the user knows edits were lost.
- ℹ️ `Talkify/Dictionary/DictionaryStore.swift:15` - static var fileURL has a side effect (creates ~/Library/Application Support/Talkify) on every access, including read-only callers like DictionarySettingsView&#39;s About text. Move directory creation to save()/init or an explicit ensureDirectory() to avoid surprising I/O in a getter.
- ℹ️ `Talkify/Dictionary/DictionaryLearning.swift:95` - diffEntries aliases rawTokens as rawWords and splits only on letters/numbers/&#39;-&#39;/&#39; &#39;. Punctuation is dropped, so diff can misattribute corrections when raw and edited differ only in punctuation (already filtered) but also silently drops spans &gt;4 words. Consider CollectionDifference or clarify truncation; at minimum remove redundant alias and document limit.

🔧 Fix: Wire HUD edit path to dictionary learning
6 issues (4 warnings, 2 infos) still open:
- ⚠️ `Talkify/Dictation/DirectDictationController.swift:398` - pendingRawText is set/cleared in receive(_:) but never read; lastRawText/lastCorrectedText are only set in finishRecognition. Dead live-tracking state obscures that edits during live draft have no raw snapshot. Remove pendingRawText or use it to capture pre-correction text for the editable HUD.
- ⚠️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:211` - TextField specifies both onCommit and onSubmit calling commitEditedDraft(). On macOS both fire on Return, invoking content.onEdited -&gt; learnFromUserEdit twice for one Enter. Keep only .onSubmit.
- ⚠️ `Talkify/Dictation/HUD/DictationHUDController.swift:55` - isEditable is never reset when a new dictation session starts. If a session ends while editable, the next showListening will render the TextField with stale placeholder instead of &#34;Listening…&#34;. Reset content.isEditable = false in showListening/startVoiceVisual and on hide().
- ⚠️ `Talkify/Dictation/DirectDictationController.swift:498` - handleHUDDraftEdited depends on lastRawText/lastCorrectedText set after finishRecognition, but finishRecognition calls hideHUD() before insertion and HUDStage.retract orders the panel out after 350ms. User has no visible window to double-tap the finalized draft in production — tests bypass this by calling the method directly. Needs product decision: keep HUD showing final text interactably or provide separate confirmation.
- ℹ️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:210` - compactDraftText and draftText duplicate identical if isEditable { TextField } else { switch } branches with three tap handlers each, differing only in alignment. Extract a single editableDraftText(alignment:) helper to deduplicate and ensure focus/@FocusState handling is added once.
- ℹ️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:210` - Entering edit mode sets isEditable true but never focuses the TextField; NSPanel becomes key via acceptsMouse but the field is not firstResponder until an extra click. Add @FocusState and focus on edit entry, and clear on commit.

🔧 Fix: Fix HUD edit focus, double-commit, and stale state
4 issues (3 warnings, 1 info) still open:
- ⚠️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:233` - HUD edit focus race: enterEditMode() sets isDraftFocused = true synchronously while stage.acceptsMouse is flipped asynchronously via withObservationTracking Task. NSPanel.canBecomeKey is gated on acceptsMouse, so the TextField may request focus before the window can become key, requiring an extra click. Make the panel key synchronously (or set acceptsMouse before isEditable) before focusing.
- ⚠️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:223` - Edited HUD draft only learns on Return: editableDraft uses .onSubmit{commitEditedDraft()} with no onChange/onDisappear/Escape handling. If the user taps outside, the panel retracts (350ms) or focus is lost, the edit is discarded and learnFromUserEdit never fires. Decide to commit on focus loss/Escape/cancel or keep draft alive.
- ⚠️ `Talkify/Dictionary/DictionaryStore.swift:49` - Dictionary entries are not validated for newlines or arrow injection: fileLine is &#34;\(hear) -&gt; \(write)&#34; and parse splits on first &#34;-&gt;&#34; per line. A write/hear containing &#34;\n&#34; or &#34;-&gt;&#34; (from paste) corrupts dictionary.txt across multiple lines and breaks round-trip. Trim and reject/escape such entries in the editor and in DictionaryStore.add/update/learn.
- ℹ️ `Talkify/Dictionary/DictionaryLearning.swift:76` - DictionaryLearning tokenizes two ways: tokenizeWords splits on anything not letter/number (so &#34;don&#39;t&#34; -&gt; [&#34;don&#34;,&#34;t&#34;]), while splitPreservingWords keeps &#34;&#39;&#34; inside a token (&#34;don&#39;t&#34; stays one token). Whole-sentence similarity vs diff can disagree on apostrophes/hyphens. Unify or document the split so &#34;don&#39;t&#34; vs &#34;do not&#34; is learned consistently.

🔧 Fix: Fix HUD focus race, edit commit, dictionary validation
3 issues (2 warnings, 1 info) still open:
- ⚠️ `Talkify/Dictation/DirectDictationController.swift:484` - receive(_:) calls dependencies.applyDictionary on every live SpeechRecognitionService update, which builds a new DictionaryCorrector (and NSRegularExpression per correction) via DictionaryStore.corrector. At ~10-15 updates/sec this rebuilds regexes on the MainActor and risks HUD jank. Cache the corrector per store.revision and reuse for the session.
- ⚠️ `Talkify/Dictation/DirectDictationController.swift:525` - finishRecognition hides the HUD before setting lastRawText/lastCorrectedText and before insertion. Edits made during listening/finalizing (when the HUD is actually visible) fail the guard in handleHUDDraftEdited because lastRawText is still empty, and after hideHUD the panel retracts (350ms) leaving no window to edit the finalized draft. The wiring is correct but never succeeds in production; tests bypass it by calling handleHUDDraftEdited directly after insertion.
- ℹ️ `Talkify/Dictionary/DictionaryStore.swift:170` - learn(correction:) loops candidates and calls add(_:) per entry, each of which increments revision and atomically rewrites dictionary.txt plus triggers the file watcher. Batch multiple learnableEntries into a single mutation/save to avoid redundant I/O and watcher events.

🔧 Fix: Cache corrector per revision, batch dictionary learning, fix HUD edit window
3 issues (2 warnings, 1 info) still open:
- ⚠️ `Talkify/Dictation/DirectDictationController.swift:542` - finishRecognition sets lastRawText/lastCorrectedText and shows final corrected text before insertion but calls hideHUD immediately after insertion completes, so the HUD&#39;s post-finalization editable window is only the insertion duration plus the 350ms retract. A user cannot realistically double-tap and edit the finalized draft after speaking finishes; production learning via HUD edits will rarely succeed even though guard checks now pass and tests call the handler directly.
- ⚠️ `Talkify/Dictation/HUD/DictationHUDController.swift:155` - DictationHUDController.hide() unconditionally clears content.isEditable before stage.retract(). If the user is mid-edit when finishRecognition&#39;s insertText completes, hide discards the draft before DictationHUDShellView&#39;s onChange(focus) / commit logic can fire (commitEditedDraft guards on isEditable). In-progress edits are lost and learnFromUserEdit never fires.
- ℹ️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:236` - editableDraft commits on focus loss via onChange(isDraftFocused) and onSubmit/onExitCommand, but when the panel retracts the TextField is removed SwiftUI-side before focus change is observed. The cancel path restores preEditText from view @State which is not shared with controller hide, so the two discard paths can disagree. Consider committing or explicitly preserving the draft in controller hide before clearing isEditable.

🔧 Fix: Fix HUD dwell and commit-before-hide race
2 issues (1 warning, 1 info) still open:
- ⚠️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:15` - preEditText is @State in the view, but HUDStage rebuilds HUDRootView/DictationHUDShellView on every claim(mount). View identity resets between enterEditMode and commit/cancel, losing the baseline for the &#34;changed?&#34; check. If the view is recreated while editing, commitEditedDraft may compare against &#34;&#34; and incorrectly treat unchanged text as changed (or vice versa) and fire learnFromUserEdit incorrectly. Move preEditText to DictationHUDContent/Controller so the baseline survives mount.
- ℹ️ `Talkify/Dictation/HUD/DictationHUDShellView.swift:217` - compactDraftText and draftText are now trivial one-line wrappers around editableDraft(alignment:). Inline them at the call sites to reduce indirection.

🔧 Fix: Move HUD edit baseline to content and inline draft wrappers
3 issues (2 warnings, 1 info) still open:
- ⚠️ `Talkify/Dictionary/DictionaryLearning.swift:45` - Term dedup key mismatches DictionaryStore: learnableEntries builds &#34;term|\(write)|&#34; but store builds &#34;term||\(write)&#34; (&#34;\(kind)|\(hear)|\(write)&#34; with hear=&#34;&#34;). Existing term entries are not recognized, so a learned term that already exists is returned as learnable and only filtered later in DictionaryStore.learn. Use the same &#34;term||\(write.lowercased())&#34; format or unified helper.
- ⚠️ `Talkify/Dictation/HUD/DictationHUDController.swift:116` - showLiveText overwrites an in-progress HUD edit: receive(_:) applies DictionaryCorrector to every volatile update and calls showLiveText unconditionally, but showLiveText does not check content.isEditable. If the user double-taps and edits during listening/finalizing, the next volatile result clobbers content.text and the edit baseline. Guard showLiveText (or receive) when isEditable is true.
- ℹ️ `Talkify/Dictionary/DictionaryLearning.swift:92` - diffEntries aliases rawTokens as rawWords (let rawWords = rawTokens) and then indexes both arrays interchangeably. The alias is dead indirection and obscures that diff is case-sensitive on raw tokens while isWhitespaceOrPunctuationOnlyChange is case-insensitive. Remove alias and clarify case handling.

🔧 Fix: Fix term dedup key, HUD live-text guard, diff alias
3 issues (2 warnings, 1 info) still open:
- ⚠️ `Talkify/Dictionary/DictionaryEntry.swift:50` - isValidForFile rejects newlines and &#34;-&gt;&#34; but not a leading &#34;#&#34;. An enabled term &#34;#hello&#34; or correction &#34;#hello -&gt; World&#34; produces fileLine &#34;#hello&#34; which DictionaryStore.parse treats as a comment (hasPrefix &#34;#&#34; without &#34;off:&#34; -&gt; return nil) and silently drops on reload. Reject (or escape) entries where trimmed write/hear would make fileLine start with &#34;#&#34; so the file round-trip is lossless.
- ⚠️ `Talkify/Dictation/DirectDictationController.swift:412` - checkAndBegin clears lastRawText/lastCorrectedText but does not cancel postFinalizationHideTask. A previous session&#39;s 2.5s dwell hide task can still fire after a new trigger that was rejected (secure field / permission), hiding the rejection message or a new HUD. Cancel postFinalizationHideTask in checkAndBegin (and on beginRejected) like showListening/stop do.
- ℹ️ `Talkify/Dictation/SpeechRecognitionService.swift:215` - Bias limit is enforced twice: DictionaryCorrector.biasPhrases caps at 40 and start(biasPhrases:) again does prefix(40). The double cap is harmless but obscures the single source of truth. Keep the limit in one place (DictionaryStore/biasPhrases) and pass through without re-slicing, or document that SpeechRecognitionService is the final enforcer.

🔧 Fix: Reject hash-prefixed entries, cancel stale hide task
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild test -scheme Talkify -destination &#34;platform=macOS&#34; CODE_SIGNING_ALLOWED=NO` (full suite)</code>
- `xcodebuild test -scheme Talkify -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO -only-testing:TalkifyTests/DictionaryTests -only-testing:TalkifyTests/DictionaryLearningTests -only-testing:TalkifyTests/DictionaryAppleOnlyRegressionTests`
- <code>manual check `grep -r Parakeet|FluidAudio|speechModel Talkify` confirms removal and `DictionaryAppleOnlyRegressionTests.appleOnlySettingsHaveNoSpeechModel`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
