### PR TITLE
[FEATURE] Teach Apple Speech the user's own words

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,7 +190,12 @@ _Avoid_: Transcript history, cloud analytics
 - The HUD shows a language tag only while a second **Dictation Language** is configured
 - Speech models use Apple's `lingering` retention policy
 - Talkify prepares the selected speech model shortly after launch
-- Talkify does not bundle or train speech models
+- Talkify biases recognition with a user-authored **Vocabulary**; it does not bundle, train, or modify speech models
+- A **Vocabulary Term** is a word or short phrase the user typed in Settings, at most 100 of them, which is Apple's ceiling for contextual strings
+- The Vocabulary is applied when an analyzer is prepared, never on the keypress; editing it rebuilds the warm analyzers so the next session carries the change
+- Failing to bias never fails a session: it is a hint, and an analyzer that refused it transcribes as an empty Vocabulary does
+- The Vocabulary holds only what the user typed; nothing is derived from what was dictated, so no recognized text is persisted by it
+- One Vocabulary serves both dictation languages, because a name is spelled the same way whichever language surrounds it
 - Onboarding installs the Apple-managed language asset only when it is missing and waits for completion
 - Talkify uses Apple Speech exclusively and has no Whisper fallback
 - Language selectors show only locales supported by Apple Speech

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ It works the other way too. Turn on **Translate before speaking** in
 Read Aloud key speaks it in your voice's language. The voice is the target, so
 there is nothing else to set.
 
+## Teach it your words
+
+Apple Speech has never heard your colleague's name, your product's, or your
+codebase's. It guesses, and it guesses the same way every session. Type those
+words into **Settings → Vocabulary** and the recognizer is told to expect them
+before you speak.
+
+This biases recognition rather than editing text afterwards. Nothing is
+rewritten after the fact, so a word on the list can only become more likely,
+never substituted into something you said. Up to 100 words, which is Apple's
+limit, kept on this Mac.
+
 ## Two languages, two triggers
 
 Pick a second language in **Settings → Language** and it gets its own trigger. Hold

--- a/Talkify/App/AppDelegate.swift
+++ b/Talkify/App/AppDelegate.swift
@@ -199,6 +199,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       // pair the trigger will use. Without it a changed target reinstalled a
       // trigger that had nothing to translate into.
       _ = settings.translationTargetIdentifier
+      // The words go on when an analyzer is warmed, so editing them re-runs
+      // the same reload a language change does.
+      _ = settings.vocabularyTerms
     } onChange: { [weak self] in
       Task { @MainActor [weak self] in
         self?.dictationController?.applyLanguages()

--- a/Talkify/App/AppSettings.swift
+++ b/Talkify/App/AppSettings.swift
@@ -36,6 +36,7 @@ final class AppSettings {
     static let transcriptDestination = "transcriptDestination"
     static let transcriptFolder = "transcriptFolder"
     static let insertionDestination = "dictationInsertionDestination"
+    static let vocabularyTerms = "vocabularyTerms"
     static let historyEnabled = "dictationHistoryEnabled"
     static let historyFolder = "dictationHistoryFolder"
   }
@@ -142,6 +143,15 @@ final class AppSettings {
   /// someone already uses does.
   var readAloudTranslates: Bool {
     didSet { defaults.set(readAloudTranslates, forKey: Keys.readAloudTranslates) }
+  }
+
+  /// Words Apple Speech is told to expect, in the order they were added.
+  ///
+  /// Stored here with every other preference rather than in a document of its
+  /// own: it is at most 100 short strings, and UserDefaults is where the rest
+  /// of this app's settings live.
+  var vocabularyTerms: [String] {
+    didSet { defaults.set(vocabularyTerms, forKey: Keys.vocabularyTerms) }
   }
 
   var readAloudVoiceID: String {
@@ -272,6 +282,11 @@ final class AppSettings {
     // existing user at the smallest HUD, so absence is checked directly.
     hudScale = defaults.object(forKey: Keys.hudScale) as? Double
       ?? Double(HUDMetrics.maximumScale)
+    // Sanitized on the way in: an older build may have written more terms,
+    // longer ones, or duplicates.
+    vocabularyTerms = Vocabulary.sanitized(
+      defaults.stringArray(forKey: Keys.vocabularyTerms) ?? []
+    )
     readAloudVoiceID = defaults.string(forKey: Keys.readAloudVoice) ?? ""
     readAloudTranslates = defaults.bool(forKey: Keys.readAloudTranslates)
     dictationTriggerBinding = Self.storedBinding(

--- a/Talkify/Dictation/DirectDictationController+Dependencies.swift
+++ b/Talkify/Dictation/DirectDictationController+Dependencies.swift
@@ -14,6 +14,8 @@ extension DirectDictationController {
     let resolveLocale: @Sendable (String?) async throws -> Locale
     let supportedLocale: @Sendable (String) async -> Locale?
     let retainOnly: @Sendable ([Locale]) async -> Void
+    /// The words Apple Speech should expect, applied before anything warms.
+    let setVocabulary: @Sendable ([String]) async -> Void
     let prewarm: @Sendable (Locale) async throws -> Void
     let startRecognition: @Sendable (
       Locale,
@@ -89,6 +91,7 @@ extension DirectDictationController {
         resolveLocale: { try await speechService.resolveLocale(identifier: $0) },
         supportedLocale: { await speechService.supportedLocale(identifier: $0) },
         retainOnly: { await speechService.retainOnly(locales: $0) },
+        setVocabulary: { await speechService.setVocabulary($0) },
         prewarm: { try await speechService.prewarm(locale: $0) },
         startRecognition: { locale, updateHandler, failureHandler, levelHandler in
           try await speechService.start(

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -217,6 +217,9 @@ final class DirectDictationController {
 
     let bound = [primary, secondaryLocale].compactMap(\.self)
     await dependencies.retainOnly(bound)
+    // Before the prewarm below, so the analyzer it leaves warm already knows
+    // the user's words rather than being rebuilt a moment later.
+    await dependencies.setVocabulary(settings.vocabularyTerms)
     try await dependencies.prewarm(primary)
 
     if let secondaryLocale {

--- a/Talkify/Dictation/SpeechRecognitionService.swift
+++ b/Talkify/Dictation/SpeechRecognitionService.swift
@@ -84,6 +84,10 @@ actor SpeechRecognitionService {
     let transcriber: SpeechTranscriber
     let analyzer: SpeechAnalyzer
     let audioFormat: AVAudioFormat
+    /// The words this analyzer was biased toward when it was built. Kept so a
+    /// warm session can be recognized as out of date rather than trusted: an
+    /// analyzer built before a word was added would go on missing it.
+    let vocabulary: [String]
   }
 
   private struct ActiveSession {
@@ -154,6 +158,8 @@ actor SpeechRecognitionService {
   func setVocabulary(_ terms: [String]) async {
     guard terms != vocabulary else { return }
     vocabulary = terms
+    // Builds in flight would finish carrying the old list. Warm sessions are
+    // dropped here too, though `ensureWarm` would notice them anyway.
     for locale in Set(preparedSessions.keys).union(buildTasks.keys) {
       discard(locale: locale)
     }
@@ -164,6 +170,13 @@ actor SpeechRecognitionService {
   /// cache, so two awaiters of the same build can never end up with the same
   /// analyzer, one using it while the other caches it as idle.
   private func ensureWarm(locale: Locale) async throws {
+    // A warm session built before the word list changed is stale. Checked here
+    // rather than relying on something outside to invalidate it: a stale
+    // analyzer would go on missing a word the user has already added, and the
+    // reason would be invisible.
+    if let warm = preparedSessions[locale], warm.vocabulary != vocabulary {
+      discard(locale: locale)
+    }
     if preparedSessions[locale] != nil { return }
 
     let task: Task<PreparedSession, any Error>
@@ -397,7 +410,8 @@ actor SpeechRecognitionService {
       locale: locale,
       transcriber: transcriber,
       analyzer: analyzer,
-      audioFormat: audioFormat
+      audioFormat: audioFormat,
+      vocabulary: vocabulary
     )
   }
 

--- a/Talkify/Dictation/SpeechRecognitionService.swift
+++ b/Talkify/Dictation/SpeechRecognitionService.swift
@@ -97,6 +97,8 @@ actor SpeechRecognitionService {
   /// only worth having if it answers as fast as the first, and that means
   /// keeping its analyzer prepared rather than building it on the keypress.
   private var preparedSessions: [Locale: PreparedSession] = [:]
+  /// Words every analyzer built from here on is biased toward.
+  private var vocabulary: [String] = []
   private var activeSession: ActiveSession?
   /// Locales reserved with AssetInventory, oldest first. The system caps how
   /// many an app may hold (`maximumReservedLocales`), so the oldest is
@@ -144,6 +146,19 @@ actor SpeechRecognitionService {
     try await ensureWarm(locale: locale)
   }
 
+  /// The words Apple Speech is told to expect from now on.
+  ///
+  /// Warm sessions carry the list they were built with, so a change drops them
+  /// and the next prewarm rebuilds. Pushing new terms into a live analyzer
+  /// instead would leave a session that is already recording biased two ways.
+  func setVocabulary(_ terms: [String]) async {
+    guard terms != vocabulary else { return }
+    vocabulary = terms
+    for locale in Set(preparedSessions.keys).union(buildTasks.keys) {
+      discard(locale: locale)
+    }
+  }
+
   /// Leaves a warm session for this locale in `preparedSessions`, building
   /// one only if no build is already under way. Exactly one path owns the
   /// cache, so two awaiters of the same build can never end up with the same
@@ -179,6 +194,18 @@ actor SpeechRecognitionService {
   /// cancel one build while a later call installs another under the same
   /// locale; clearing blindly would drop the newer task's entry and let a third
   /// build start, which is exactly the duplicate install this map prevents.
+  /// Points the analyzer at the user's words.
+  ///
+  /// Never throws outward. Biasing is a hint: an analyzer that refused it
+  /// transcribes exactly as it would with an empty list, and failing a session
+  /// over a hint would trade the whole feature for part of one.
+  private func bias(_ analyzer: SpeechAnalyzer, toward terms: [String]) async {
+    guard !terms.isEmpty else { return }
+    var context = await analyzer.context
+    context.contextualStrings[.general] = terms
+    try? await analyzer.setContext(context)
+  }
+
   private func clearBuildTask(_ task: Task<PreparedSession, any Error>, for locale: Locale) {
     if buildTasks[locale] == task {
       buildTasks[locale] = nil
@@ -364,6 +391,7 @@ actor SpeechRecognitionService {
     )
     let analyzer = SpeechAnalyzer(modules: modules, options: options)
     try await analyzer.prepareToAnalyze(in: audioFormat)
+    await bias(analyzer, toward: vocabulary)
 
     return PreparedSession(
       locale: locale,

--- a/Talkify/Settings/Sections/VocabularySettingsView.swift
+++ b/Talkify/Settings/Sections/VocabularySettingsView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// The Vocabulary section: words Apple Speech is told to expect.
+///
+/// A list and a text field, and nothing else. What may join the list is
+/// `Vocabulary`'s business, so this only reports which rule refused a term.
+struct VocabularySettingsView: View {
+  @Bindable var settings: AppSettings
+
+  @State private var entry = ""
+  @Environment(\.colorSchemeContrast) private var contrast
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      SettingsCard(title: "Your words") {
+        SettingsRow(title: "Add a word", description: description) {
+          HStack(spacing: 8) {
+            TextField("Name, acronym, jargon", text: $entry)
+              .textFieldStyle(.roundedBorder)
+              .frame(width: 200)
+              .onSubmit(add)
+            Button("Add", action: add)
+              .buttonStyle(SettingsButtonStyle())
+              .disabled(entry.trimmingCharacters(in: .whitespaces).isEmpty)
+          }
+        }
+
+        ForEach(settings.vocabularyTerms, id: \.self) { term in
+          SettingsRow(title: term) {
+            Button("Remove") { remove(term) }
+              .buttonStyle(SettingsButtonStyle())
+          }
+        }
+      }
+
+      Text(
+        "Apple Speech has never heard your colleague's name or your product's, "
+          + "so it guesses. These words tell it what to expect before you "
+          + "speak, rather than correcting the text afterwards. They stay on "
+          + "this Mac and are never sent anywhere."
+      )
+      .font(.caption)
+      .foregroundStyle(.white.opacity(contrast == .increased ? 0.7 : 0.45))
+      .fixedSize(horizontal: false, vertical: true)
+      .padding(.horizontal, 6)
+    }
+  }
+
+  /// Says which rule refused a term, rather than letting the field look broken.
+  private var description: String {
+    let remaining = Vocabulary.maximumTermCount - settings.vocabularyTerms.count
+    guard remaining > 0 else {
+      return "The list is full at \(Vocabulary.maximumTermCount) words, which "
+        + "is Apple's limit. Remove one to add another"
+    }
+    return "\(remaining) of \(Vocabulary.maximumTermCount) left. "
+      + "Up to \(Vocabulary.maximumTermLength) characters each"
+  }
+
+  private func add() {
+    guard let terms = Vocabulary.adding(entry, to: settings.vocabularyTerms) else { return }
+    settings.vocabularyTerms = terms
+    entry = ""
+  }
+
+  private func remove(_ term: String) {
+    settings.vocabularyTerms.removeAll { $0 == term }
+  }
+}

--- a/Talkify/Settings/Sections/VocabularySettingsView.swift
+++ b/Talkify/Settings/Sections/VocabularySettingsView.swift
@@ -13,15 +13,30 @@ struct VocabularySettingsView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 18) {
       SettingsCard(title: "Your words") {
-        SettingsRow(title: "Add a word", description: description) {
-          HStack(spacing: 8) {
+        SettingsRow(
+          title: "Add a word",
+          description: "Up to \(Vocabulary.maximumTermLength) characters each"
+        ) {
+          HStack(spacing: 10) {
             TextField("Name, acronym, jargon", text: $entry)
               .textFieldStyle(.roundedBorder)
-              .frame(width: 200)
+              .frame(width: 190)
               .onSubmit(add)
+              .disabled(isFull)
             Button("Add", action: add)
               .buttonStyle(SettingsButtonStyle())
-              .disabled(entry.trimmingCharacters(in: .whitespaces).isEmpty)
+              .disabled(isFull || entry.trimmingCharacters(in: .whitespaces).isEmpty)
+            // The count is the readout, the way the HUD size row reads out its
+            // percentage. Monospaced and fixed width so it does not shift the
+            // button as the digits grow.
+            Text("\(settings.vocabularyTerms.count)/\(Vocabulary.maximumTermCount)")
+              .font(.system(size: 12, weight: .medium))
+              .monospacedDigit()
+              .foregroundStyle(.white.opacity(isFull ? 0.85 : 0.62))
+              .frame(width: 54, alignment: .trailing)
+              .accessibilityLabel(
+                "\(settings.vocabularyTerms.count) of \(Vocabulary.maximumTermCount) words used"
+              )
           }
         }
 
@@ -46,15 +61,10 @@ struct VocabularySettingsView: View {
     }
   }
 
-  /// Says which rule refused a term, rather than letting the field look broken.
-  private var description: String {
-    let remaining = Vocabulary.maximumTermCount - settings.vocabularyTerms.count
-    guard remaining > 0 else {
-      return "The list is full at \(Vocabulary.maximumTermCount) words, which "
-        + "is Apple's limit. Remove one to add another"
-    }
-    return "\(remaining) of \(Vocabulary.maximumTermCount) left. "
-      + "Up to \(Vocabulary.maximumTermLength) characters each"
+  /// Apple's ceiling, reached. The field and the button go dead rather than
+  /// refusing silently, which reads as broken.
+  private var isFull: Bool {
+    settings.vocabularyTerms.count >= Vocabulary.maximumTermCount
   }
 
   private func add() {

--- a/Talkify/Settings/SettingsSections.swift
+++ b/Talkify/Settings/SettingsSections.swift
@@ -20,6 +20,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
   case dropTranscription
   case readAloud
   case language
+  case vocabulary
   case shortcuts
   case updates
   case insights
@@ -36,6 +37,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .dropTranscription: "Drop Transcription"
     case .readAloud: "Read Aloud"
     case .language: "Language"
+    case .vocabulary: "Vocabulary"
     case .shortcuts: "Shortcuts"
     case .updates: "Updates"
     case .insights: "Insights"
@@ -51,6 +53,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .dropTranscription: "Transcribe audio and video files"
     case .readAloud: "Choose the voice that reads selected text"
     case .language: "Choose your languages"
+    case .vocabulary: "Teach it your words"
     case .shortcuts: "Rebind Direct Dictation triggers and Read Aloud"
     case .updates: "Keep Talkify current"
     case .insights: "Review your local Direct Dictation activity"
@@ -66,6 +69,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case .dropTranscription: "square.and.arrow.down"
     case .readAloud: "speaker.wave.2"
     case .language: "globe"
+    case .vocabulary: "character.book.closed"
     case .shortcuts: "keyboard"
     case .updates: "arrow.down.circle"
     case .insights: "chart.bar.xaxis"

--- a/Talkify/Settings/SettingsView.swift
+++ b/Talkify/Settings/SettingsView.swift
@@ -261,6 +261,8 @@ private struct SettingsContent: View {
           ReadAloudSettingsView(settings: settings)
         case .language:
           LanguageSettingsView(settings: settings, runtimeState: runtimeState)
+        case .vocabulary:
+          VocabularySettingsView(settings: settings)
         case .shortcuts:
           ShortcutsSettingsView(settings: settings)
         case .updates:

--- a/Talkify/Vocabulary/Vocabulary.swift
+++ b/Talkify/Vocabulary/Vocabulary.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// The words a user tells Apple Speech to expect.
+///
+/// The one accuracy gap a general on-device model cannot close by itself: it
+/// has never heard your colleague's name or your product's, so it mishears
+/// them every session and no better model fixes that, because the information
+/// is not in it. `AnalysisContext.contextualStrings` is where it goes.
+///
+/// Biasing before the words are heard, rather than rewriting them after. A
+/// find-and-replace pass over finished text has no edge to its category and
+/// eats real words: "3 mm" becomes "3" the first time "mm" is on the list.
+///
+/// A value type with static rules, so what may join the list is testable
+/// without a Settings window or a recognizer.
+enum Vocabulary {
+  /// Apple asks for at most 100 phrases across all tags. Talkify spends them
+  /// all on one tag, so this is the whole budget.
+  static let maximumTermCount = 100
+
+  /// No documented limit behind this one. Apple asks for phrases "relatively
+  /// brief", and a term the length of a sentence never matches what anyone
+  /// says, so this only stops a pasted paragraph taking a slot.
+  static let maximumTermLength = 64
+
+  /// Cleans up one entered term, or returns nil when there is nothing left.
+  ///
+  /// Casing survives: whatever the recognizer settles on is what lands in the
+  /// document, so someone who typed "Talkify" wants that capital.
+  static func normalized(_ raw: String) -> String? {
+    let collapsed = raw
+      .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !collapsed.isEmpty, collapsed.count <= maximumTermLength else { return nil }
+    return collapsed
+  }
+
+  /// The list with `term` added, or nil when it cannot join: nothing left after
+  /// cleaning, too long, already there, or the list is full.
+  ///
+  /// Case-insensitive on duplicates because two spellings of one word are one
+  /// acoustic hint. Diacritics stay distinct: "resume" and "résumé" are
+  /// different words, and telling them apart is why someone added the second.
+  static func adding(_ term: String, to terms: [String]) -> [String]? {
+    guard let normalized = normalized(term), terms.count < maximumTermCount else { return nil }
+    let existing = Set(terms.map { $0.lowercased() })
+    guard !existing.contains(normalized.lowercased()) else { return nil }
+    return terms + [normalized]
+  }
+
+  /// A stored list made safe to use, because UserDefaults holds whatever was
+  /// last written and an older build may have written more, longer, or
+  /// duplicate terms.
+  static func sanitized(_ terms: [String]) -> [String] {
+    var seen = Set<String>()
+    var result: [String] = []
+    for term in terms {
+      guard let normalized = normalized(term) else { continue }
+      guard seen.insert(normalized.lowercased()).inserted else { continue }
+      result.append(normalized)
+      if result.count == maximumTermCount { break }
+    }
+    return result
+  }
+}

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -79,6 +79,7 @@ struct DirectDictationControllerTests {
     translationPrepareHangs: Bool = false,
     translateBody: (@Sendable (String) async throws -> String)? = nil,
     retainedPairs: OSAllocatedUnfairLock<[TranslationPair?]> = .init(initialState: []),
+    appliedVocabulary: OSAllocatedUnfairLock<[String]> = .init(initialState: []),
     insertOutcome: TextInsertionService.InsertionOutcome = .inserted
   ) -> DirectDictationController.Dependencies {
     DirectDictationController.Dependencies(
@@ -86,6 +87,7 @@ struct DirectDictationControllerTests {
       resolveLocale: { _ in Locale(identifier: "en_US") },
       supportedLocale: { _ in nil },
       retainOnly: { _ in },
+      setVocabulary: { terms in appliedVocabulary.withLock { $0 = terms } },
       prewarm: { _ in prewarmed.withLock { $0 = true } },
       startRecognition: { locale, _, _, _ in
         startEntries.withLock { $0 += 1 }
@@ -819,6 +821,29 @@ struct DirectDictationControllerTests {
     #expect(bindings.trigger == settings.dictationTriggerBinding)
     #expect(bindings.secondary == nil)
     #expect(bindings.translate == nil)
+  }
+
+  /// The words are handed over before anything warms, so the analyzer that is
+  /// left warm already knows them rather than being rebuilt a moment later.
+  @Test func theVocabularyReachesTheRecognizerBeforePrewarming() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let applied = OSAllocatedUnfairLock<[String]>(initialState: [])
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.vocabularyTerms = ["Talkify", "Ada Lovelace"]
+    let controller = makeController(
+      settings: settings,
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        appliedVocabulary: applied
+      )
+    )
+
+    await prepare(controller, prewarmed: prewarmed)
+
+    #expect(applied.withLock { $0 } == ["Talkify", "Ada Lovelace"])
+    controller.stop()
   }
 
   /// The clipboard rescue can be refused too, while a read holds its lease.

--- a/TalkifyTests/SettingsWindowTests.swift
+++ b/TalkifyTests/SettingsWindowTests.swift
@@ -31,7 +31,7 @@ struct SettingsWindowTests {
   @Test func settingsSectionsStayFocusedOnImplementedFeatures() {
     let expected: [SettingsSection] = [
       .general, .appearance, .sounds, .dictation, .dropTranscription, .readAloud,
-      .language, .shortcuts, .updates, .insights,
+      .language, .vocabulary, .shortcuts, .updates, .insights,
     ]
     #expect(SettingsSection.allCases == expected)
     #expect(SettingsSectionGroup.settings.sections == expected)

--- a/TalkifyTests/VocabularyTests.swift
+++ b/TalkifyTests/VocabularyTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import Talkify
+
+/// What may join the word list. Pure rules, so they hold without a Settings
+/// window or a recognizer.
+struct VocabularyTests {
+  @Test func casingSurvives() {
+    // Whatever the recognizer settles on is what lands in the document, so a
+    // capital someone typed is part of what they asked for.
+    #expect(Vocabulary.normalized("Talkify") == "Talkify")
+    #expect(Vocabulary.normalized("  SwiftUI  ") == "SwiftUI")
+  }
+
+  @Test func runsOfWhitespaceCollapse() {
+    #expect(Vocabulary.normalized("Ada   Lovelace") == "Ada Lovelace")
+    #expect(Vocabulary.normalized("\n Ada \t Lovelace \n") == "Ada Lovelace")
+  }
+
+  @Test func nothingUsefulIsNotATerm() {
+    #expect(Vocabulary.normalized("") == nil)
+    #expect(Vocabulary.normalized("   \n\t ") == nil)
+  }
+
+  /// A term the length of a sentence never matches what anyone says, so it
+  /// only takes a slot from one that would.
+  @Test func aPastedParagraphIsRefused() {
+    let long = String(repeating: "a", count: Vocabulary.maximumTermLength + 1)
+    #expect(Vocabulary.normalized(long) == nil)
+    #expect(Vocabulary.adding(long, to: []) == nil)
+  }
+
+  /// Two spellings of one word are one acoustic hint.
+  @Test func duplicatesAreRefusedWhateverTheCasing() {
+    let terms = ["Talkify"]
+    #expect(Vocabulary.adding("talkify", to: terms) == nil)
+    #expect(Vocabulary.adding("TALKIFY", to: terms) == nil)
+  }
+
+  /// "resume" and "résumé" are different words, and telling them apart is the
+  /// reason someone added the accented one.
+  @Test func accentsAreTheirOwnTerm() {
+    #expect(Vocabulary.adding("résumé", to: ["resume"]) == ["resume", "résumé"])
+  }
+
+  @Test func theListStopsAtApplesLimit() {
+    let full = (1...Vocabulary.maximumTermCount).map { "term\($0)" }
+    #expect(full.count == Vocabulary.maximumTermCount)
+    #expect(Vocabulary.adding("one more", to: full) == nil)
+  }
+
+  @Test func addingKeepsTheOrderTheyWereAdded() {
+    var terms: [String] = []
+    for word in ["Talkify", "SwiftUI", "Ada"] {
+      terms = Vocabulary.adding(word, to: terms) ?? terms
+    }
+    #expect(terms == ["Talkify", "SwiftUI", "Ada"])
+  }
+
+  /// Stored values come from whatever an older build wrote, so they are made
+  /// safe on the way in rather than trusted.
+  @Test func aStoredListIsRepaired() {
+    let stored = [
+      "  Talkify  ",
+      "talkify",
+      "",
+      String(repeating: "b", count: Vocabulary.maximumTermLength + 1),
+      "Ada Lovelace",
+    ]
+    #expect(Vocabulary.sanitized(stored) == ["Talkify", "Ada Lovelace"])
+  }
+
+  @Test func aStoredListIsCutToTheLimit() {
+    let stored = (1...Vocabulary.maximumTermCount + 20).map { "term\($0)" }
+    #expect(Vocabulary.sanitized(stored).count == Vocabulary.maximumTermCount)
+  }
+}

--- a/docs/adr/0008-user-authored-vocabulary.md
+++ b/docs/adr/0008-user-authored-vocabulary.md
@@ -1,0 +1,40 @@
+# A user-authored Vocabulary biases recognition
+
+Direct Dictation gains a **Vocabulary**: words the user types in Settings that
+Apple Speech is told to expect. The terms reach the recognizer through
+`AnalysisContext.contextualStrings`, applied with `SpeechAnalyzer.setContext`
+when an analyzer is prepared.
+
+This closes the one accuracy gap a general on-device model cannot close by
+itself. The model has never heard the user's colleague, product or codebase, so
+it mishears them every session, and no better model fixes it because the
+information is not in the model.
+
+Biasing before the words are heard, rather than rewriting text after. A
+find-and-replace pass over finished text has no edge to its category: a list
+holding "mm" turns "the gap is 3 mm" into "the gap is 3", silently, with no
+undo. Biasing can only make a word Talkify was told about more likely; it never
+edits what was said.
+
+## Consequences
+
+- Terms are applied when an analyzer is prepared, never on the keypress:
+  `setContext` is async, and the warm session exists so the key meets an
+  analyzer with nothing left to do.
+- Editing the list drops the warm analyzers so the next prewarm rebuilds with
+  the new terms. Pushing terms into a live analyzer would leave a session that
+  is already recording biased two ways.
+- Failing to bias never fails a session. It is a hint, and an analyzer that
+  refused it transcribes exactly as an empty list does.
+- Nothing is derived from what was dictated. The list holds what the user typed
+  and nothing else, so "Talkify persists no recognized text" is untouched.
+- One list across both dictation languages. A name is spelled the same way
+  whichever language surrounds it.
+- At most 100 terms, which is Apple's documented ceiling across all tags, and
+  64 characters each, which is a guard rather than a limit.
+- Stored in `AppSettings` on UserDefaults with every other preference, and
+  sanitized on read: an older build may have written more, longer, or duplicate
+  terms.
+
+The mechanism was found by @kalki-kgp in issue #19, along with Apple's phrase
+ceiling.


### PR DESCRIPTION
Words typed in Settings > Vocabulary are handed to Apple Speech before you speak, through `AnalysisContext.contextualStrings`. It closes the one accuracy gap a general on-device model cannot close by itself: it has never heard your colleague's name or your product's, so it mishears them every session, and no better model fixes that because the information is not in the model.

This biases recognition rather than rewriting finished text. That distinction is the whole design. A find-and-replace pass has no edge to its category: a list holding "mm" turns "the gap is 3 mm" into "the gap is 3", silently. Biasing can only make a word Talkify was told about more likely; it never substitutes anything into what you said.

Terms go on when an analyzer is prepared, never on the keypress, because the warm session exists so the key meets an analyzer with nothing left to do. Editing the list drops the warm analyzers so the next prewarm carries the change. Failing to bias never fails a session, since it is a hint and a refused one transcribes exactly as an empty list does.

The list holds only what you typed. Nothing is learned from what was dictated, so it persists no recognized text. At most 100 terms, which is Apple's documented ceiling, stored in AppSettings with every other preference.

The mechanism and Apple's phrase ceiling were found by @kalki-kgp in #19, and ADR-0008 says so.

Closes #19