### PR TITLE
[FIX] Hang the HUD below the menu bar on displays with no real notch

### DIFF
--- a/Talkify/CoreHUD/HUDNotchGeometry.swift
+++ b/Talkify/CoreHUD/HUDNotchGeometry.swift
@@ -104,8 +104,22 @@ enum HUDNotchGeometry {
     hasMeasuredNotch(for: screen) ? 11 : 0
   }
 
+  /// Clearance between the true top of the screen and the housing, on a
+  /// display with no measured notch.
+  ///
+  /// A real notch already sits in its own housing, clear of wherever the
+  /// system draws status items. The simulated stand-in has no such housing:
+  /// pinned flush to the screen's top edge it draws directly over the menu
+  /// bar, hiding whatever status item sits under it — including Talkify's
+  /// own (issue #83). So there the shape hangs just below the menu bar
+  /// instead of over it.
+  static func topInset(for screen: HUDScreenSnapshot) -> CGFloat {
+    hasMeasuredNotch(for: screen) ? 0 : screen.menuBarHeight
+  }
+
   /// The host window's frame: content size plus shadow slack, centered and
-  /// pinned to the top, clamped to the screen width.
+  /// pinned to the top (below the menu bar on a display with no notch of its
+  /// own), clamped to the screen width.
   ///
   /// Sized for the standard metrics whatever the user's HUD size, so the
   /// window stays fixed per display (ADR-0001) and a smaller shape simply
@@ -120,7 +134,7 @@ enum HUDNotchGeometry {
 
     return CGRect(
       x: screen.frame.midX - width / 2,
-      y: screen.frame.maxY - height,
+      y: screen.frame.maxY - height - topInset(for: screen),
       width: width,
       height: height
     )

--- a/Talkify/CoreHUD/HUDPreviews.swift
+++ b/Talkify/CoreHUD/HUDPreviews.swift
@@ -10,16 +10,19 @@ enum HUDPreviewScreen {
     frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
     safeAreaTop: 32,
     auxiliaryTopLeftArea: CGRect(x: 0, y: 950, width: 663.5, height: 32),
-    auxiliaryTopRightArea: CGRect(x: 848.5, y: 950, width: 663.5, height: 32)
+    auxiliaryTopRightArea: CGRect(x: 848.5, y: 950, width: 663.5, height: 32),
+    menuBarHeight: 32
   )
 
-  /// An external display: simulated notch footprint, no fillets.
+  /// An external display: simulated notch footprint, no fillets, and its own
+  /// menu bar the housing has to hang below (issue #83).
   static let external = HUDScreenSnapshot(
     id: 2,
     frame: CGRect(x: 0, y: 0, width: 2560, height: 1440),
     safeAreaTop: 0,
     auxiliaryTopLeftArea: nil,
-    auxiliaryTopRightArea: nil
+    auxiliaryTopRightArea: nil,
+    menuBarHeight: 24
   )
 
   static var wallpaper: some View {

--- a/Talkify/CoreHUD/HUDScreenSnapshot.swift
+++ b/Talkify/CoreHUD/HUDScreenSnapshot.swift
@@ -9,4 +9,10 @@ struct HUDScreenSnapshot: Equatable, Sendable {
   let safeAreaTop: CGFloat
   let auxiliaryTopLeftArea: CGRect?
   let auxiliaryTopRightArea: CGRect?
+  /// This display's own reserved strip for the system menu bar, i.e. `frame`
+  /// minus `visibleFrame` at the top. Zero on a display that shows no menu
+  /// bar of its own. Distinct from `safeAreaTop`: that is the *notch*, a
+  /// housing the HUD hugs; this is the *menu bar*, a bar of status items the
+  /// HUD must clear (issue #83).
+  let menuBarHeight: CGFloat
 }

--- a/Talkify/CoreHUD/HUDStage.swift
+++ b/Talkify/CoreHUD/HUDStage.swift
@@ -56,7 +56,8 @@ final class HUDStage {
       frame: .zero,
       safeAreaTop: 0,
       auxiliaryTopLeftArea: nil,
-      auxiliaryTopRightArea: nil
+      auxiliaryTopRightArea: nil,
+      menuBarHeight: 0
     )
     hostingView = NSHostingView(
       rootView: HUDRootView(
@@ -99,7 +100,8 @@ final class HUDStage {
         frame: screen.frame,
         safeAreaTop: screen.safeAreaInsets.top,
         auxiliaryTopLeftArea: screen.auxiliaryTopLeftArea,
-        auxiliaryTopRightArea: screen.auxiliaryTopRightArea
+        auxiliaryTopRightArea: screen.auxiliaryTopRightArea,
+        menuBarHeight: screen.frame.maxY - screen.visibleFrame.maxY
       )
     }
     return HUDPlacement.selectDisplay(

--- a/TalkifyTests/HUDMetricsTests.swift
+++ b/TalkifyTests/HUDMetricsTests.swift
@@ -54,7 +54,8 @@ struct HUDMinimumScaleTests {
         frame: CGRect(x: 0, y: 0, width: width, height: 982),
         safeAreaTop: 0,
         auxiliaryTopLeftArea: nil,
-        auxiliaryTopRightArea: nil
+        auxiliaryTopRightArea: nil,
+        menuBarHeight: 24
       )
     }
     let side = (width - notchWidth) / 2
@@ -63,7 +64,8 @@ struct HUDMinimumScaleTests {
       frame: CGRect(x: 0, y: 0, width: width, height: 982),
       safeAreaTop: 32,
       auxiliaryTopLeftArea: CGRect(x: 0, y: 0, width: side, height: 32),
-      auxiliaryTopRightArea: CGRect(x: width - side, y: 0, width: side, height: 32)
+      auxiliaryTopRightArea: CGRect(x: width - side, y: 0, width: side, height: 32),
+      menuBarHeight: 32
     )
   }
 

--- a/TalkifyTests/HUDNotchGeometryTests.swift
+++ b/TalkifyTests/HUDNotchGeometryTests.swift
@@ -8,14 +8,16 @@ struct HUDNotchGeometryTests {
     frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
     safeAreaTop: 32,
     auxiliaryTopLeftArea: CGRect(x: 0, y: 950, width: 663.5, height: 32),
-    auxiliaryTopRightArea: CGRect(x: 848.5, y: 950, width: 663.5, height: 32)
+    auxiliaryTopRightArea: CGRect(x: 848.5, y: 950, width: 663.5, height: 32),
+    menuBarHeight: 32
   )
   private let external = HUDScreenSnapshot(
     id: 2,
     frame: CGRect(x: 1512, y: 200, width: 2560, height: 1440),
     safeAreaTop: 0,
     auxiliaryTopLeftArea: nil,
-    auxiliaryTopRightArea: nil
+    auxiliaryTopRightArea: nil,
+    menuBarHeight: 24
   )
 
   @Test func measuresNotchBySubtractingAuxiliaryAreas() {
@@ -33,7 +35,8 @@ struct HUDNotchGeometryTests {
       frame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
       safeAreaTop: 0,
       auxiliaryTopLeftArea: CGRect(x: 0, y: 1085, width: 700, height: 32),
-      auxiliaryTopRightArea: CGRect(x: 1028, y: 1085, width: 700, height: 32)
+      auxiliaryTopRightArea: CGRect(x: 1028, y: 1085, width: 700, height: 32),
+      menuBarHeight: 32
     )
     #expect(HUDNotchGeometry.measuredClosedSize(for: flat) == nil)
   }
@@ -106,6 +109,26 @@ struct HUDNotchGeometryTests {
     #expect(frame.maxY == notched.frame.maxY)
   }
 
+  /// Issue #83: a real notch already sits in its own housing, clear of
+  /// wherever the system draws status items, so there is nothing for the
+  /// shape to hide there — it keeps hugging the true top edge.
+  @Test func topInsetIsZeroOnANotchedDisplay() {
+    #expect(HUDNotchGeometry.topInset(for: notched) == 0)
+  }
+
+  /// Issue #83: with no real notch to hug, a shape pinned flush to the
+  /// screen's top edge draws directly over the menu bar — hiding whatever
+  /// status item sits under it, including Talkify's own. Clearing the menu
+  /// bar's own height keeps the shape below it instead.
+  @Test func topInsetMatchesTheMenuBarOnADisplayWithNoNotch() {
+    #expect(HUDNotchGeometry.topInset(for: external) == external.menuBarHeight)
+  }
+
+  @Test func windowFrameHangsBelowTheMenuBarWithNoNotch() {
+    let frame = HUDNotchGeometry.windowFrame(for: external)
+    #expect(frame.maxY == external.frame.maxY - external.menuBarHeight)
+  }
+
   /// Issue #24: the shape shrinks so it stops covering usable screen, but
   /// the housing band does not — it is hardware here and menu-bar clearance
   /// on a display with no notch.
@@ -165,7 +188,8 @@ struct HUDNotchGeometryTests {
       frame: CGRect(x: 0, y: 0, width: 600, height: 800),
       safeAreaTop: 0,
       auxiliaryTopLeftArea: nil,
-      auxiliaryTopRightArea: nil
+      auxiliaryTopRightArea: nil,
+      menuBarHeight: 24
     )
     let frame = HUDNotchGeometry.windowFrame(for: narrow)
     #expect(frame.width == 600)

--- a/TalkifyTests/HUDPlacementTests.swift
+++ b/TalkifyTests/HUDPlacementTests.swift
@@ -8,14 +8,16 @@ struct HUDPlacementTests {
     frame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
     safeAreaTop: 32,
     auxiliaryTopLeftArea: nil,
-    auxiliaryTopRightArea: nil
+    auxiliaryTopRightArea: nil,
+    menuBarHeight: 24
   )
   private let external = HUDScreenSnapshot(
     id: 2,
     frame: CGRect(x: 1728, y: 200, width: 2560, height: 1440),
     safeAreaTop: 0,
     auxiliaryTopLeftArea: nil,
-    auxiliaryTopRightArea: nil
+    auxiliaryTopRightArea: nil,
+    menuBarHeight: 24
   )
 
   @Test func selectsDisplayOfKnownTarget() {

--- a/TalkifyTests/HUDRenderTests.swift
+++ b/TalkifyTests/HUDRenderTests.swift
@@ -22,7 +22,8 @@ struct HUDRenderTests {
       frame: CGRect(x: 0, y: 0, width: 1512, height: 982),
       safeAreaTop: 32,
       auxiliaryTopLeftArea: CGRect(x: 0, y: 0, width: 663.5, height: 32),
-      auxiliaryTopRightArea: CGRect(x: 848.5, y: 0, width: 663.5, height: 32)
+      auxiliaryTopRightArea: CGRect(x: 848.5, y: 0, width: 663.5, height: 32),
+      menuBarHeight: 32
     )
   }
 


### PR DESCRIPTION
On the MacBook's built-in display the HUD's simulated notch sits inside the real one, clear of the status items on either side. On an external monitor there is no notch to clear, but the housing still pinned flush to the screen's top edge, drawing straight over the system menu bar and whatever status item happened to fall under it, including Talkify's own. This adds a `menuBarHeight` reading per display and, on a display with no measured notch, hangs the housing that far below the screen's top edge instead of flush against it, so it floats clear of the menu bar. 

<img width="689" height="215" alt="Screenshot 2026-08-24 at 17 22 01" src="https://github.com/user-attachments/assets/eb33f406-918a-4fe4-9ffb-aa87a5e7d6eb" />

Closes #83.