### PR TITLE
[FIX] Keep Lightning-fast in the cask description

### DIFF
--- a/Casks/talkify.rb
+++ b/Casks/talkify.rb
@@ -4,7 +4,7 @@ cask "talkify" do
 
   url "https://github.com/tornikegomareli/Talkify/releases/download/v#{version}/Talkify.dmg"
   name "Talkify"
-  desc "On-device voice dictation from the notch"
+  desc "Lightning-fast, local first voice dictation from the notch"
   homepage "https://github.com/tornikegomareli/Talkify"
 
   livecheck do


### PR DESCRIPTION
I trimmed it out of the cask description in #121 on style grounds. That was not my call to make: it is the product's own line, and the description is the one place the cask is allowed to sell the app. Restored verbatim.

It passes brew style and sits at 59 characters, inside the 80 a cask description allows, so nothing about the upstream submission changes.