### PR TITLE
[FIX] Drive the insertion deadlines from an injectable clock

### DIFF
--- a/Talkify/Dictation/InsertionClock.swift
+++ b/Talkify/Dictation/InsertionClock.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// The monotonic time source behind the insertion service's deadlines.
+///
+/// Injectable for the same reason `awaitValue(of:orGiveUpAfter:)` keeps its
+/// waiters seam-shaped: against the wall clock, a snapshot test's 100ms budget
+/// is really an assertion that the runner was fast enough, which a loaded CI
+/// machine fails and a re-run passes (#82). A test drives this clock by hand,
+/// so a timeout asserts the deadline was honoured rather than that the
+/// machine kept up.
+struct InsertionClock: Sendable {
+  /// Monotonic time elapsed since this clock's own fixed origin.
+  let now: @Sendable () -> Duration
+  /// Suspends for `duration` of this clock's time, throwing when the
+  /// sleeping task is cancelled, exactly as `Task.sleep(for:)` does.
+  let sleep: @Sendable (Duration) async throws -> Void
+
+  /// The production clock: real time, anchored when the dependencies are built.
+  static var continuous: Self {
+    let origin = ContinuousClock.now
+    return Self(
+      now: { origin.duration(to: ContinuousClock.now) },
+      sleep: { try await Task.sleep(for: $0) }
+    )
+  }
+}

--- a/Talkify/Dictation/TextInsertionService+Clipboard.swift
+++ b/Talkify/Dictation/TextInsertionService+Clipboard.swift
@@ -83,7 +83,8 @@ extension TextInsertionService {
 
     let readClipboardItems = dependencies.readClipboardItems
     let timeout = dependencies.snapshotTimeout
-    let deadline = ContinuousClock.now.advanced(by: timeout)
+    let clock = dependencies.clock
+    let deadline = clock.now() + timeout
     let completionLock = OSAllocatedUnfairLock(initialState: false)
     let readLease = clipboardReadLease
     let pasteboard = dependencies.pasteboard
@@ -103,14 +104,15 @@ extension TextInsertionService {
         }
       }
 
-      let timeoutTask = Self.makeSnapshotTimeoutTask(after: timeout) {
+      let timeoutTask = Self.makeSnapshotTimeoutTask(after: timeout, on: clock) {
         complete(.timedOut)
       }
       let executeRead: @Sendable () -> Void = {
         let result = Self.readStableSnapshot(
           of: backgroundPasteboard,
           using: readClipboardItems,
-          before: deadline
+          before: deadline,
+          on: clock
         )
         readLease.withLock { $0 = false }
         timeoutTask.cancel()
@@ -128,29 +130,32 @@ extension TextInsertionService {
   /// - Parameters:
   ///   - pasteboard: The pasteboard whose change count bounds each read.
   ///   - readClipboardItems: The all-or-nothing snapshot operation.
-  ///   - deadline: The total deadline shared by both permitted reads.
+  ///   - deadline: The total deadline shared by both permitted reads, in the
+  ///     injected clock's time.
+  ///   - clock: The time source the deadline was built from.
   /// - Returns: A stable snapshot, a completed failure, an unstable result, or
   ///   a timeout when the second read cannot start or finish within the budget.
   private nonisolated static func readStableSnapshot(
     of pasteboard: NSPasteboard,
     using readClipboardItems: @Sendable () -> [ClipboardItemSnapshot]?,
-    before deadline: ContinuousClock.Instant
+    before deadline: Duration,
+    on clock: InsertionClock
   ) -> SnapshotAcquisitionResult {
     let startCount = pasteboard.changeCount
     let firstSnapshot = readClipboardItems()
     let firstEndCount = pasteboard.changeCount
-    guard ContinuousClock.now < deadline else { return .timedOut }
+    guard clock.now() < deadline else { return .timedOut }
 
     if firstEndCount == startCount {
       guard let firstSnapshot else { return .failed }
       return .accepted(items: firstSnapshot, changeCount: firstEndCount)
     }
 
-    guard ContinuousClock.now < deadline else { return .timedOut }
+    guard clock.now() < deadline else { return .timedOut }
     let secondStartCount = pasteboard.changeCount
     let secondSnapshot = readClipboardItems()
     let secondEndCount = pasteboard.changeCount
-    guard ContinuousClock.now < deadline else { return .timedOut }
+    guard clock.now() < deadline else { return .timedOut }
     guard secondEndCount == secondStartCount else { return .unstable }
     guard let secondSnapshot else { return .failed }
     return .accepted(items: secondSnapshot, changeCount: secondEndCount)
@@ -163,15 +168,17 @@ extension TextInsertionService {
   ///
   /// - Parameters:
   ///   - timeout: The total duration allowed for snapshot acquisition.
+  ///   - clock: The time source the timer elapses against.
   ///   - onTimeout: The single-resume contender invoked when the budget elapses.
   /// - Returns: A task the actual reader must cancel when it completes.
   private nonisolated static func makeSnapshotTimeoutTask(
     after timeout: Duration,
+    on clock: InsertionClock,
     onTimeout: @escaping @Sendable () -> Void
   ) -> Task<Void, Never> {
     Task {
       do {
-        try await Task.sleep(for: timeout)
+        try await clock.sleep(timeout)
       } catch {
         return
       }

--- a/Talkify/Dictation/TextInsertionService.swift
+++ b/Talkify/Dictation/TextInsertionService.swift
@@ -82,6 +82,10 @@ final class TextInsertionService {
     /// How long a copy is given to reach the pasteboard. Long enough for a
     /// browser to answer, short enough that a key press does not feel stuck.
     var copyTimeout: Duration = .milliseconds(400)
+    /// The time source behind the snapshot and copy deadlines. Injectable so
+    /// a test drives time instead of betting the runner beats a real
+    /// deadline, which is the bet that flaked on loaded CI machines (#82).
+    var clock: InsertionClock = .continuous
 
     /// Builds the production boundaries around the shared general pasteboard.
     static var live: Self {
@@ -115,7 +119,8 @@ final class TextInsertionService {
           try? await Task.sleep(for: .milliseconds(500))
         },
         postCopyShortcut: TextInsertionService.postCopyShortcut,
-        copyTimeout: .milliseconds(400)
+        copyTimeout: .milliseconds(400),
+        clock: .continuous
       )
     }
   }
@@ -377,12 +382,13 @@ final class TextInsertionService {
   /// - Returns: the new change count, or nil if the count never moved, which
   ///   is what nothing being selected looks like.
   private func waitForCopy(after changeCount: Int) async -> Int? {
-    let deadline = ContinuousClock.now.advanced(by: dependencies.copyTimeout)
-    while ContinuousClock.now < deadline {
+    let clock = dependencies.clock
+    let deadline = clock.now() + dependencies.copyTimeout
+    while clock.now() < deadline {
       let current = dependencies.pasteboard.changeCount
       if current != changeCount { return current }
       do {
-        try await Task.sleep(for: .milliseconds(10))
+        try await clock.sleep(.milliseconds(10))
       } catch {
         return nil
       }

--- a/TalkifyTests/TextInsertionServiceTests.swift
+++ b/TalkifyTests/TextInsertionServiceTests.swift
@@ -24,7 +24,8 @@ struct TextInsertionServiceTests {
       postPasteShortcut: { true },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -64,7 +65,8 @@ struct TextInsertionServiceTests {
       },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -100,7 +102,8 @@ struct TextInsertionServiceTests {
       },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -133,7 +136,8 @@ struct TextInsertionServiceTests {
       },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -168,7 +172,8 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      waitForPasteRead: {}
+      waitForPasteRead: {},
+      clock: makeHeldClock()
     ))
 
     let outcome = await service.insert("dictated text", into: makeTarget())
@@ -196,7 +201,8 @@ struct TextInsertionServiceTests {
       waitForPasteRead: {
         pasteboard.clearContents()
         pasteboard.setString("new clipboard", forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -205,35 +211,58 @@ struct TextInsertionServiceTests {
   }
 
   /// Verifies a healthy delayed read still pastes and restores within its budget.
-  @Test func delayedSnapshotWithinDeadlinePastesAndRestores() async {
-    let pasteboard = makePasteboard()
+  ///
+  /// The delay is in driven-clock time: the read is held open across a 100ms
+  /// advance of a 150ms budget, so what is asserted is that a slow but
+  /// in-budget read pastes, not that this machine got there in time.
+  @Test nonisolated func delayedSnapshotWithinDeadlinePastesAndRestores() async {
+    let pasteboard = NSPasteboard(
+      name: NSPasteboard.Name(
+        "TextInsertionServiceTests-\(UUID().uuidString)"
+      )
+    )
     pasteboard.clearContents()
     pasteboard.setString("previous clipboard", forType: .string)
-    let delay = DispatchSemaphore(value: 0)
-    var pastedText: String?
+    let clock = DrivenClock()
+    let readerStarted = DispatchSemaphore(value: 0)
+    let allowReadToFinish = DispatchSemaphore(value: 0)
+    let pastedText = OSAllocatedUnfairLock<String?>(initialState: nil)
+    defer {
+      allowReadToFinish.signal()
+    }
 
-    nonisolated(unsafe) let backgroundPasteboard = pasteboard
-    let service = TextInsertionService(dependencies: .init(
-      pasteboard: pasteboard,
-      readClipboardItems: {
-        _ = delay.wait(timeout: .now() + .milliseconds(40))
-        return TextInsertionService.snapshot(of: backgroundPasteboard)
-      },
-      snapshotTimeout: .milliseconds(150),
-      focusedElement: { nil },
-      frontmostApplication: { nil },
-      isProcessRunning: { _ in true },
-      isTargetFocused: { _ in true },
-      postPasteShortcut: { true },
-      waitForPasteRead: {
-        pastedText = pasteboard.string(forType: .string)
-      }
-    ))
+    nonisolated(unsafe) let observedPasteboard = pasteboard
+    let service = await MainActor.run {
+      TextInsertionService(dependencies: .init(
+        pasteboard: observedPasteboard,
+        readClipboardItems: {
+          readerStarted.signal()
+          _ = allowReadToFinish.wait(timeout: .now() + 10)
+          return TextInsertionService.snapshot(of: observedPasteboard)
+        },
+        snapshotTimeout: .milliseconds(150),
+        focusedElement: { nil },
+        frontmostApplication: { nil },
+        isProcessRunning: { _ in true },
+        isTargetFocused: { _ in true },
+        postPasteShortcut: { true },
+        waitForPasteRead: {
+          pastedText.withLock { $0 = observedPasteboard.string(forType: .string) }
+        },
+        clock: clock.insertionClock
+      ))
+    }
 
-    let outcome = await service.insert("dictated text", into: makeTarget())
+    let insertion = Task { @MainActor in
+      await service.insert("dictated text", into: makeTarget())
+    }
+    #expect(wait(for: readerStarted, timeout: .now() + 10) == .success)
+    clock.advance(by: .milliseconds(100))
+    allowReadToFinish.signal()
 
+    let outcome = await insertion.value
     #expect(outcome == .inserted)
-    #expect(pastedText == "dictated text")
+    #expect(pastedText.withLock { $0 } == "dictated text")
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
   }
 
@@ -268,7 +297,8 @@ struct TextInsertionServiceTests {
       postPasteShortcut: { true },
       waitForPasteRead: {
         pastedText = pasteboard.string(forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
 
     let outcome = await service.insert("dictated text", into: makeTarget())
@@ -312,7 +342,8 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      waitForPasteRead: {}
+      waitForPasteRead: {},
+      clock: makeHeldClock()
     ))
 
     let outcome = await service.insert("dictated text", into: makeTarget())
@@ -350,7 +381,8 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      waitForPasteRead: {}
+      waitForPasteRead: {},
+      clock: makeHeldClock()
     ))
 
     let outcome = await service.insert("dictated text", into: makeTarget())
@@ -385,7 +417,8 @@ struct TextInsertionServiceTests {
       },
       waitForPasteRead: {
         waitedForPasteRead = true
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -441,7 +474,8 @@ struct TextInsertionServiceTests {
         postedPaste = true
         return true
       },
-      waitForPasteRead: {}
+      waitForPasteRead: {},
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert("dictated text", into: makeTarget())
 
@@ -488,9 +522,13 @@ struct TextInsertionServiceTests {
     pasteboard.clearContents()
     pasteboard.setString("previous clipboard", forType: .string)
 
-    let eventWaitBudget = DispatchTimeInterval.seconds(2)
+    // An event wait, not a time bound: the budget is only spent when the run
+    // is already broken, so it can be generous instead of measuring how fast
+    // a loaded runner schedules the reader (#82).
+    let eventWaitBudget = DispatchTimeInterval.seconds(10)
     let blockingWaitBudget = DispatchTimeInterval.seconds(10)
     let snapshotTimeout = Duration.milliseconds(25)
+    let clock = DrivenClock()
     let readerStartedForBlocker = DispatchSemaphore(value: 0)
     let readerStartedForTest = DispatchSemaphore(value: 0)
     let allowReaderToFinish = DispatchSemaphore(value: 0)
@@ -561,7 +599,8 @@ struct TextInsertionServiceTests {
           postedPaste.withLock { $0 = true }
           return true
         },
-        waitForPasteRead: {}
+        waitForPasteRead: {},
+        clock: clock.insertionClock
       ))
     }
     let clipboardReaderQueue = await MainActor.run {
@@ -585,18 +624,11 @@ struct TextInsertionServiceTests {
     #expect(blockerObservedReaderStart.withLock { $0 })
     #expect(!insertionCompleted.withLock { $0 })
 
-    let snapshotDeadlineElapsed = DispatchSemaphore(value: 0)
-    DispatchQueue.global(qos: .userInitiated).asyncAfter(
-      deadline: .now() + .milliseconds(30)
-    ) {
-      snapshotDeadlineElapsed.signal()
-    }
-    #expect(
-      wait(
-        for: snapshotDeadlineElapsed,
-        timeout: .now() + eventWaitBudget
-      ) == .success
-    )
+    // Drive the injected clock past the snapshot budget instead of sleeping
+    // it away: the timeout is forced by the test, not raced against the
+    // runner (#82).
+    await waitForSleeper(on: clock)
+    clock.advance(by: snapshotTimeout)
 
     allowReaderToFinish.signal()
     let readerQueueDrained = DispatchSemaphore(value: 0)
@@ -632,6 +664,7 @@ struct TextInsertionServiceTests {
     pasteboard.clearContents()
     pasteboard.setString("previous clipboard", forType: .string)
 
+    let clock = DrivenClock()
     let readerStarted = DispatchSemaphore(value: 0)
     let allowFirstReadToFinish = DispatchSemaphore(value: 0)
     let readerReturned = DispatchSemaphore(value: 0)
@@ -687,7 +720,8 @@ struct TextInsertionServiceTests {
           if let text = observedPasteboard.string(forType: .string) {
             pastedTexts.withLock { $0.append(text) }
           }
-        }
+        },
+        clock: clock.insertionClock
       ))
     }
     let insert: @MainActor @Sendable (String) async
@@ -698,24 +732,29 @@ struct TextInsertionServiceTests {
     let firstInsertion = Task {
       await insert("first dictated text")
     }
-    #expect(wait(for: readerStarted, timeout: .now() + 1) == .success)
+    // An event wait, not a time bound: the budget is only spent when the run
+    // is already broken, so it can be generous instead of measuring how fast
+    // a loaded runner schedules the reader (#82).
+    #expect(wait(for: readerStarted, timeout: .now() + 10) == .success)
 
-    let busySkipStarted = ContinuousClock.now
     let secondOutcome = await insert("second dictated text")
-    let busySkipDuration = busySkipStarted.duration(to: .now)
 
     #expect(secondOutcome == .unavailable)
-    // A generous ceiling on purpose. What proves the busy path did not queue
-    // behind the stuck read is that it returned at all: the first read is held
-    // open until `releaseReader()`, so an implementation that waited for it
-    // would hang here rather than come back slowly. A tight bound measures the
-    // runner's load instead, which failed this test on CI at 50ms.
-    #expect(busySkipDuration < .seconds(2))
+    // The busy skip never consults the clock, and only this test advances it,
+    // so coming back at all proves the skip did not queue behind the held-open
+    // read: an implementation that waited for it would hang here forever. The
+    // wall-clock ceiling this replaces measured the runner's load instead,
+    // which failed this test on CI at 50ms.
     #expect(readCount.withLock { $0 } == 1)
     #expect(postedPasteCount.withLock { $0 } == 0)
     #expect(pastedTexts.withLock { $0 }.isEmpty)
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
 
+    // The held-open read is meant to outlive its budget: arm the deadline and
+    // drive the clock past it, so the first insertion's timeout is forced
+    // rather than waited for.
+    await waitForSleeper(on: clock)
+    clock.advance(by: .milliseconds(100))
     let firstOutcome = await firstInsertion.value
     #expect(firstOutcome == .unavailable)
     #expect(readCount.withLock { $0 } == 1)
@@ -723,7 +762,7 @@ struct TextInsertionServiceTests {
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
 
     releaseReader()
-    #expect(wait(for: readerReturned, timeout: .now() + 1) == .success)
+    #expect(wait(for: readerReturned, timeout: .now() + 10) == .success)
     // The reader signals from inside the read closure, so the lease is still
     // held for a moment after it. Retrying rather than sleeping a fixed 10ms
     // keeps this from depending on how fast the machine gets there; a refused
@@ -741,6 +780,62 @@ struct TextInsertionServiceTests {
     #expect(readCount.withLock { $0 } == 2)
     #expect(postedPasteCount.withLock { $0 } == 1)
     #expect(pastedTexts.withLock { $0 } == ["third dictated text"])
+    #expect(pasteboard.string(forType: .string) == "previous clipboard")
+  }
+
+  /// The deadline is honoured, not raced: with the read held open, driving
+  /// the clock past the snapshot budget is the only thing that times the
+  /// acquisition out. No real time passes here, so a starved runner cannot
+  /// change the answer either way.
+  @Test nonisolated func drivingTheClockPastTheSnapshotBudgetTimesTheReadOut() async {
+    let pasteboard = NSPasteboard(
+      name: NSPasteboard.Name(
+        "TextInsertionServiceTests-\(UUID().uuidString)"
+      )
+    )
+    pasteboard.clearContents()
+    pasteboard.setString("previous clipboard", forType: .string)
+    let clock = DrivenClock()
+    let readerStarted = DispatchSemaphore(value: 0)
+    let allowReadToFinish = DispatchSemaphore(value: 0)
+    let postedPaste = OSAllocatedUnfairLock(initialState: false)
+    defer {
+      allowReadToFinish.signal()
+    }
+
+    nonisolated(unsafe) let observedPasteboard = pasteboard
+    let service = await MainActor.run {
+      TextInsertionService(dependencies: .init(
+        pasteboard: observedPasteboard,
+        readClipboardItems: {
+          readerStarted.signal()
+          _ = allowReadToFinish.wait(timeout: .now() + 10)
+          return TextInsertionService.snapshot(of: observedPasteboard)
+        },
+        snapshotTimeout: .milliseconds(100),
+        focusedElement: { nil },
+        frontmostApplication: { nil },
+        isProcessRunning: { _ in true },
+        isTargetFocused: { _ in true },
+        postPasteShortcut: {
+          postedPaste.withLock { $0 = true }
+          return true
+        },
+        waitForPasteRead: {},
+        clock: clock.insertionClock
+      ))
+    }
+
+    let insertion = Task { @MainActor in
+      await service.insert("dictated text", into: makeTarget())
+    }
+    #expect(wait(for: readerStarted, timeout: .now() + 10) == .success)
+    await waitForSleeper(on: clock)
+    clock.advance(by: .milliseconds(100))
+
+    let outcome = await insertion.value
+    #expect(outcome == .unavailable)
+    #expect(!postedPaste.withLock { $0 })
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
   }
 
@@ -978,7 +1073,8 @@ struct TextInsertionServiceTests {
       postPasteShortcut: { true },
       waitForPasteRead: {
         textAvailableWhileTargetReads = pasteboard.string(forType: .string)
-      }
+      },
+      clock: makeHeldClock()
     ))
     let outcome = await service.insert(
       "dictated text",
@@ -1041,7 +1137,8 @@ struct TextInsertionServiceTests {
         typesWhileStaged = pasteboard.types?.map(\.rawValue) ?? []
         return true
       },
-      waitForPasteRead: {}
+      waitForPasteRead: {},
+      clock: makeHeldClock()
     ))
 
     let outcome = await service.insert(
@@ -1109,7 +1206,8 @@ struct TextInsertionServiceTests {
         pasteboard.clearContents()
         pasteboard.setString("the selected sentence", forType: .string)
         return true
-      }
+      },
+      clock: makeHeldClock()
     ))
 
     let copied = await service.copySelection()
@@ -1125,6 +1223,8 @@ struct TextInsertionServiceTests {
     let pasteboard = makePasteboard()
     pasteboard.clearContents()
     pasteboard.setString("previous clipboard", forType: .string)
+    let clock = DrivenClock()
+    let copyFired = OSAllocatedUnfairLock(initialState: false)
 
     let service = TextInsertionService(dependencies: .init(
       pasteboard: pasteboard,
@@ -1137,11 +1237,28 @@ struct TextInsertionServiceTests {
       postPasteShortcut: { true },
       waitForPasteRead: {},
       // Copy fired and nothing came of it, exactly as an empty selection does.
-      postCopyShortcut: { true },
-      copyTimeout: .milliseconds(60)
+      postCopyShortcut: {
+        copyFired.withLock { $0 = true }
+        return true
+      },
+      copyTimeout: .milliseconds(60),
+      clock: clock.insertionClock
     ))
 
+    // The copy deadline is driven, not waited out. Advancing only once Copy
+    // has fired keeps the snapshot's own timer out of it: by then that timer
+    // is cancelled, so the sleeper this wakes is the copy poll's.
+    let driver = Task.detached {
+      while !copyFired.withLock({ $0 }) {
+        await Task.yield()
+      }
+      while !clock.hasSleeper {
+        await Task.yield()
+      }
+      clock.advance(by: .milliseconds(60))
+    }
     let copied = await service.copySelection()
+    await driver.value
 
     #expect(copied == nil)
     #expect(pasteboard.string(forType: .string) == "previous clipboard")
@@ -1168,7 +1285,8 @@ struct TextInsertionServiceTests {
       postCopyShortcut: {
         didCopy.withLock { $0 = true }
         return true
-      }
+      },
+      clock: makeHeldClock()
     ))
 
     let copied = await service.copySelection()
@@ -1198,6 +1316,23 @@ struct TextInsertionServiceTests {
     semaphore.wait(timeout: timeout)
   }
 
+  /// A clock nothing advances. Deadlines armed on it can never elapse, so a
+  /// test that expects no timeout cannot lose one to a starved runner, which
+  /// is exactly how this family flaked on CI (#82).
+  private nonisolated func makeHeldClock() -> InsertionClock {
+    DrivenClock().insertionClock
+  }
+
+  /// Yields until the driven clock has a sleeper armed, so an advance lands
+  /// on the deadline timer rather than into empty air before it starts
+  /// waiting. An event wait, not a time bound: it costs nothing on a healthy
+  /// run and hangs visibly on a broken one.
+  private nonisolated func waitForSleeper(on clock: DrivenClock) async {
+    while !clock.hasSleeper {
+      await Task.yield()
+    }
+  }
+
   /// Builds the same optional all-or-nothing snapshot closure used in production.
   ///
   /// The closure retains the named pasteboard for background use so tests keep
@@ -1224,6 +1359,82 @@ struct TextInsertionServiceTests {
       isSecure: false,
       displayID: nil
     )
+  }
+}
+
+/// A clock the tests advance by hand, following the precedent #82 named: a
+/// timeout test drives time rather than waiting for it, so the assertion is
+/// that the deadline was honoured, not that the machine was fast enough.
+private final class DrivenClock: Sendable {
+  private struct Sleeper {
+    let id: UUID
+    let wakeAt: Duration
+    let continuation: CheckedContinuation<Void, any Error>
+  }
+
+  private struct State {
+    var now: Duration = .zero
+    var sleepers: [Sleeper] = []
+  }
+
+  private let state = OSAllocatedUnfairLock(initialState: State())
+
+  /// Whether any sleep is currently suspended on this clock.
+  var hasSleeper: Bool {
+    state.withLock { !$0.sleepers.isEmpty }
+  }
+
+  /// Moves the clock forward and wakes every sleep the move satisfies.
+  func advance(by duration: Duration) {
+    let woken = state.withLock { state -> [Sleeper] in
+      state.now += duration
+      let now = state.now
+      let due = state.sleepers.filter { $0.wakeAt <= now }
+      state.sleepers.removeAll { $0.wakeAt <= now }
+      return due
+    }
+    for sleeper in woken {
+      sleeper.continuation.resume()
+    }
+  }
+
+  /// The injectable boundary handed to the service under test.
+  var insertionClock: InsertionClock {
+    InsertionClock(
+      now: { [self] in state.withLock { $0.now } },
+      sleep: { [self] in try await sleep(for: $0) }
+    )
+  }
+
+  private func sleep(for duration: Duration) async throws {
+    let id = UUID()
+    try await withTaskCancellationHandler {
+      try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+        // The cancellation check shares the lock with the handler below, so
+        // a cancel can never slip between checking and registering and leave
+        // the sleep suspended forever.
+        let cancelledBeforeRegistering = state.withLock { state -> Bool in
+          guard !Task.isCancelled else { return true }
+          state.sleepers.append(Sleeper(
+            id: id,
+            wakeAt: state.now + duration,
+            continuation: continuation
+          ))
+          return false
+        }
+        if cancelledBeforeRegistering {
+          continuation.resume(throwing: CancellationError())
+        }
+      }
+    } onCancel: {
+      let cancelled = state.withLock { state -> Sleeper? in
+        guard let index = state.sleepers.firstIndex(where: { $0.id == id }) else {
+          return nil
+        }
+        return state.sleepers.remove(at: index)
+      }
+      cancelled?.continuation.resume(throwing: CancellationError())
+    }
   }
 }
 


### PR DESCRIPTION
This is the injectable-clock fix you sketched as option 2 on #82, after the reruns on #68 pushed the flake from occasional to constant. The clipboard reader's snapshot deadline and the copy wait now run on an InsertionClock seam in Dependencies, continuous in production and driven by hand in the tests, so the whole family holds or advances time itself: the happy-path tests arm deadlines that can never elapse, and the timeout tests force the deadline instead of racing a real timer against the runner, which makes the assertion "the deadline was honoured" rather than "the machine was fast enough". That also retires the 2-second busy-skip ceiling whose own comment recorded a CI failure at 50ms, and the 1-second scheduling waits I flagged on #68 become generous event budgets that only spend themselves on a genuinely broken run. I routed waitForCopy through the same clock deliberately: it is the same real-deadline shape in the same file and one seam serves both, which is a shade past what I promised on #82, so I would rather say it here than let the diff imply it. Production behaviour is unchanged, since the live clock is the same continuous clock the deadlines used before. The full suite is green locally on Apple Silicon at 433 passed with the four expected media-fixture skips, and the insertion class now finishes with no real sleeping at all. I used Claude Code for most of the writing under my direction and can explain every line.

Closes #82