### PR TITLE
[FIX] Shape before translating, and record what actually landed

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -190,7 +190,8 @@ _Avoid_: Transcript history, cloud analytics
 - The shaping prompt library is user-editable in Settings, seeded with three default prompts
 - The transcript-as-data framing around every shaping prompt is fixed and never editable
 - A deleted or unknown selected shaping prompt inserts the raw words unchanged
-- Transcription history keeps the words as spoken, before shaping
+- Transcription history keeps the words as spoken; a translated session's second line is what actually landed, so it is written after shaping and before insertion
+- Shaping runs before translation: a prompt carries its own language and its one-shot example in that language, and a translator handed cleaned-up words has less to get wrong
 - The shaping choice is captured in the Dictation session settings snapshot, along with the whole prompt library while shaping is on
 - A session that will shape keeps the HUD up through the shaping phase, saying which prompt it shapes with over a bar that fills toward the shaping timeout — the model reports no real progress, so time toward the timeout is the honest measure — and the HUD leaves early when the answer lands
 - While a shaping-enabled session with a nonempty prompt library is recording, the bare Left and Right arrow keys cycle the session's shaping pick through the library and None, wrapping at the ends; they are swallowed only then, and a modified arrow always passes through

--- a/Talkify/Dictation/DirectDictationController.swift
+++ b/Talkify/Dictation/DirectDictationController.swift
@@ -283,7 +283,9 @@ final class DirectDictationController {
   /// it writes history or reaches the clipboard, and killing the process in
   /// that window loses the words with nothing to recover them from. No longer
   /// than that: a wedged insertion must not hold the quit open forever.
-  static let finishGrace = TranslationService.defaultTimeout + .seconds(2)
+  static let finishGrace = TranslationService.defaultTimeout
+    + PromptShapingService.defaultTimeout
+    + .seconds(2)
 
   /// Waits for an in-flight finish to insert its text, giving up after
   /// `timeout` so a stuck insertion cannot hold the quit forever. Giving up
@@ -749,13 +751,22 @@ final class DirectDictationController {
         // promised a translation, and pasting the untranslated words instead
         // lands the wrong language in someone else's document.
         var text = spoken
-        if let pair = session.translation, !spoken.isEmpty {
+        // Shaping first, then translation. A prompt is written in one language,
+        // with a one-shot example in it, so handing it a translation of the
+        // words asks it to work in a language it was not written for; and a
+        // translator given cleaned-up words has less to get wrong.
+        if let chosenPrompt, willShape {
+          text = await dependencies.shapeText(text, chosenPrompt)
+        }
+        // Shaped or passed through, the phase is over.
+        if willShape { dependencies.hideHUD() }
+
+        if let pair = session.translation, !text.isEmpty {
           do {
-            text = try await translation.translate(spoken, with: pair)
+            text = try await translation.translate(text, with: pair)
           } catch {
-            // The shaping presentation must not outlive the session it
-            // promised to shape.
-            if willShape { dependencies.hideHUD() }
+            // The rescue is the words as spoken, not as shaped: shaping is a
+            // convenience and the raw words are what must survive.
             await recordHistory(spoken: spoken, delivered: nil, session: session)
             // Clipboard-only whatever the session's destination: nothing is
             // pasted, and the words survive where the user can reach them.
@@ -774,16 +785,12 @@ final class DirectDictationController {
           }
         }
 
+        // Last before insertion, so the delivered line is what actually
+        // lands: written earlier it recorded a translation nobody received,
+        // because shaping had not run yet. Still before insertion, so a
+        // failed paste cannot lose the words (ADR-0007).
         await recordHistory(spoken: spoken, delivered: text, session: session)
 
-        // Shaping runs after the history write on purpose: history keeps the
-        // words as spoken, and any shaping failure inserts them unchanged.
-        if let chosenPrompt, willShape, !text.isEmpty {
-          text = await dependencies.shapeText(text, chosenPrompt)
-        }
-        // Shaped or passthrough, the phase is over; insertion proceeds
-        // exactly as an unshaped session's does.
-        if willShape { dependencies.hideHUD() }
         let outcome = await dependencies.insertText(
           text, focusedTarget, session.insertionDestination
         )

--- a/TalkifyTests/DirectDictationControllerTests.swift
+++ b/TalkifyTests/DirectDictationControllerTests.swift
@@ -839,6 +839,91 @@ struct DirectDictationControllerTests {
     #expect(bindings.translate == nil)
   }
 
+  /// Shaping runs before translation. A prompt is written in one language,
+  /// with its one-shot example in that language, so handing it a translation
+  /// of the words asks it to work in a language it was not written for.
+  @Test func shapingSeesTheSpokenWordsAndTranslationSeesTheShapedOnes() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let shapedInput = OSAllocatedUnfairLock<String?>(initialState: nil)
+    let translatedInput = OSAllocatedUnfairLock<String?>(initialState: nil)
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.translationTargetIdentifier = "es"
+    settings.promptShapingEnabled = true
+    settings.promptShapingPromptID = settings.shapingPrompts[0].id
+    let controller = makeController(
+      settings: settings,
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "um so ship it thursday" },
+        translateBody: { text in
+          translatedInput.withLock { $0 = text }
+          return "envíalo el jueves"
+        },
+        shapeText: { text, _ in
+          shapedInput.withLock { $0 = text }
+          return "Ship it on Thursday"
+        }
+      )
+    )
+    await prepareWithTranslation(controller, prewarmed: prewarmed)
+
+    controller.handle(.triggerPressed(.translate))
+    controller.handle(.triggerReleased(.translate))
+    await waitUntil("Session never latched") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    controller.handle(.triggerPressed(.translate))
+    await waitUntil("Finish never delivered") { !recorder.insertedTexts.isEmpty }
+
+    #expect(shapedInput.withLock { $0 } == "um so ship it thursday")
+    #expect(translatedInput.withLock { $0 } == "Ship it on Thursday")
+    #expect(recorder.insertedTexts == ["envíalo el jueves"])
+    controller.stop()
+  }
+
+  /// History's delivered line is what landed. Written before shaping it
+  /// recorded a translation nobody received, which only shows with both
+  /// features on, because that line exists only for a translated session.
+  @Test func historyRecordsTheTextThatWasActuallyInserted() async {
+    let recorder = Recorder()
+    let prewarmed = OSAllocatedUnfairLock(initialState: false)
+    let historyEntries = OSAllocatedUnfairLock<[HistoryEntry]>(initialState: [])
+    let settings = AppSettings(defaults: freshDefaults())
+    settings.dictationHistoryEnabled = true
+    settings.translationTargetIdentifier = "es"
+    settings.promptShapingEnabled = true
+    settings.promptShapingPromptID = settings.shapingPrompts[0].id
+    let controller = makeController(
+      settings: settings,
+      dependencies: makeDependencies(
+        recorder: recorder,
+        prewarmed: prewarmed,
+        finishRecognition: { "um so ship it thursday" },
+        historyEntries: historyEntries,
+        translateBody: { _ in "envíalo el jueves" },
+        shapeText: { _, _ in "Ship it on Thursday" }
+      )
+    )
+    await prepareWithTranslation(controller, prewarmed: prewarmed)
+
+    controller.handle(.triggerPressed(.translate))
+    controller.handle(.triggerReleased(.translate))
+    await waitUntil("Session never latched") {
+      controller.sessionStateForTesting == .recording(.latched)
+    }
+    controller.handle(.triggerPressed(.translate))
+    await waitUntil("Finish never delivered") { !recorder.insertedTexts.isEmpty }
+
+    let entries = historyEntries.withLock { $0 }
+    // The spoken half is still the words as spoken, and the delivered half is
+    // what the document received.
+    #expect(entries.map(\.text) == ["um so ship it thursday"])
+    #expect(entries.first?.translation?.text == recorder.insertedTexts.first)
+    controller.stop()
+  }
+
   /// The clipboard rescue can be refused too, while a read holds its lease.
   /// Saying only that the translation failed would promise words that are not
   /// anywhere the user can reach.


### PR DESCRIPTION
Follow-ups to #68, found while reviewing it. All three come from the same cause: prompt shaping arrived from a branch that predates translation, so the two transforms ended up in an order nobody chose.

Shaping now runs before translation. A prompt carries its own language and its one-shot example in that language, so handing it a translation asks it to work in a language it was not written for. A translator handed cleaned-up words also has less to get wrong.

The history write moves last, still ahead of insertion so a failed paste cannot lose the words. Where it was, the delivered line recorded a translation nobody received, because shaping had not run yet. The spoken half is unchanged.

And `finishGrace` covered a translation but not a shaping pass, so a finish could outlast the quit hold by shaping's ten seconds and take the words with it, history included. That is the same mistake I made in 0.7.0 one step further out, so it now names every bounded step a finish can be inside.

Both new tests fail against the previous order.