### PR TITLE
[FIX] Install with one Homebrew command

### DIFF
--- a/Casks/talkify.rb
+++ b/Casks/talkify.rb
@@ -2,11 +2,15 @@ cask "talkify" do
   version "0.8.0"
   sha256 "8303642a3cbc94f04ece5bc2dc06a5b7423a8f974248406d4daaf3c08ac474d0"
 
-  url "https://github.com/tornikegomareli/Talkify/releases/download/v#{version}/Talkify.dmg",
-      verified: "github.com/tornikegomareli/Talkify/"
+  url "https://github.com/tornikegomareli/Talkify/releases/download/v#{version}/Talkify.dmg"
   name "Talkify"
-  desc "Lightning-fast, local first voice dictation from the notch"
+  desc "On-device voice dictation from the notch"
   homepage "https://github.com/tornikegomareli/Talkify"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
 
   depends_on macos: :tahoe
   depends_on arch: :arm64

--- a/Casks/talkify.rb
+++ b/Casks/talkify.rb
@@ -12,6 +12,7 @@ cask "talkify" do
     strategy :github_latest
   end
 
+  auto_updates true
   depends_on macos: :tahoe
   depends_on arch: :arm64
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ And dictated text is inserted by pasting it, so it passes through the system cli
 With Homebrew:
 
 ```bash
-brew tap tornikegomareli/talkify https://github.com/tornikegomareli/Talkify
-brew trust --tap tornikegomareli/talkify
-brew install --cask talkify
+brew install --cask tornikegomareli/talkify/talkify
 ```
 
-Homebrew 6 refuses to load anything from a third-party tap until you trust it,
-so the middle line is required. It is asking whether you trust this repository;
-[read the cask](Casks/talkify.rb) first if you would rather check what it does.
+The full name is what makes it one line. Homebrew 6 will not load anything from
+a third-party tap until you trust it, but installing by full name adds the tap
+and trusts this one cask on its own — nothing else in the tap, and no separate
+`brew trust`. [Read the cask](Casks/talkify.rb) first if you would rather see
+what it does.
 
 Or grab [**Talkify.dmg**](https://github.com/tornikegomareli/Talkify/releases/latest/download/Talkify.dmg) from the latest release.
 


### PR DESCRIPTION
The install instructions asked people to run brew tap, then brew trust, then brew install. Only the last one is needed. Homebrew's install command taps and trusts a fully qualified name itself: cmd/install.rb calls ensure_installed! on the tap and then trust_fully_qualified_items!, which trusts that single cask and nothing else in the tap. So brew install --cask tornikegomareli/talkify/talkify is the whole thing, and it grants less trust than the line it replaces.

I checked it rather than taking the docs at their word. With the tap untrusted, brew info --cask talkify fails with "Refusing to load cask from untrusted tap" and brew info --cask tornikegomareli/talkify/talkify succeeds.

The cask also had two real problems. brew audit --cask --online --new fails on the verified parameter, which is deprecated in favour of the url stanza standing alone, and that would block ever submitting this cask upstream. auto_updates was missing even though Sparkle updates the app in place. Both fixed, plus a livecheck for the releases the url already points at, and the description no longer opens with Lightning-fast.

Closes nothing; the tap trust behaviour is Homebrew's by design and this documents the narrow way through it.