### PR TITLE
[FIX] Put the HUD where the notch would be on other displays

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -106,6 +106,7 @@ _Avoid_: Transcript history, cloud analytics
 - The HUD always descends from the top center of its display and is never placed at the bottom
 - Displays without a physical notch show a simulated notch: the same surface with a stand-in footprint
 - The simulated notch omits the corner fillets that hug a physical housing
+- The simulated notch sits where a physical one would, over the menu bar, because that is what it imitates; an off-by-default **Clear the menu bar on other displays** setting hangs it below instead, for a menu bar crowded enough that a centred shape reaches a status item
 - The HUD behaves identically on every display; only the notch measurement differs
 - **HUD size** scales the whole HUD shape — width, bands, corner radius, draft text, and each voice visual together — so a smaller HUD keeps its voice visual instead of trading it away
 - **HUD size** is a Settings slider from 20% to 100% in 5% steps, defaulting to 100%, and applies on every display rather than only where there is no notch

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -36,6 +36,7 @@ final class AppSettings {
     static let transcriptDestination = "transcriptDestination"
     static let transcriptFolder = "transcriptFolder"
     static let insertionDestination = "dictationInsertionDestination"
+    static let hudClearsMenuBar = "hudClearsMenuBar"
     static let historyEnabled = "dictationHistoryEnabled"
     static let historyFolder = "dictationHistoryFolder"
   }
@@ -142,6 +143,16 @@ final class AppSettings {
   /// someone already uses does.
   var readAloudTranslates: Bool {
     didSet { defaults.set(readAloudTranslates, forKey: Keys.readAloudTranslates) }
+  }
+
+  /// Whether the shape hangs below the menu bar on a display with no notch.
+  ///
+  /// Off, so it sits where the notch would be and looks like the housing it
+  /// imitates. On for a crowded menu bar, where a centred 540-point shape can
+  /// reach far enough right to cover a status item — including Talkify's own,
+  /// which is how a session is stopped without the key (issue #83).
+  var hudClearsMenuBar: Bool {
+    didSet { defaults.set(hudClearsMenuBar, forKey: Keys.hudClearsMenuBar) }
   }
 
   var readAloudVoiceID: String {
@@ -272,6 +283,7 @@ final class AppSettings {
     // existing user at the smallest HUD, so absence is checked directly.
     hudScale = defaults.object(forKey: Keys.hudScale) as? Double
       ?? Double(HUDMetrics.maximumScale)
+    hudClearsMenuBar = defaults.bool(forKey: Keys.hudClearsMenuBar)
     readAloudVoiceID = defaults.string(forKey: Keys.readAloudVoice) ?? ""
     readAloudTranslates = defaults.bool(forKey: Keys.readAloudTranslates)
     dictationTriggerBinding = Self.storedBinding(

--- a/Talkify/CoreHUD/HUDNotchGeometry.swift
+++ b/Talkify/CoreHUD/HUDNotchGeometry.swift
@@ -62,7 +62,7 @@ enum HUDNotchGeometry {
     includesTextBand: Bool
   ) -> CGSize {
     CGSize(
-      width: min(metrics.contentWidth, windowFrame(for: screen).width),
+      width: min(metrics.contentWidth, windowSize(for: screen).width),
       height: closedSize(for: screen).height
         + visualBandHeight
         + (includesTextBand ? metrics.textBandHeight : 0)
@@ -113,8 +113,13 @@ enum HUDNotchGeometry {
   /// bar, hiding whatever status item sits under it — including Talkify's
   /// own (issue #83). So there the shape hangs just below the menu bar
   /// instead of over it.
-  static func topInset(for screen: HUDScreenSnapshot) -> CGFloat {
-    hasMeasuredNotch(for: screen) ? 0 : screen.menuBarHeight
+  /// - Parameter clearsMenuBar: Whether a display with no housing hangs the
+  ///   shape below the menu bar instead of over it. Over it looks like the
+  ///   notch it imitates; below it keeps the status items reachable, which is
+  ///   what someone with a crowded menu bar needs (issue #83).
+  static func topInset(for screen: HUDScreenSnapshot, clearsMenuBar: Bool) -> CGFloat {
+    guard !hasMeasuredNotch(for: screen) else { return 0 }
+    return clearsMenuBar ? screen.menuBarHeight : 0
   }
 
   /// The host window's frame: content size plus shadow slack, centered and
@@ -125,18 +130,29 @@ enum HUDNotchGeometry {
   /// window stays fixed per display (ADR-0001) and a smaller shape simply
   /// centers itself inside it. The window is invisible and click-through, so
   /// the unused slack costs nothing.
-  static func windowFrame(for screen: HUDScreenSnapshot) -> CGRect {
-    let metrics = HUDMetrics.standard
-    let width = min(metrics.contentWidth + shadowPadding * 2, screen.frame.width)
-    let height = closedSize(for: screen).height
-      + max(metrics.waveBandHeight, metrics.visualBandHeight + metrics.maxTextBandHeight)
-      + shadowPadding
-
+  static func windowFrame(
+    for screen: HUDScreenSnapshot,
+    clearsMenuBar: Bool
+  ) -> CGRect {
+    let size = windowSize(for: screen)
     return CGRect(
-      x: screen.frame.midX - width / 2,
-      y: screen.frame.maxY - height - topInset(for: screen),
-      width: width,
-      height: height
+      x: screen.frame.midX - size.width / 2,
+      y: screen.frame.maxY - size.height - topInset(for: screen, clearsMenuBar: clearsMenuBar),
+      width: size.width,
+      height: size.height
+    )
+  }
+
+  /// The window's size, which does not depend on where it is pinned. Separate
+  /// so the callers that only want its width need know nothing about the menu
+  /// bar.
+  static func windowSize(for screen: HUDScreenSnapshot) -> CGSize {
+    let metrics = HUDMetrics.standard
+    return CGSize(
+      width: min(metrics.contentWidth + shadowPadding * 2, screen.frame.width),
+      height: closedSize(for: screen).height
+        + max(metrics.waveBandHeight, metrics.visualBandHeight + metrics.maxTextBandHeight)
+        + shadowPadding
     )
   }
 }

--- a/Talkify/CoreHUD/HUDStage.swift
+++ b/Talkify/CoreHUD/HUDStage.swift
@@ -234,7 +234,13 @@ final class HUDStage {
         self?.onCardEvent?(event)
       }
     )
-    panel.setFrame(HUDNotchGeometry.windowFrame(for: screen), display: true)
+    panel.setFrame(
+      HUDNotchGeometry.windowFrame(
+        for: screen,
+        clearsMenuBar: settings.hudClearsMenuBar
+      ),
+      display: true
+    )
     panel.orderFrontRegardless()
   }
 

--- a/Talkify/DropTranscription/HUD/DropHUDView.swift
+++ b/Talkify/DropTranscription/HUD/DropHUDView.swift
@@ -38,7 +38,7 @@ struct DropHUDView: View {
   /// the full shape. Growing rather than appearing is what makes the gesture
   /// read as one movement.
   private var size: CGSize {
-    let windowWidth = HUDNotchGeometry.windowFrame(for: screen).width
+    let windowWidth = HUDNotchGeometry.windowSize(for: screen).width
     let width = min(metrics.contentWidth, windowWidth)
     switch drop.mode {
     case .none:

--- a/Talkify/Settings/Sections/AppearanceSettingsView.swift
+++ b/Talkify/Settings/Sections/AppearanceSettingsView.swift
@@ -71,6 +71,17 @@ struct AppearanceSettingsView: View {
           valueLabel: { "\(Int(($0 * 100).rounded()))%" }
         )
 
+        SettingsRow(
+          title: "Clear the menu bar on other displays",
+          description: "A display with no notch has nothing to hug, so the "
+            + "shape sits where a notch would be. Turn this on if it covers "
+            + "your menu bar icons."
+        ) {
+          Toggle("Clear the menu bar on other displays", isOn: $settings.hudClearsMenuBar)
+            .labelsHidden()
+            .toggleStyle(.switch)
+        }
+
         SettingsPickerRow(
           title: "Reveal style",
           description: "How the HUD appears when Direct Dictation starts",

--- a/TalkifyTests/HUDNotchGeometryTests.swift
+++ b/TalkifyTests/HUDNotchGeometryTests.swift
@@ -82,7 +82,7 @@ struct HUDNotchGeometryTests {
       visualBandHeight: HUDMetrics.standard.waveBandHeight,
       includesTextBand: false
     )
-    let window = HUDNotchGeometry.windowFrame(for: notched)
+    let window = HUDNotchGeometry.windowFrame(for: notched, clearsMenuBar: false)
     #expect(content.height <= window.height - HUDNotchGeometry.shadowPadding)
   }
 
@@ -97,7 +97,7 @@ struct HUDNotchGeometryTests {
   }
 
   @Test func windowFrameIsTopCenterWithShadowSlack() {
-    let frame = HUDNotchGeometry.windowFrame(for: notched)
+    let frame = HUDNotchGeometry.windowFrame(for: notched, clearsMenuBar: false)
     let expectedWidth: CGFloat = 540 + 44 * 2
     let tallestBands = max(
       HUDMetrics.standard.waveBandHeight,
@@ -112,8 +112,24 @@ struct HUDNotchGeometryTests {
   /// Issue #83: a real notch already sits in its own housing, clear of
   /// wherever the system draws status items, so there is nothing for the
   /// shape to hide there — it keeps hugging the true top edge.
+  /// The preference only governs a display with no housing. A notched one
+  /// hugs its own notch either way.
+  @Test func aNotchedDisplayIgnoresTheMenuBarPreference() {
+    #expect(HUDNotchGeometry.topInset(for: notched, clearsMenuBar: true) == 0)
+    #expect(HUDNotchGeometry.topInset(for: notched, clearsMenuBar: false) == 0)
+  }
+
+  /// Off, the shape sits where the notch would be, which is what it imitates.
+  @Test func aDisplayWithNoNotchSitsOverTheMenuBarByDefault() {
+    #expect(HUDNotchGeometry.topInset(for: external, clearsMenuBar: false) == 0)
+    #expect(
+      HUDNotchGeometry.windowFrame(for: external, clearsMenuBar: false).maxY
+        == external.frame.maxY
+    )
+  }
+
   @Test func topInsetIsZeroOnANotchedDisplay() {
-    #expect(HUDNotchGeometry.topInset(for: notched) == 0)
+    #expect(HUDNotchGeometry.topInset(for: notched, clearsMenuBar: true) == 0)
   }
 
   /// Issue #83: with no real notch to hug, a shape pinned flush to the
@@ -121,11 +137,11 @@ struct HUDNotchGeometryTests {
   /// status item sits under it, including Talkify's own. Clearing the menu
   /// bar's own height keeps the shape below it instead.
   @Test func topInsetMatchesTheMenuBarOnADisplayWithNoNotch() {
-    #expect(HUDNotchGeometry.topInset(for: external) == external.menuBarHeight)
+    #expect(HUDNotchGeometry.topInset(for: external, clearsMenuBar: true) == external.menuBarHeight)
   }
 
   @Test func windowFrameHangsBelowTheMenuBarWithNoNotch() {
-    let frame = HUDNotchGeometry.windowFrame(for: external)
+    let frame = HUDNotchGeometry.windowFrame(for: external, clearsMenuBar: true)
     #expect(frame.maxY == external.frame.maxY - external.menuBarHeight)
   }
 
@@ -167,7 +183,7 @@ struct HUDNotchGeometryTests {
   /// whatever the user's HUD size, so a smaller shape centers inside it
   /// instead of resizing the window mid-session.
   @Test func windowFrameIgnoresHUDSize() {
-    let frame = HUDNotchGeometry.windowFrame(for: external)
+    let frame = HUDNotchGeometry.windowFrame(for: external, clearsMenuBar: true)
     let smallest = HUDMetrics(scale: HUDMetrics.minimumScale)
     let content = HUDNotchGeometry.contentSize(
       for: external,
@@ -191,7 +207,7 @@ struct HUDNotchGeometryTests {
       auxiliaryTopRightArea: nil,
       menuBarHeight: 24
     )
-    let frame = HUDNotchGeometry.windowFrame(for: narrow)
+    let frame = HUDNotchGeometry.windowFrame(for: narrow, clearsMenuBar: false)
     #expect(frame.width == 600)
     #expect(frame.midX == 300)
   }


### PR DESCRIPTION
On a display with no notch the shape hung below the menu bar, so on an external monitor it floats in the desktop rather than sitting where the housing it imitates would be.

That offset came from #83, where a centred shape covered someone's status icons and they could not stop a session without the key. The shape is 540 points wide and centred, so on an ordinary external display it never reaches the right-hand status area: the offset was paying for one crowded menu bar with everyone else's placement. It is now a setting in Appearance, off by default, so the case #83 reported still has an answer.

Window level was never the problem, for the record: the panel already sits at mainMenu + 3, above the menu bar. This was placement.

Splitting `windowSize` out of `windowFrame` keeps the two callers that only want a width from having to know about the menu bar.